### PR TITLE
Add option to specify hostNetwork in spark-operator deployment

### DIFF
--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      hostNetwork: {{ .Values.webhook.hostNetwork }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -85,6 +85,8 @@ webhook:
   enable: false
   # -- Webhook service port
   port: 8080
+  # -- Set deployment to use host networking, solves network access issues on EKS with custom CNI
+  hostNetwork: false
   # -- The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2.
   # Empty string (default) will operate on all namespaces
   namespaceSelector: ""


### PR DESCRIPTION
Solves https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1235

Because: https://medium.com/@denisstortisilva/kubernetes-eks-calico-and-custom-admission-webhooks-a2956b49bd0d