### PR TITLE
re-enable e2e integration tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -178,9 +178,13 @@ jobs:
           docker build -t gcr.io/spark-operator/spark-operator:local .
           minikube image load gcr.io/spark-operator/spark-operator:local
 
-      # The integration tests are currently broken see: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1416
-      # - name: Run chart-testing (integration test)
-      #   run: make integation-test
+      - name: Apply CRDs
+        run: |
+          minikube kubectl -- apply -f manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+          minikube kubectl -- apply -f manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+
+      - name: Run chart-testing (integration test)
+        run: make integration-test
       
       - name: Setup tmate session
         if: failure()

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.22
-appVersion: v1beta2-1.3.6-3.1.1
+version: 1.1.23
+appVersion: v1beta2-1.3.7-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/manifest/spark-application-rbac/spark-application-rbac.yaml
+++ b/manifest/spark-application-rbac/spark-application-rbac.yaml
@@ -36,6 +36,9 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifest/spark-operator-install/spark-operator.yaml
+++ b/manifest/spark-operator-install/spark-operator.yaml
@@ -21,25 +21,25 @@ metadata:
   namespace: spark-operator
   labels:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+    app.kubernetes.io/version: local
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: sparkoperator
-      app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+      app.kubernetes.io/version: local
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+        app.kubernetes.io/version: local
     spec:
       serviceAccountName: sparkoperator
       containers:
       - name: sparkoperator
-        image: gcr.io/spark-operator/spark-operator:v1beta2-1.3.0-3.1.1
+        image: ghcr.io/googlecloudplatform/spark-operator:local
         imagePullPolicy: Always
         args:
         - -logtostderr

--- a/manifest/spark-operator-with-webhook-install/spark-operator-patch.yaml
+++ b/manifest/spark-operator-with-webhook-install/spark-operator-patch.yaml
@@ -19,7 +19,7 @@ metadata:
   name: sparkoperator
   labels:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+    app.kubernetes.io/version: local
   namespace: spark-operator
 spec:
   template:

--- a/manifest/spark-operator-with-webhook-install/spark-operator-webhook.yaml
+++ b/manifest/spark-operator-with-webhook-install/spark-operator-webhook.yaml
@@ -21,20 +21,20 @@ metadata:
   namespace: spark-operator
   labels:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+    app.kubernetes.io/version: local
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+        app.kubernetes.io/version: local
     spec:
       serviceAccountName: sparkoperator
       restartPolicy: Never
       containers:
       - name: main
-        image: gcr.io/spark-operator/spark-operator:v1beta2-1.3.0-3.1.1
+        image: ghcr.io/googlecloudplatform/spark-operator:local
         imagePullPolicy: IfNotPresent
         command: ["/usr/bin/gencerts.sh", "-p"]
 ---
@@ -50,4 +50,4 @@ spec:
       name: webhook
   selector:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v1beta2-1.3.0-3.1.1
+    app.kubernetes.io/version: local

--- a/manifest/spark-operator-with-webhook-install/spark-operator-with-webhook.yaml
+++ b/manifest/spark-operator-with-webhook-install/spark-operator-with-webhook.yaml
@@ -21,20 +21,20 @@ metadata:
   namespace: spark-operator
   labels:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v2.4.0-v1beta1
+    app.kubernetes.io/version: local
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: sparkoperator
-      app.kubernetes.io/version: v2.4.0-v1beta1
+      app.kubernetes.io/version: local
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: v2.4.0-v1beta1
+        app.kubernetes.io/version: local
       initializers:
         pending: []
     spec:
@@ -45,7 +45,7 @@ spec:
             secretName: spark-webhook-certs
       containers:
         - name: sparkoperator
-          image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-latest
+          image: ghcr.io/googlecloudplatform/spark-operator:local
           imagePullPolicy: Always
           volumeMounts:
             - name: webhook-certs
@@ -64,20 +64,20 @@ metadata:
   namespace: spark-operator
   labels:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v2.4.0-v1beta1
+    app.kubernetes.io/version: local
 spec:
   backoffLimit: 3
   template:
     metadata:
       labels:
         app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: v2.4.0-v1beta1
+        app.kubernetes.io/version: local
     spec:
       serviceAccountName: sparkoperator
       restartPolicy: Never
       containers:
         - name: main
-          image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-latest
+          image: ghcr.io/googlecloudplatform/spark-operator:local
           imagePullPolicy: IfNotPresent
           command: ["/usr/bin/gencerts.sh", "-p"]
 ---
@@ -93,4 +93,4 @@ spec:
       name: webhook
   selector:
     app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v2.4.0-v1beta1
+    app.kubernetes.io/version: local

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -32,9 +32,11 @@ import (
 func TestSubmitSparkPiYaml(t *testing.T) {
 	t.Parallel()
 
-	appName := "spark-pi"
+	appName := "spark-pi-basic"
 	sa, err := appFramework.MakeSparkApplicationFromYaml("../../examples/spark-pi.yaml")
 	assert.Equal(t, nil, err)
+
+	sa.ObjectMeta.Name = appName
 
 	if appFramework.SparkTestNamespace != "" {
 		sa.ObjectMeta.Namespace = appFramework.SparkTestNamespace

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -135,8 +135,8 @@ func (f *Framework) setupOperator(sparkNs, opImage string, opImagePullPolicy str
 		job.Spec.Template.Spec.Containers[0].Image = opImage
 	}
 
-	for _, container := range job.Spec.Template.Spec.Containers {
-		container.ImagePullPolicy = v1.PullPolicy(opImagePullPolicy)
+	for i := range job.Spec.Template.Spec.Containers {
+		job.Spec.Template.Spec.Containers[i].ImagePullPolicy = v1.PullPolicy(opImagePullPolicy)
 	}
 
 	err = CreateJob(f.KubeClient, f.Namespace.Name, job)
@@ -167,8 +167,8 @@ func (f *Framework) setupOperator(sparkNs, opImage string, opImagePullPolicy str
 		deploy.Spec.Template.Spec.Containers[0].Image = opImage
 	}
 
-	for _, container := range deploy.Spec.Template.Spec.Containers {
-		container.ImagePullPolicy = v1.PullPolicy(opImagePullPolicy)
+	for i := range deploy.Spec.Template.Spec.Containers {
+		deploy.Spec.Template.Spec.Containers[i].ImagePullPolicy = v1.PullPolicy(opImagePullPolicy)
 	}
 
 	err = CreateDeployment(f.KubeClient, f.Namespace.Name, deploy)

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -36,6 +36,8 @@ func TestLifeCycleManagement(t *testing.T) {
 	app, err := appFramework.MakeSparkApplicationFromYaml("../../examples/spark-pi.yaml")
 	assert.Equal(t, nil, err)
 
+	app.ObjectMeta.Name = appName
+
 	if appFramework.SparkTestNamespace != "" {
 		app.ObjectMeta.Namespace = appFramework.SparkTestNamespace
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -34,12 +34,11 @@ var framework *operatorFramework.Framework
 var TIMEOUT = 240 * time.Second
 var INTERVAL = 1 * time.Second
 
-var STATES = [9]string{
+var STATES = [8]string{
 	"",
 	"SUBMITTED",
 	"RUNNING",
 	"COMPLETED",
-	"INVALIDATING",
 	"PENDING_RERUN",
 	"SUBMITTED",
 	"RUNNING",

--- a/test/e2e/volume_mount_test.go
+++ b/test/e2e/volume_mount_test.go
@@ -40,10 +40,12 @@ type describeClient struct {
 }
 
 func TestMountConfigMap(t *testing.T) {
-	appName := "spark-pi"
+	appName := "spark-pi-configmap"
 
 	sa, err := appFramework.MakeSparkApplicationFromYaml("../../examples/spark-pi-configmap.yaml")
 	assert.Equal(t, nil, err)
+
+	sa.ObjectMeta.Name = appName
 
 	if appFramework.SparkTestNamespace != "" {
 		sa.ObjectMeta.Namespace = appFramework.SparkTestNamespace


### PR DESCRIPTION
I've reworked the https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1485 PR. 
Thanks @RonZhang724 for doing the preparatory work in https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1504; this new PR is introducing minimal changes in just running the actual integration testing. 