### PR TITLE
Add new features: When a user submits a job to k8s using the native spark-submit, the spark-operator also senses the creation of the driver pod and creates the sparkApplication CR instance as well as the service ingress

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,7 +278,7 @@ func buildPodInformerFactory(kubeClient clientset.Interface) informers.SharedInf
 		podFactoryOpts = append(podFactoryOpts, informers.WithNamespace(*namespace))
 	}
 	tweakListOptionsFunc := func(options *metav1.ListOptions) {
-		options.LabelSelector = fmt.Sprintf("%s,%s", operatorConfig.SparkRoleLabel, operatorConfig.LaunchedBySparkOperatorLabel)
+		options.LabelSelector = operatorConfig.SparkRoleLabel
 		if len(*labelSelectorFilter) > 0 {
 			options.LabelSelector = options.LabelSelector + "," + *labelSelectorFilter
 		}


### PR DESCRIPTION
Add new features: When a user submits a job to k8s using the native spark-submit, the spark-operator also senses the creation of the driver pod and creates the sparkApplication CR instance as well as the service ingress