### PR TITLE
remove unmatched quotes from user-guide.md

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -130,7 +130,7 @@ spec:
   sparkConf:
     spark.ui.port: "4045"
     spark.eventLog.enabled: "true"
-    spark.eventLog.dir": "hdfs://hdfs-namenode-1:8020/spark/spark-events"
+    spark.eventLog.dir: "hdfs://hdfs-namenode-1:8020/spark/spark-events"
 ```
 
 ### Specifying Hadoop Configuration


### PR DESCRIPTION
I found mismatched quotes from user-guide.md merged from PR https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/1524

