### PR TITLE
Update user-guide.md

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -844,4 +844,4 @@ To customize the operator, you can follow the steps below:
 2. Create docker images to be used for Spark with [docker-image tool](https://spark.apache.org/docs/latest/running-on-kubernetes.html#docker-images).
 3. Create a new operator image based on the above image. You need to modify the `FROM` tag in the [Dockerfile](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/Dockerfile) with your Spark image.
 4. Build and push your operator image built above.
-5. Deploy the new image by modifying the [/manifest/spark-operator.yaml](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/manifest/spark-operator.yaml) file and specifying your operator image.
+5. Deploy the new image by modifying the [/manifest/spark-operator.yaml](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/manifest/spark-operator-install/spark-operator.yaml) file and specifying your operator image.


### PR DESCRIPTION
This path is updated as per the info provided here in the below link: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/commits/a010501d7800b9490cd09dcc6d316737b9928da1/manifest/spark-operator.yaml?browsing_rename_history=true&new_path=manifest/spark-operator-install/spark-operator.yaml&original_branch=master