### PR TITLE
Add PVC permission to Operator role

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.28
+version: 1.1.29
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/rbac.yaml
+++ b/charts/spark-operator-chart/templates/rbac.yaml
@@ -17,6 +17,7 @@ rules:
   - ""
   resources:
   - pods
+  - persistentvolumeclaims
   verbs:
   - "*"
 - apiGroups:


### PR DESCRIPTION
Add PVC permission to Operator role, so that Spark Operator able to create Driver pod with PVC by follow spark configs:
```
    spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.options.claimName: "driver"
    spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.options.storageClass: "gp2"
    spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.options.sizeLimit: "50Gi"
    spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.mount.path: "/data"
    spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.mount.readOnly: "false"
```

https://spark.apache.org/docs/latest/running-on-kubernetes.html#using-kubernetes-volumes
