### PR TITLE
BUGFIX: Added cancel method to fix context leak

### DIFF
--- a/sparkctl/cmd/event.go
+++ b/sparkctl/cmd/event.go
@@ -154,7 +154,8 @@ func streamEvents(events watch.Interface, streamSince int64) error {
 		table = prepareNewTable()
 		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 		ctx := context.TODO()
-		ctx, _ = context.WithTimeout(ctx, watchExpire)
+		ctx, cancel := context.WithTimeout(ctx, watchExpire)
+		defer cancel()
 		_, err := clientWatch.UntilWithoutRetry(ctx, events, func(ev watch.Event) (bool, error) {
 			if event, isEvent := ev.Object.(*v1.Event); isEvent {
 				// Ensure to display events which are newer than last creation time of SparkApplication


### PR DESCRIPTION
This PR fixes a context leak bug in your code.

## Summary
While triaging your project, our bug fixing tool generated the following message-
> In file: [event.go](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/sparkctl/cmd/event.go#L157), method `context.WithTimeout` is called where the returned cancel function is ignored. It is suggested that the returned cancel function shouldn't be ignored.


## Details
In the line below, a context is created using the `WithTimeout` method, where the returned `cancelFunc` handler is ignored. 
```
ctx, _ = context.WithTimeout(ctx, watchExpire)
```
I have introduced the `cancel` handler and deferred it so that once the method `Run()` completes execution, it can be safely cancelled.


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
