### PR TITLE
Support building multi-platform images of spark-operator.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v3.1.1
+ARG SPARK_IMAGE=apache/spark:v3.1.3
 
 FROM golang:1.15.2-alpine as builder
 
@@ -32,7 +32,7 @@ COPY main.go main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /usr/bin/spark-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o /usr/bin/spark-operator main.go
 
 FROM ${SPARK_IMAGE}
 USER root

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -20,7 +20,7 @@
 # 1. Your Docker version is >= 18.09.3
 # 2. export DOCKER_BUILDKIT=1
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v3.1.1
+ARG SPARK_IMAGE=apache/spark:v3.1.3
 
 FROM golang:1.14.0-alpine as builder
 
@@ -38,7 +38,7 @@ COPY main.go main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /usr/bin/spark-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o /usr/bin/spark-operator main.go
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -10,6 +10,12 @@ The easiest way to build the operator without worrying about its dependencies is
 $ docker build -t <image-tag> .
 ```
 
+Or if you want to build multi-platform images, you can build with `docker buildx` like this:
+
+```bash
+$ docker buildx build --platform linux/amd64,linux/arm64 --push -t <image-tag> .
+```
+
 The operator image is built upon a base Spark image that defaults to `gcr.io/spark-operator/spark:v3.1.1`. If you want to use your own Spark image (e.g., an image with a different version of Spark or some custom dependencies), specify the argument `SPARK_IMAGE` as the following example shows: 
 
 ```bash


### PR DESCRIPTION
Also note, here I changed default base image (i.e. SPARK_IMAGE) to apache/spark:3.1.3, because arm64 manifest of gcr.io/spark-operator/spark:v3.1.1 is actually amd64, so we change to apache/spark:3.1.3

<img width="848" alt="2022-10-08 10 17 04" src="https://user-images.githubusercontent.com/261698/194683893-6e1ed578-1562-4b23-82bd-333f9adb6054.png">
