### PR TITLE
Client Mode Support

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -143,6 +143,8 @@ const (
 	SparkExecutorJavaOptions = "spark.executor.extraJavaOptions"
 	// SparkExecutorDeleteOnTermination is the Spark configuration for specifying whether executor pods should be deleted in case of failure or normal termination
 	SparkExecutorDeleteOnTermination = "spark.kubernetes.executor.deleteOnTermination"
+	//SparkDriverHost is the Spark configuration used for communicating with the executors and standalone Master.
+	SparkDriverHost = "spark.driver.host"
 )
 
 const (

--- a/pkg/controller/sparkapplication/driver_pod.go
+++ b/pkg/controller/sparkapplication/driver_pod.go
@@ -1,0 +1,231 @@
+package sparkapplication
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/webhook/resourceusage"
+)
+
+type clientModeSubmissionPodManager interface {
+	createClientDriverPod(app *v1beta2.SparkApplication) (string, string, error)
+	getClientDriverPod(app *v1beta2.SparkApplication) (*corev1.Pod, error)
+}
+
+type realClientModeSubmissionPodManager struct {
+	kubeClient kubernetes.Interface
+	podLister  v1.PodLister
+}
+
+func (spm *realClientModeSubmissionPodManager) createClientDriverPod(app *v1beta2.SparkApplication) (string, string, error) {
+	var image string
+	if app.Spec.Image != nil {
+		image = *app.Spec.Image
+	} else if app.Spec.Driver.Image != nil {
+		image = *app.Spec.Driver.Image
+	}
+
+	if image == "" {
+		return "", "", fmt.Errorf("no image specified in .spec.image or .spec.driver.image in SparkApplication %s,%s",
+			app.Namespace, app.Name)
+	}
+
+	driverPodName := getDriverPodName(app)
+	submissionID := uuid.New().String()
+	submissionCmdArgs, err := buildSubmissionCommandArgs(app, driverPodName, submissionID)
+
+	if err != nil {
+		return "", "", err
+	}
+
+	command := []string{"sh", "-c", fmt.Sprintf("$SPARK_HOME/bin/spark-submit %s", strings.Join(submissionCmdArgs, " "))}
+
+	labels := make(map[string]string)
+	labels[config.SparkRoleLabel] = "client-driver"
+	labels[config.SparkAppNameLabel] = app.Name
+	labels[config.SubmissionIDLabel] = submissionID
+
+	for key, val := range app.Labels {
+		labels[key] = val
+	}
+	for key, val := range app.Spec.Driver.Labels {
+		labels[key] = val
+	}
+
+	for key, value := range app.Spec.SparkConf {
+		if strings.HasPrefix(key, "spark.kubernetes.driver.label.") {
+			label := strings.ReplaceAll(key, "spark.kubernetes.driver.label.", "")
+			labels[label] = value
+		}
+	}
+
+	imagePullSecrets := make([]corev1.LocalObjectReference, len(app.Spec.ImagePullSecrets))
+	for i, secret := range app.Spec.ImagePullSecrets {
+		imagePullSecrets[i] = corev1.LocalObjectReference{Name: secret}
+	}
+	imagePullPolicy := corev1.PullIfNotPresent
+	if app.Spec.ImagePullPolicy != nil {
+		imagePullPolicy = corev1.PullPolicy(*app.Spec.ImagePullPolicy)
+	}
+
+	var driverCpuQuantity string
+	if app.Spec.Driver.CoreRequest != nil {
+		driverCpuQuantity = *app.Spec.Driver.CoreRequest
+	} else {
+		driverCpuQuantity = fmt.Sprintf("%d", *app.Spec.Driver.Cores)
+	}
+
+	var driverCpuQuantityLimit string
+	if app.Spec.Driver.CoreLimit != nil {
+		driverCpuQuantityLimit = *app.Spec.Driver.CoreLimit
+	} else {
+		driverCpuQuantityLimit = driverCpuQuantity
+	}
+
+	driverOverheadMemory, err :=
+		resourceusage.MemoryRequiredForSparkPod(app.Spec.Driver.SparkPodSpec, app.Spec.MemoryOverheadFactor, app.Spec.Type, 1)
+	if err != nil {
+		return "", "", err
+	}
+
+	var args []string
+	for _, argument := range app.Spec.Arguments {
+		args = append(args, argument)
+	}
+
+	//append all env variables
+	var envVars []corev1.EnvVar
+	for key, value := range app.Spec.Driver.EnvVars {
+		envVars = append(envVars, corev1.EnvVar{Name: key, Value: value})
+	}
+
+	for key, value := range app.Spec.SparkConf {
+		if strings.HasPrefix(key, "spark.kubernetes.driverEnv.") {
+			env := strings.ReplaceAll(key, "spark.kubernetes.driverEnv.", "")
+			envVars = append(envVars, corev1.EnvVar{Name: env, Value: value})
+		}
+	}
+
+	envVars = append(envVars,
+		corev1.EnvVar{Name: "SPARK_K8S_DRIVER_POD_IP",
+			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}})
+
+	envVars = append(envVars,
+		corev1.EnvVar{Name: "SPARK_DRIVER_BIND_ADDRESS",
+			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}})
+
+	//append all annotations
+	annotations := make(map[string]string)
+	for key, value := range app.Spec.Driver.Annotations {
+		annotations[key] = value
+	}
+	for key, value := range app.Annotations {
+		annotations[key] = value
+	}
+
+	for key, value := range app.Spec.SparkConf {
+		if strings.HasPrefix(key, "spark.kubernetes.driver.annotation.") {
+			annotation := strings.ReplaceAll(key, "spark.kubernetes.driver.annotation.", "")
+			annotations[annotation] = value
+		}
+	}
+	nodeSelectors := make(map[string]string)
+	for key, value := range app.Spec.SparkConf {
+		if strings.HasPrefix(key, "spark.kubernetes.node.selector.") {
+			nodeSelector := strings.ReplaceAll(key, "spark.kubernetes.node.selector.", "")
+			nodeSelectors[nodeSelector] = value
+		}
+	}
+
+	//append all volumes
+	var volumes []corev1.Volume
+	var volumeMounts []corev1.VolumeMount
+
+	for _, value := range app.Spec.Volumes {
+		volumes = append(volumes, corev1.Volume{Name: value.Name,
+			VolumeSource: value.VolumeSource})
+	}
+	volumes = append(volumes, corev1.Volume{Name: "spark-local-dir-1",
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: "Memory"}}})
+	volumes = append(volumes, corev1.Volume{Name: "hadoop-properties",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: fmt.Sprintf("%s-%s-hadoop-config", app.Name, uuid.New().String())},
+		}}})
+	volumes = append(volumes, corev1.Volume{Name: "spark-conf-volume",
+		VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: fmt.Sprintf("%s-%s-driver-conf-map", app.Name, uuid.New().String())},
+		}}})
+
+	for _, value := range app.Spec.Driver.VolumeMounts {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: value.Name,
+			MountPath: value.MountPath})
+	}
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: "spark-local-dir-1",
+		MountPath: fmt.Sprintf("/var/data/spark-%s", uuid.New().String())})
+	clientDriver := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            driverPodName,
+			Namespace:       app.Namespace,
+			Labels:          labels,
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(app)},
+		},
+		Spec: corev1.PodSpec{
+			ImagePullSecrets: imagePullSecrets,
+			Volumes:          volumes,
+			NodeSelector:     nodeSelectors,
+			Containers: []corev1.Container{
+				{
+					Name:            "spark-kubernetes-driver",
+					Image:           image,
+					Command:         command,
+					Args:            args,
+					ImagePullPolicy: imagePullPolicy,
+					Env:             envVars,
+					VolumeMounts:    volumeMounts,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(driverCpuQuantity),
+							corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%d", driverOverheadMemory)),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(driverCpuQuantityLimit),
+							corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%d", driverOverheadMemory)),
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	if app.Spec.ServiceAccount != nil {
+		clientDriver.Spec.ServiceAccountName = *app.Spec.ServiceAccount
+	} else if app.Spec.Driver.ServiceAccount != nil {
+		clientDriver.Spec.ServiceAccountName = *app.Spec.Driver.ServiceAccount
+	}
+
+	glog.Infof("Creating the %s for running spark in client mode", clientDriver.Name)
+	_, err = spm.kubeClient.CoreV1().Pods(app.Namespace).Create(clientDriver)
+	if err != nil {
+		return "", "", err
+	}
+
+	return submissionID, driverPodName, nil
+}
+
+func (spm *realClientModeSubmissionPodManager) getClientDriverPod(app *v1beta2.SparkApplication) (*corev1.Pod, error) {
+	return spm.podLister.Pods(app.Namespace).Get(getDriverPodName(app))
+}

--- a/pkg/controller/sparkapplication/driver_pod_test.go
+++ b/pkg/controller/sparkapplication/driver_pod_test.go
@@ -1,0 +1,116 @@
+package sparkapplication
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubeclientfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func newFakePodManager(pods ...*corev1.Pod) clientModeSubmissionPodManager {
+	kubeClient := kubeclientfake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0*time.Second)
+	podInformer := informerFactory.Core().V1().Pods()
+	lister := podInformer.Lister()
+	for _, pod := range pods {
+		if pod != nil {
+			podInformer.Informer().GetIndexer().Add(pod)
+			kubeClient.CoreV1().Pods(pod.GetNamespace()).Create(pod)
+		}
+	}
+	return &realClientModeSubmissionPodManager{
+		podLister:  lister,
+		kubeClient: kubeClient,
+	}
+}
+
+func TestCreateDriverPod(t *testing.T) {
+	var core int32 = 1
+	memory := "512m"
+
+	os.Setenv(kubernetesServiceHostEnvVar, "localhost")
+	os.Setenv(kubernetesServicePortEnvVar, "443")
+	// Case 1: Image doesn't exist.
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta2.SparkApplicationStatus{},
+	}
+
+	podManager := newFakePodManager(nil)
+	submissionID, driverPodName, err := podManager.createClientDriverPod(app)
+	assert.NotNil(t, err)
+	assert.Empty(t, submissionID)
+	assert.Empty(t, driverPodName)
+
+	// Case 2:  Driver Pod created successfully.
+	app = &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Image: stringptr("spark-base-image"),
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  "spark-kubernetes-driver",
+							Image: "spark-driver:latest",
+						},
+					},
+					Memory: &memory,
+					Cores:  &core,
+				},
+			},
+		},
+		Status: v1beta2.SparkApplicationStatus{},
+	}
+	podManager = newFakePodManager(nil)
+	submissionID, driverPodName, err = podManager.createClientDriverPod(app)
+	assert.Nil(t, err)
+	assert.NotNil(t, submissionID)
+	assert.NotNil(t, driverPodName)
+
+}
+
+func TestGetDriverPod(t *testing.T) {
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Status: v1beta2.SparkApplicationStatus{},
+	}
+
+	// Case 1: driver pod does not exist
+	podManager := newFakePodManager(nil)
+	podResult, err := podManager.getClientDriverPod(app)
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
+	assert.Nil(t, podResult)
+
+	// Case 2: driver pod created
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-driver",
+			Namespace: "default",
+		},
+	}
+	podManager = newFakePodManager(pod)
+	podResult, err = podManager.getClientDriverPod(app)
+	assert.Nil(t, err)
+	assert.NotNil(t, podResult)
+	assert.Equal(t, pod, podResult)
+
+}

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -74,6 +74,10 @@ func buildSubmissionCommandArgs(app *v1beta2.SparkApplication, driverPodName str
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%s", config.SparkMemoryOverheadFactor, *app.Spec.MemoryOverheadFactor))
 	}
+	if app.Spec.Mode == v1beta2.ClientMode {
+		args = append(args, "--conf",
+			fmt.Sprintf("%s=%s", config.SparkDriverHost, "$SPARK_K8S_DRIVER_POD_IP"))
+	}
 
 	// Operator triggered spark-submit should never wait for App completion
 	args = append(args, "--conf", fmt.Sprintf("%s=false", config.SparkWaitAppCompletion))

--- a/pkg/webhook/resourceusage/util.go
+++ b/pkg/webhook/resourceusage/util.go
@@ -112,7 +112,7 @@ func parseJavaMemoryString(str string) (int64, error) {
 }
 
 // Logic copied from https://github.com/apache/spark/blob/c4bbfd177b4e7cb46f47b39df9fd71d2d9a12c6d/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
-func memoryRequiredForSparkPod(spec so.SparkPodSpec, memoryOverheadFactor *string, appType so.SparkApplicationType, replicas int64) (int64, error) {
+func MemoryRequiredForSparkPod(spec so.SparkPodSpec, memoryOverheadFactor *string, appType so.SparkApplicationType, replicas int64) (int64, error) {
 	var memoryBytes int64
 	if spec.Memory != nil {
 		memory, err := parseJavaMemoryString(*spec.Memory)
@@ -153,7 +153,7 @@ func memoryRequiredForSparkPod(spec so.SparkPodSpec, memoryOverheadFactor *strin
 func resourceUsage(spec so.SparkApplicationSpec) (ResourceList, error) {
 	driverMemoryOverheadFactor := spec.MemoryOverheadFactor
 	executorMemoryOverheadFactor := spec.MemoryOverheadFactor
-	driverMemory, err := memoryRequiredForSparkPod(spec.Driver.SparkPodSpec, driverMemoryOverheadFactor, spec.Type, 1)
+	driverMemory, err := MemoryRequiredForSparkPod(spec.Driver.SparkPodSpec, driverMemoryOverheadFactor, spec.Type, 1)
 	if err != nil {
 		return ResourceList{}, err
 	}
@@ -162,7 +162,7 @@ func resourceUsage(spec so.SparkApplicationSpec) (ResourceList, error) {
 	if spec.Executor.Instances != nil {
 		instances = int64(*spec.Executor.Instances)
 	}
-	executorMemory, err := memoryRequiredForSparkPod(spec.Executor.SparkPodSpec, executorMemoryOverheadFactor, spec.Type, instances)
+	executorMemory, err := MemoryRequiredForSparkPod(spec.Executor.SparkPodSpec, executorMemoryOverheadFactor, spec.Type, instances)
 	if err != nil {
 		return ResourceList{}, err
 	}


### PR DESCRIPTION
In relation to issue https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1281, this PR adds client mode support. When client mode is chosen, upon application submission, a driver is pod is created instead of the spark submit pod and the application begins to run. 

Additions:
-driver pod class that sets up the driver pod for submission 
-driver pod test class
-driver host added to spark conf for executors


@liyinan926 @akhurana001 @catalinii