### PR TITLE
Fix concurrencyPolicy is an enum

### DIFF
--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -51,6 +51,10 @@ spec:
             spec:
               properties:
                 concurrencyPolicy:
+                  enum:
+                  - Allow
+                  - Forbid
+                  - Replace
                   type: string
                 failedRunHistoryLimit:
                   format: int32


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/2919f521ccde71fc54b8d72ba0474c5872c7d4aa/pkg/apis/sparkoperator.k8s.io/v1beta1/types.go#L83-L91

Also documented this way https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/docs/api-docs.md#sparkoperator.k8s.io/v1beta2.ConcurrencyPolicy