### PR TITLE
Chart: add patch permissions for spark operator SA to support spark 3.5.0

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.0
+version: 1.2.1
 appVersion: v1beta2-1.3.8-3.5.0
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -31,6 +31,7 @@ rules:
   - get
   - delete
   - update
+  - patch
 - apiGroups:
   - extensions
   - networking.k8s.io


### PR DESCRIPTION
While trying to run spark operator with Spark 3.5.0, I noticed the following errors:

```
Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "spark-pi-test-run-1-72fa8a8c0fd5639e-driver-svc" is forbidden: User "system:serviceaccount:spark:sparkoperator-spark-spark-operator" cannot patch resource "services" in API group "" in the namespace "spark-test-apps".
 at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:238)
 at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:518)
 at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:535)
 at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handlePatch(OperationSupport.java:430)
 at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handlePatch(OperationSupport.java:408)
 at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handlePatch(BaseOperation.java:713)
 at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.lambda$patch$2(HasMetadataOperation.java:232)
 at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.patch(HasMetadataOperation.java:237)
 at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.patch(HasMetadataOperation.java:252)
 at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.serverSideApply(BaseOperation.java:1132)
 at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.serverSideApply(BaseOperation.java:92)
 at io.fabric8.kubernetes.client.extension.ResourceAdapter.serverSideApply(ResourceAdapter.java:325)
 at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
 at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
 at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
 at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
 at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
 at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
 at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
 at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.performOperation(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:294)
 at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.serverSideApply(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:324)
 at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.serverSideApply(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:55)
 at org.apache.spark.deploy.k8s.submit.Client.run(KubernetesClientApplication.scala:176)
 at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.$anonfun$run$6(KubernetesClientApplication.scala:256)
 at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.$anonfun$run$6$adapted(KubernetesClientApplication.scala:250)
 at org.apache.spark.util.SparkErrorUtils.tryWithResource(SparkErrorUtils.scala:48)
 at org.apache.spark.util.SparkErrorUtils.tryWithResource$(SparkErrorUtils.scala:46)
 at org.apache.spark.util.Utils$.tryWithResource(Utils.scala:94)
 at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.run(KubernetesClientApplication.scala:250)
 at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.start(KubernetesClientApplication.scala:223)
 at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
 at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
 at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
 at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
 at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
 at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
 at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
...
```

and

```
Forbidden!Configured service account doesn't have access. Service account may have been revoked. configmaps "spark-drv-415b968c103c268a-conf-map" is forbidden: User "system:serviceaccount:spark:sparkoperator-spark-spark-operator" cannot patch resource "configmaps" in API group "" in the namespace "spark-test-apps".
```

These errors cause spark applications to fail. 

So I added the `patch` permissions to spark-operator service account - with this change spark applications run successfully with Spark 3.5.0 .