### PR TITLE
Support using spark application metrics as operator metrics labels

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.1.26
-appVersion: v1beta2-1.3.4-3.1.1
+appVersion: v1beta2-1.3.7-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.20
+version: 1.1.26
 appVersion: v1beta2-1.3.4-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -98,6 +98,7 @@ All charts linted successfully
 | metrics.port | int | `10254` | Metrics port |
 | metrics.portName | string | `"metrics"` | Metrics port name |
 | metrics.prefix | string | `""` | Metric prefix, will be added to all exported metrics |
+| metrics.metricsLabels |  list | `[]` | List of spark application labels to be added to operator's metrics |
 | nameOverride | string | `""` | String to partially override `spark-operator.fullname` template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Additional annotations to add to the pod |

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
         {{- if .Values.metrics.enable }}
         - -enable-metrics=true
         - -metrics-labels=app_type
+        {{- range .Values.metrics.metricsLabels }}
+        - -metrics-labels={{ . }}
+        {{- end }}
         - -metrics-port={{ .Values.metrics.port }}
         - -metrics-endpoint={{ .Values.metrics.endpoint }}
         - -metrics-prefix={{ .Values.metrics.prefix }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -110,6 +110,8 @@ metrics:
   endpoint: /metrics
   # -- Metric prefix, will be added to all exported metrics
   prefix: ""
+  # -- Labels from spark applications to be added to the operator metrics, e.g. : ["environment", "region"]
+  metricsLabels: []
 
 # -- Prometheus pod monitor for operator's pod.
 podMonitor:


### PR DESCRIPTION
### Goal:
This PR's goal is to allow adding additional labels to the operator metrics.

Currently, the only available label in the operator metrics is `app_type`, 
but I think it is very useful to add additional labels from our spark applications. 

For example internally, I added two labels in addition to 'app_type' that Im using in order to create alerts. 
     