### PR TITLE
feat: add helm flag for cert reload interval

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.27
+version: 1.1.28
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -79,6 +79,7 @@ spec:
         - -webhook-svc-name={{ include "spark-operator.fullname" . }}-webhook
         - -webhook-config-name={{ include "spark-operator.fullname" . }}-webhook-config
         - -webhook-namespace-selector={{ .Values.webhook.namespaceSelector }}
+        - -webhook-cert-reload-interval={{ .Values.webhook.certReloadInterval }}
         {{- end }}
         - -enable-resource-quota-enforcement={{ .Values.resourceQuotaEnforcement.enable }}
         {{- if gt (int .Values.replicaCount) 1 }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -96,8 +96,10 @@ webhook:
   cleanupAnnotations:
     "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
-    # -- Webhook Timeout in seconds
+  # -- Webhook Timeout in seconds
   timeout: 30
+  # -- Interval to refresh webhook cert
+  certReloadInterval: 10s
 
 metrics:
   # -- Enable prometheus metric scraping


### PR DESCRIPTION
## What does this change do?
- Introduces a new Helm `values` flag to alter the webhook cert reload interval.
- Sets this value to 10 seconds by default.
   - If the certificate isn't loaded properly, the Spark Operator fails to do any work because it cannot communicate with Kubernetes. Reducing this to 10 seconds ensures the Spark Operator can stay available.