### PR TITLE
Add PrometheusRule template for creating spark alerts

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.20
+version: 1.1.27
 appVersion: v1beta2-1.3.4-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -98,6 +98,9 @@ All charts linted successfully
 | metrics.port | int | `10254` | Metrics port |
 | metrics.portName | string | `"metrics"` | Metrics port name |
 | metrics.prefix | string | `""` | Metric prefix, will be added to all exported metrics |
+| prometheusRule.enabled | string | `false` | Enable prometheus rules |
+| prometheusRule.additionalLabels | object | `{}` | Prometheus rule additional labels |
+| prometheusRule.rules | list | `[]` | Prometheus rule alerts list |
 | nameOverride | string | `""` | String to partially override `spark-operator.fullname` template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Additional annotations to add to the pod |

--- a/charts/spark-operator-chart/templates/prometheusrules.yaml
+++ b/charts/spark-operator-chart/templates/prometheusrules.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "spark-operator.fullname" . }}
+  labels:
+  {{- include "spark-operator.labels" . | nindent 4 }}
+  {{- with .Values.prometheusRule.additionalLabels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $values := . -}}
+  {{- with .Values.prometheusRule.rules }}
+  groups:
+  - name: {{ include "spark-operator.fullname" $values }} 
+    rules:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -111,6 +111,21 @@ metrics:
   # -- Metric prefix, will be added to all exported metrics
   prefix: ""
 
+# PrometheusRules for Spark Operator
+prometheusRule:
+  enabled: false
+#  additionalLabels:
+#    env: production
+#  rules:
+#  - alert: SparkApplicationFailed
+#    expr: (rate(spark_app_failure_count[10m])) > 0
+#    for: 24h
+#    labels:
+#      prometheus: myprometheus
+#    annotations:
+#      description: Spark application failed to complete
+#      summary: Spark application hasn't run for 24 hours
+
 # -- Prometheus pod monitor for operator's pod.
 podMonitor:
   # -- If enabled, a pod monitor for operator's pod will be submitted. Note that prometheus metrics should be enabled as well.


### PR DESCRIPTION
### Goal:
Enable creating prometheus alerts. 

I'v added here a new template for `PrometheusRule`, and disabled it by default in the values.
