### PR TITLE
fix executor event formatting

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -1026,15 +1026,15 @@ func (c *Controller) recordDriverEvent(app *v1beta2.SparkApplication, phase v1be
 func (c *Controller) recordExecutorEvent(app *v1beta2.SparkApplication, state v1beta2.ExecutorState, args ...interface{}) {
 	switch state {
 	case v1beta2.ExecutorCompletedState:
-		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorCompleted", "Executor %s completed", args)
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorCompleted", "Executor %s completed", args...)
 	case v1beta2.ExecutorPendingState:
-		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorPending", "Executor %s is pending", args)
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorPending", "Executor %s is pending", args...)
 	case v1beta2.ExecutorRunningState:
-		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorRunning", "Executor %s is running", args)
+		c.recorder.Eventf(app, apiv1.EventTypeNormal, "SparkExecutorRunning", "Executor %s is running", args...)
 	case v1beta2.ExecutorFailedState:
-		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkExecutorFailed", "Executor %s failed with ExitCode: %d, Reason: %s", args)
+		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkExecutorFailed", "Executor %s failed with ExitCode: %d, Reason: %s", args...)
 	case v1beta2.ExecutorUnknownState:
-		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkExecutorUnknownState", "Executor %s in unknown state", args)
+		c.recorder.Eventf(app, apiv1.EventTypeWarning, "SparkExecutorUnknownState", "Executor %s in unknown state", args...)
 	}
 }
 


### PR DESCRIPTION
The formatter args for the executor events are passed as slice instead of vararg, this causes the events to be displayed as follows:
`Executor [exec-name %!s(int32=143) Error] failed with ExitCode: %!d(MISSING), Reason: %!s(MISSING)` 

Expected event format:
`Executor [exec-name Error] failed with ExitCode: 143, Reason: <reason>` 