### PR TITLE
Add webhook fail on error + fix docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build-api-docs:
 			-out-file /repo/docs/api-docs.md"
 
 helm-docs:
-	docker run --rm --volume "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:latest
+	docker run --rm --volume "$$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:latest
 
 fmt-check: clean
 	@echo "running fmt check"; cd "$(dirname $0)"; \

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.26
+version: 1.1.27
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -84,7 +84,7 @@ All charts linted successfully
 | controllerThreads | int | `10` | Operator concurrency, higher values might increase memory usage |
 | fullnameOverride | string | `""` | String to override release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"gcr.io/spark-operator/spark-operator"` | Image repository |
+| image.repository | string | `"ghcr.io/googlecloudplatform/spark-operator"` | Image repository |
 | image.tag | string | `""` | if set, override the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | ingressUrlFormat | string | `""` | Ingress URL format. Requires the UI service to be enabled by setting `uiService.enable` to true. |
@@ -125,6 +125,8 @@ All charts linted successfully
 | sparkJobNamespace | string | `""` | Set this if running spark jobs in a different namespace than the operator |
 | tolerations | list | `[]` | List of node taints to tolerate |
 | uiService.enable | bool | `true` | Enable UI service creation for Spark application |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |
 | webhook.cleanupAnnotations | object | `{"helm.sh/hook":"pre-delete, pre-upgrade","helm.sh/hook-delete-policy":"hook-succeeded"}` | The annotations applied to the cleanup job, required for helm lifecycle hooks |
 | webhook.enable | bool | `false` | Enable webhook server |
 | webhook.initAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-weight":"50"}` | The annotations applied to init job, required to restore certs deleted by the cleanup job during upgrade |
@@ -136,4 +138,4 @@ All charts linted successfully
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| yuchaoran2011 | yuchaoran2011@gmail.com |  |
+| yuchaoran2011 | <yuchaoran2011@gmail.com> |  |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -129,6 +129,7 @@ All charts linted successfully
 | volumes | list | `[]` |  |
 | webhook.cleanupAnnotations | object | `{"helm.sh/hook":"pre-delete, pre-upgrade","helm.sh/hook-delete-policy":"hook-succeeded"}` | The annotations applied to the cleanup job, required for helm lifecycle hooks |
 | webhook.enable | bool | `false` | Enable webhook server |
+| webhook.failOnError | bool | `false` |  |
 | webhook.initAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-weight":"50"}` | The annotations applied to init job, required to restore certs deleted by the cleanup job during upgrade |
 | webhook.namespaceSelector | string | `""` | The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2. Empty string (default) will operate on all namespaces |
 | webhook.port | int | `8080` | Webhook service port |

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
         - -webhook-svc-namespace={{ .Release.Namespace }}
         - -webhook-port={{ .Values.webhook.port }}
         - -webhook-timeout={{ .Values.webhook.timeout }}
+        - -webhook-fail-on-error={{ .Values.webhook.failOnError }}
         - -webhook-svc-name={{ include "spark-operator.fullname" . }}-webhook
         - -webhook-config-name={{ include "spark-operator.fullname" . }}-webhook-config
         - -webhook-namespace-selector={{ .Values.webhook.namespaceSelector }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -97,6 +97,7 @@ webhook:
     "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
     # -- Webhook Timeout in seconds
+  failOnError: false
   timeout: 30
 
 metrics:


### PR DESCRIPTION
## Changes
- Fixed `helm-docs` make goal to correctly mount working directory
  - Bundled docs update that looked to be missing a few changes since original generation
- Added spot to configure `webhook-fail-on-error` flag via helm chart