### PR TITLE
Add automatic creation of RBAC for the driver

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.17
+version: 1.1.18
 appVersion: v1beta2-1.3.3-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -85,6 +85,24 @@ rules:
   - scheduledsparkapplications/status
   verbs:
   - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
   {{- if .Values.batchScheduler.enable }}
   # required for the `volcano` batch scheduler
 - apiGroups:

--- a/manifest/spark-operator-install/spark-operator-rbac.yaml
+++ b/manifest/spark-operator-install/spark-operator-rbac.yaml
@@ -63,6 +63,12 @@ rules:
 - apiGroups: ["scheduling.volcano.sh"]
   resources: ["podgroups", "queues", "queues/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/sparkapplication/autopilot/autopilot.go
+++ b/pkg/controller/sparkapplication/autopilot/autopilot.go
@@ -1,0 +1,120 @@
+package autopilot
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+
+	corev1 "k8s.io/api/core/v1"
+	rolev1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func getOwnerReference(app *v1beta2.SparkApplication) *metav1.OwnerReference {
+	controller := true
+	return &metav1.OwnerReference{
+		APIVersion: v1beta2.SchemeGroupVersion.String(),
+		Kind:       reflect.TypeOf(v1beta2.SparkApplication{}).Name(),
+		Name:       app.Name,
+		UID:        app.UID,
+		Controller: &controller,
+	}
+}
+
+func GetDefaultDriverServiceAccount(app *v1beta2.SparkApplication) string {
+	return fmt.Sprintf("%s-driver", app.Name)
+}
+
+func CreateOrUpdateDriverRBAC(app *v1beta2.SparkApplication, kubeClient clientset.Interface) error {
+	saService := NewSAService(kubeClient)
+	rbacService := NewRBACService(kubeClient)
+
+	roleName := fmt.Sprintf("%s-driver-role", app.Name)
+	roleBindingName := fmt.Sprintf("%s-driver-binding", app.Name)
+
+	driverSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetDefaultDriverServiceAccount(app),
+			Namespace: app.Namespace,
+			Labels: map[string]string{
+				"control-plane": "google-spark-operator",
+			},
+			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(app)},
+		},
+	}
+
+	err := saService.CreateOrUpdateServiceAccount(app.Namespace, driverSA)
+	if err != nil {
+		return err
+	}
+
+	driverRole := &rolev1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: app.Namespace,
+			Labels: map[string]string{
+				"control-plane": "google-spark-operator",
+			},
+			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(app)},
+		},
+		Rules: []rolev1.PolicyRule{
+			{
+				Verbs:     []string{rolev1.VerbAll},
+				APIGroups: []string{""},
+				Resources: []string{corev1.ResourcePods.String()},
+			},
+			{
+				Verbs:     []string{rolev1.VerbAll},
+				APIGroups: []string{""},
+				Resources: []string{corev1.ResourceServices.String()},
+			},
+			{
+				Verbs:     []string{rolev1.VerbAll},
+				APIGroups: []string{""},
+				Resources: []string{corev1.ResourceConfigMaps.String()},
+			},
+			{
+				Verbs:     []string{rolev1.VerbAll},
+				APIGroups: []string{""},
+				Resources: []string{corev1.ResourcePersistentVolumeClaims.String()},
+			},
+		},
+	}
+
+	err = rbacService.CreateOrUpdateRole(app.Namespace, driverRole)
+	if err != nil {
+		return err
+	}
+
+	driverBinding := &rolev1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleBindingName,
+			Namespace: app.Namespace,
+			Labels: map[string]string{
+				"control-plane": "google-spark-operator",
+			},
+			OwnerReferences: []metav1.OwnerReference{*getOwnerReference(app)},
+		},
+		Subjects: []rolev1.Subject{
+			{
+				Kind:      rolev1.ServiceAccountKind,
+				Namespace: app.Namespace,
+				Name:      GetDefaultDriverServiceAccount(app),
+			},
+		},
+		RoleRef: rolev1.RoleRef{
+			Kind:     "Role",
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     roleName,
+		},
+	}
+
+	err = rbacService.CreateOrUpdateRoleBinding(app.Namespace, driverBinding)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/sparkapplication/autopilot/core.go
+++ b/pkg/controller/sparkapplication/autopilot/core.go
@@ -1,0 +1,74 @@
+package autopilot
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type SA interface {
+	GetServiceAccount(name string) (*corev1.ServiceAccount, error)
+	CreateServiceAccount(namespace string, sa *corev1.ServiceAccount) error
+	UpdateServiceAccount(namespace string, sa *corev1.ServiceAccount) error
+	DeleteServiceAccount(namespace, name string) error
+	CreateOrUpdateServiceAccount(namespace string, sa *corev1.ServiceAccount) error
+}
+
+type SAService struct {
+	kubeClient clientset.Interface
+}
+
+func NewSAService(kubeClient clientset.Interface) *SAService {
+	return &SAService{
+		kubeClient: kubeClient,
+	}
+}
+
+func (r *SAService) GetServiceAccount(namespace, name string) (*corev1.ServiceAccount, error) {
+	return r.kubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (r *SAService) CreateServiceAccount(namespace string, sa *corev1.ServiceAccount) error {
+	_, err := r.kubeClient.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SAService) UpdateServiceAccount(namespace string, sa *corev1.ServiceAccount) error {
+	_, err := s.kubeClient.CoreV1().ServiceAccounts(namespace).Update(context.TODO(), sa, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (r *SAService) CreateOrUpdateServiceAccount(namespace string, sa *corev1.ServiceAccount) error {
+	storedSA, err := r.GetServiceAccount(namespace, sa.Name)
+	if err != nil {
+		// If no resource we need to create.
+		if apierrors.IsNotFound(err) {
+			return r.CreateServiceAccount(namespace, sa)
+		}
+		return err
+	}
+
+	// Already exists, need to Update.
+	// Set the correct resource version to ensure we are on the latest version. This way the only valid
+	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
+	// we will replace the current namespace state.
+	sa.ResourceVersion = storedSA.ResourceVersion
+	return r.UpdateServiceAccount(namespace, sa)
+}
+
+func (r *SAService) DeleteServiceAccount(namespace, name string) error {
+	err := r.kubeClient.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/sparkapplication/autopilot/rbac.go
+++ b/pkg/controller/sparkapplication/autopilot/rbac.go
@@ -1,0 +1,142 @@
+package autopilot
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// RBAC is the service that knows how to interact with k8s to manage RBAC related resources.
+type RBAC interface {
+	GetClusterRole(name string) (*rbacv1.ClusterRole, error)
+	GetRole(namespace, name string) (*rbacv1.Role, error)
+	GetRoleBinding(namespace, name string) (*rbacv1.RoleBinding, error)
+	CreateRole(namespace string, role *rbacv1.Role) error
+	CreateRoleBinding(namespace string, binding *rbacv1.RoleBinding) error
+	UpdateRole(namespace string, role *rbacv1.Role) error
+	UpdateRoleBinding(namespace string, binding *rbacv1.RoleBinding) error
+	DeleteRole(namespace, name string) error
+	DeleteRoleBinding(namespace, name string) error
+	CreateOrUpdateRole(namespace string, binding *rbacv1.Role) error
+	CreateOrUpdateRoleBinding(namespace string, binding *rbacv1.RoleBinding) error
+}
+
+// RBACService is the RBAC service implementation using API calls to kubernetes.
+type RBACService struct {
+	kubeClient clientset.Interface
+}
+
+// NewRBACService returns a new RBAC KubeService.
+func NewRBACService(kubeClient clientset.Interface) *RBACService {
+	return &RBACService{
+		kubeClient: kubeClient,
+	}
+}
+
+func (r *RBACService) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
+	return r.kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (r *RBACService) GetRole(namespace, name string) (*rbacv1.Role, error) {
+	return r.kubeClient.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (r *RBACService) GetRoleBinding(namespace, name string) (*rbacv1.RoleBinding, error) {
+	return r.kubeClient.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (r *RBACService) DeleteRole(namespace, name string) error {
+	err := r.kubeClient.RbacV1().Roles(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RBACService) CreateRole(namespace string, role *rbacv1.Role) error {
+	_, err := r.kubeClient.RbacV1().Roles(namespace).Create(context.TODO(), role, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *RBACService) UpdateRole(namespace string, role *rbacv1.Role) error {
+	_, err := s.kubeClient.RbacV1().Roles(namespace).Update(context.TODO(), role, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (r *RBACService) CreateOrUpdateRole(namespace string, role *rbacv1.Role) error {
+	storedRole, err := r.GetRole(namespace, role.Name)
+	if err != nil {
+		// If no resource we need to create.
+		if apierrors.IsNotFound(err) {
+			return r.CreateRole(namespace, role)
+		}
+		return err
+	}
+
+	// Already exists, need to Update.
+	// Set the correct resource version to ensure we are on the latest version. This way the only valid
+	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
+	// we will replace the current namespace state.
+	role.ResourceVersion = storedRole.ResourceVersion
+	return r.UpdateRole(namespace, role)
+}
+
+func (r *RBACService) DeleteRoleBinding(namespace, name string) error {
+	err := r.kubeClient.RbacV1().RoleBindings(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RBACService) CreateRoleBinding(namespace string, binding *rbacv1.RoleBinding) error {
+	_, err := r.kubeClient.RbacV1().RoleBindings(namespace).Create(context.TODO(), binding, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RBACService) UpdateRoleBinding(namespace string, binding *rbacv1.RoleBinding) error {
+	_, err := r.kubeClient.RbacV1().RoleBindings(namespace).Update(context.TODO(), binding, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RBACService) CreateOrUpdateRoleBinding(namespace string, binding *rbacv1.RoleBinding) error {
+	storedBinding, err := r.GetRoleBinding(namespace, binding.Name)
+	if err != nil {
+		// If no resource we need to create.
+		if apierrors.IsNotFound(err) {
+			return r.CreateRoleBinding(namespace, binding)
+		}
+		return err
+	}
+
+	// Check if the role ref has changed, roleref updates are not allowed, if changed then delete and create again the role binding.
+	// https://github.com/kubernetes/kubernetes/blob/0f0a5223dfc75337d03c9b80ae552ae8ef138eeb/pkg/apis/rbac/validation/validation.go#L157-L159
+	if storedBinding.RoleRef != binding.RoleRef {
+		if err := r.DeleteRoleBinding(namespace, binding.Name); err != nil {
+			return err
+		}
+		return r.CreateRoleBinding(namespace, binding)
+	}
+
+	// Already exists, need to Update.
+	// Set the correct resource version to ensure we are on the latest version. This way the only valid
+	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
+	// we will replace the current namespace state.
+	binding.ResourceVersion = storedBinding.ResourceVersion
+	return r.UpdateRoleBinding(namespace, binding)
+}

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -701,7 +701,7 @@ func (c *Controller) submitSparkApplication(app *v1beta2.SparkApplication) *v1be
 
 	driverPodName := getDriverPodName(app)
 	submissionID := uuid.New().String()
-	submissionCmdArgs, err := buildSubmissionCommandArgs(app, driverPodName, submissionID)
+	submissionCmdArgs, err := buildSubmissionCommandArgs(app, driverPodName, submissionID, c.kubeClient)
 	if err != nil {
 		app.Status = v1beta2.SparkApplicationStatus{
 			AppState: v1beta2.ApplicationState{

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -291,7 +291,7 @@ func addDriverConfOptions(app *v1beta2.SparkApplication, submissionID string, ku
 	} else if kubeClient != nil {
 		err := autopilot.CreateOrUpdateDriverRBAC(app, kubeClient)
 		if err != nil {
-			glog.V(2).Infof("Autopilot error: %w", err)
+			glog.V(2).Infof("Autopilot error: %s", err.Error())
 		} else {
 			driverConfOptions = append(driverConfOptions,
 				fmt.Sprintf(

--- a/pkg/controller/sparkapplication/submission_test.go
+++ b/pkg/controller/sparkapplication/submission_test.go
@@ -397,7 +397,7 @@ func TestPopulateLabels_Driver_Executor(t *testing.T) {
 	}
 
 	submissionID := uuid.New().String()
-	driverOptions, err := addDriverConfOptions(app, submissionID)
+	driverOptions, err := addDriverConfOptions(app, submissionID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,7 +469,7 @@ func TestPopulateLabelsOverride_Driver_Executor(t *testing.T) {
 	}
 
 	submissionID := uuid.New().String()
-	driverOptions, err := addDriverConfOptions(app, submissionID)
+	driverOptions, err := addDriverConfOptions(app, submissionID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -571,7 +571,7 @@ func TestProxyUserArg(t *testing.T) {
 
 	submissionID := uuid.New().String()
 	driverPodName := getDriverPodName(app)
-	args, err := buildSubmissionCommandArgs(app, driverPodName, submissionID)
+	args, err := buildSubmissionCommandArgs(app, driverPodName, submissionID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Purpose:
Automatic creation of RBAC objects for the driver pod if ServiceAccount is not specified. 