### PR TITLE
Add {{$appName}} {{$appNamespace}} variables support for SparkConf

### DIFF
--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -135,6 +135,9 @@ func buildSubmissionCommandArgs(app *v1beta2.SparkApplication, driverPodName str
 
 	// Add Spark configuration properties.
 	for key, value := range app.Spec.SparkConf {
+		// SparkConf value can use {{appName}} and {{appNamespace}} variables
+		value = getSparkUIingressURL(value, app.GetName(), app.GetNamespace())
+
 		// Configuration property for the driver pod name has already been set.
 		if key != config.SparkDriverPodNameKey {
 			args = append(args, "--conf", fmt.Sprintf("%s=%s", key, value))

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -135,7 +135,7 @@ func buildSubmissionCommandArgs(app *v1beta2.SparkApplication, driverPodName str
 
 	// Add Spark configuration properties.
 	for key, value := range app.Spec.SparkConf {
-		// SparkConf value can use {{appName}} and {{appNamespace}} variables
+		// SparkConf value can use {{$appName}} and {{$appNamespace}} variables
 		value = getSparkUIingressURL(value, app.GetName(), app.GetNamespace())
 
 		// Configuration property for the driver pod name has already been set.


### PR DESCRIPTION
```
ingressUrlFormat "xxxdomain.com/{{$appNamespace}}/{{$appName}}"
```
In the case, webui worked must be set the `spark.ui.proxyBase=/{{$appNamespace}}/{{$appName}}`, otherwise the page is messed up,
but now the spark.ui.proxyBase can not use {{$appName}} and {{$appNamespace}} variables, so I create the PR.