### PR TITLE
recognize manual submits in history of ScheduledSparkApplication

### DIFF
--- a/pkg/controller/scheduledsparkapplication/controller_util.go
+++ b/pkg/controller/scheduledsparkapplication/controller_util.go
@@ -32,10 +32,5 @@ func (s sparkApps) Swap(i, j int) {
 
 func (s sparkApps) Less(i, j int) bool {
 	// Sort explicitly by decreasing order of application CreationTimestamp.
-	if s[j].CreationTimestamp.Equal(&s[i].CreationTimestamp) {
-		// Inorder to pass the tests, we need to sort by Name because there is no CreationTimeStamp on test clients.
-		return s[i].Name > s[j].Name
-	} else {
-		return s[j].CreationTimestamp.Before(&s[i].CreationTimestamp)
-	}
+	return s[j].CreationTimestamp.Before(&s[i].CreationTimestamp)
 }

--- a/pkg/controller/scheduledsparkapplication/controller_util.go
+++ b/pkg/controller/scheduledsparkapplication/controller_util.go
@@ -31,6 +31,11 @@ func (s sparkApps) Swap(i, j int) {
 }
 
 func (s sparkApps) Less(i, j int) bool {
-	// Sort by decreasing order of application names and correspondingly creation time.
-	return s[i].Name > s[j].Name
+	// Sort explicitly by decreasing order of application CreationTimestamp.
+	if s[j].CreationTimestamp.Equal(&s[i].CreationTimestamp) {
+		// Inorder to pass the tests, we need to sort by Name because there is no CreationTimeStamp on test clients.
+		return s[i].Name > s[j].Name
+	} else {
+		return s[j].CreationTimestamp.Before(&s[i].CreationTimestamp)
+	}
 }

--- a/sparkctl/cmd/create.go
+++ b/sparkctl/cmd/create.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	crdclientset "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
 )
 
 const bufferSize = 1024
@@ -148,6 +149,12 @@ func createFromScheduledSparkApplication(name string, kubeClient clientset.Inter
 		},
 		Spec: *sapp.Spec.Template.DeepCopy(),
 	}
+
+	app.ObjectMeta.Labels = make(map[string]string)
+	for key, value := range sapp.Labels {
+		app.ObjectMeta.Labels[key] = value
+	}
+	app.ObjectMeta.Labels[config.ScheduledSparkAppNameLabel] = sapp.Name
 
 	if err := createSparkApplication(app, kubeClient, crdClient); err != nil {
 		return fmt.Errorf("failed to create SparkApplication %s: %v", app.Name, err)


### PR DESCRIPTION
This Pull request changes how `sparkctl` creates new apps from an already declared `scheduledsparkapplication` by adding the required labels to the created object so that the operator can track the created `sparkapplication` as one of the `scheduledsparkapplicaion` runs.

This Pull request also changes how sorting for `sparkApps` works and sorts based on `CreatoionTimeStamp` first and `Name` second.
#1656 