### PR TITLE
chore: updating spark registry and tags on examples and docs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -74,9 +74,9 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: gcr.io/spark/spark:v3.1.1
+  image: apache/spark:v3.1.1
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.1.3.jar
 ```
 
 ### Specifying Deployment Mode
@@ -767,9 +767,9 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: gcr.io/spark/spark:v3.1.1
+    image: apache/spark:v3.1.3
     mainClass: org.apache.spark.examples.SparkPi
-    mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar
+    mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.1.3.jar
     driver:
       cores: 1
       memory: 512m

--- a/docs/volcano-integration.md
+++ b/docs/volcano-integration.md
@@ -31,11 +31,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v3.1.1"
+  image: "apache/spark:v3.1.3"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-v3.1.1.jar"
-  sparkVersion: "3.1.1"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-v3.1.3.jar"
+  sparkVersion: "3.1.3"
   batchScheduler: "volcano"   #Note: the batch scheduler name must be specified with `volcano`
   restartPolicy:
     type: Never
@@ -49,7 +49,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"        
     labels:
-      version: 3.1.1
+      version: 3.1.3
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
@@ -59,7 +59,7 @@ spec:
     instances: 1
     memory: "512m"    
     labels:
-      version: 3.1.1
+      version: 3.1.3
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-pi-configmap.yaml
+++ b/examples/spark-pi-configmap.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v3.1.1"
+  image: "apache/spark:v3.1.3"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
-  sparkVersion: "3.1.1"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.3.jar"
+  sparkVersion: "3.1.3"
   restartPolicy:
     type: Never
   volumes:
@@ -37,7 +37,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     serviceAccount: spark
     volumeMounts:
       - name: config-vol
@@ -47,7 +47,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     volumeMounts:
       - name: config-vol
         mountPath: /opt/spark/mycm

--- a/examples/spark-pi-custom-resource.yaml
+++ b/examples/spark-pi-custom-resource.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v3.1.1"
+  image: "apache/spark:v3.1.3"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
-  sparkVersion: "3.1.1"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.3.jar"
+  sparkVersion: "3.1.3"
   restartPolicy:
     type: Never
   volumes:
@@ -38,7 +38,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
@@ -48,7 +48,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-pi-schedule.yaml
+++ b/examples/spark-pi-schedule.yaml
@@ -25,11 +25,11 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: "gcr.io/spark-operator/spark:v3.1.1"
+    image: "apache/spark:v3.1.3"
     imagePullPolicy: Always
     mainClass: org.apache.spark.examples.SparkPi
-    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
-    sparkVersion: "3.1.1"
+    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.3.jar"
+    sparkVersion: "3.1.3"
     restartPolicy:
       type: Never
     driver:
@@ -37,11 +37,11 @@ spec:
       coreLimit: "1200m"
       memory: "512m"
       labels:
-        version: 3.1.1
+        version: 3.1.3
       serviceAccount: spark
     executor:
       cores: 1
       instances: 1
       memory: "512m"
       labels:
-        version: 3.1.1
+        version: 3.1.3

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "gcr.io/spark-operator/spark:v3.1.1"
+  image: "apache/spark:v3.1.3"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar"
-  sparkVersion: "3.1.1"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.1.3.jar"
+  sparkVersion: "3.1.3"
   restartPolicy:
     type: Never
   volumes:
@@ -38,7 +38,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
@@ -48,7 +48,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-py-pi.yaml
+++ b/examples/spark-py-pi.yaml
@@ -25,10 +25,10 @@ spec:
   type: Python
   pythonVersion: "3"
   mode: cluster
-  image: "gcr.io/spark-operator/spark-py:v3.1.1"
+  image: "apache/spark-py:v3.1.3"
   imagePullPolicy: Always
   mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
-  sparkVersion: "3.1.1"
+  sparkVersion: "3.1.3"
   restartPolicy:
     type: OnFailure
     onFailureRetries: 3
@@ -40,11 +40,11 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3
     serviceAccount: spark
   executor:
     cores: 1
     instances: 1
     memory: "512m"
     labels:
-      version: 3.1.1
+      version: 3.1.3


### PR DESCRIPTION
See issue #1868.
Updating the examples and docs to reduce the friction to new users.
The accessible container registry and tag is `apache/spark:v3.1.3` with spark version `3.1.3`.
The examples point to older version `3.1.1` no longer exist and pods fail with `ImagePullBackOff`.

Update: signed the cla.
