### PR TITLE
Subpath support for config map volume mounts

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.25
+version: 1.1.26
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.1.25
-appVersion: v1beta2-1.3.7-3.1.1
+appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,9 @@
+# Troubleshooting
+
+This file is meant to be consumed as a FAQ.
+
+## Why am I unable to provide a custom `spark.properties` via `sparkConfigMap` in the CRD Spec?
+Have a look at `addSparkConfigMap(...)` in `patch.go`. We use SubPath mounts to mount multiple files to the same folder
+(`SPARK_CONF_DIR`). Spark itself uses a ConfigMap to mount its auto-generated `spark.properties` to the driver pods 
+container. We simply re-mount the VolumeMount as SubPath. There exists no agreed/upstream-compatible solution to provide
+your own `spark.properties` because it would override the auto-generated spark defaults.

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -17,11 +17,17 @@ limitations under the License.
 package config
 
 const (
+	// DefaultSparkPropertiesFile is the
+	DefaultSparkPropertiesFile = "spark.properties"
 	// DefaultSparkConfDir is the default directory for Spark configuration files if not specified.
 	// This directory is where the Spark ConfigMap is mounted in the driver and executor containers.
-	DefaultSparkConfDir = "/etc/spark/conf"
+	DefaultSparkConfDir = "/opt/spark/conf"
 	// SparkConfigMapVolumeName is the name of the ConfigMap volume of Spark configuration files.
 	SparkConfigMapVolumeName = "spark-configmap-volume"
+	// SparkConfigMapVolumeDriverName is the designated name for the driver ConfigMap VolumeMounted to the driver container
+	SparkConfigMapVolumeDriverName = "spark-conf-volume-driver"
+	// SparkConfigMapVolumeExecName is the designated name for the executor ConfigMap VolumeMounted to the executor container
+	SparkConfigMapVolumeExecName = "spark-conf-volume-exec"
 	// DefaultHadoopConfDir is the default directory for Spark configuration files if not specified.
 	// This directory is where the Hadoop ConfigMap is mounted in the driver and executor containers.
 	DefaultHadoopConfDir = "/etc/hadoop/conf"


### PR DESCRIPTION
This PR addresses several issues discussed at length in #216 
It allows for additional config files to be mounted into ``SPARK_CONF_DIR`` and adds compatibility to the upstream by changing ``DefaultSparkConfDir`` to ``/opt/spark/conf``
@tahesse worked quite a bit to handle tests, documentation and additional modifications to my original patch. 

It's important to note that this does not add any capability to [change the actual mounted spark.properties file](https://github.com/bbenzikry/spark-on-k8s-operator/blob/29bb31b25ca71152180b49fd688dfbc366ed681d/docs/troubleshooting.md), though we have discussed adding merge logic once this PR goes through. 

