### PR TITLE
Allow to set webhook job resource limits (#1429,#1300)

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -129,9 +129,11 @@ All charts linted successfully
 | uiService.enable | bool | `true` | Enable UI service creation for Spark application |
 | webhook.cleanupAnnotations | object | `{"helm.sh/hook":"pre-delete, pre-upgrade","helm.sh/hook-delete-policy":"hook-succeeded"}` | The annotations applied to the cleanup job, required for helm lifecycle hooks |
 | webhook.cleanupPodLabels | object | `{}` | The podLabels applied to the pod of the cleanup job |
+| webhook.cleanupResources | object | `{}` | Cleanup job Pod resource requests and limits |
 | webhook.enable | bool | `false` | Enable webhook server |
 | webhook.initAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-weight":"50"}` | The annotations applied to init job, required to restore certs deleted by the cleanup job during upgrade |
 | webhook.initPodLabels | object | `{}` | The podLabels applied to the pod of the init job |
+| webhook.initResources | object | `{}` | Init job Pod resource requests and limits |
 | webhook.namespaceSelector | string | `""` | The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2. Empty string (default) will operate on all namespaces |
 | webhook.port | int | `8080` | Webhook service port |
 | webhook.timeout | int | `30` |  |

--- a/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -49,6 +49,8 @@ spec:
           -H \"Content-Type: application/json\" \
           --data \"{\\\"kind\\\":\\\"DeleteOptions\\\",\\\"apiVersion\\\":\\\"batch/v1\\\",\\\"propagationPolicy\\\":\\\"Foreground\\\"}\" \
           https://kubernetes.default.svc/apis/batch/v1/namespaces/{{ .Release.Namespace }}/jobs/{{ include "spark-operator.fullname" . }}-webhook-init"
+        resources:
+          {{- toYaml .Values.webhook.cleanupResources | nindent 10 }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/templates/webhook-init-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-init-job.yaml
@@ -39,6 +39,8 @@ spec:
             "-r", "{{ include "spark-operator.fullname" . }}-webhook-certs",
             "-p"
           ]
+        resources:
+          {{- toYaml .Values.webhook.initResources | nindent 10 }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -105,6 +105,14 @@ webhook:
     "helm.sh/hook-weight": "50"
   # -- The podLabels applied to the pod of the init job
   initPodLabels: {}
+  # -- Resources applied to init job
+  initResources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
   # -- The annotations applied to the cleanup job, required for helm lifecycle hooks
   cleanupAnnotations:
     "helm.sh/hook": pre-delete, pre-upgrade
@@ -112,6 +120,15 @@ webhook:
     # -- Webhook Timeout in seconds
   # -- The podLabels applied to the pod of the cleanup job
   cleanupPodLabels: {}
+  # -- Resources applied to cleanup job
+  cleanupResources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
   timeout: 30
 
 metrics:


### PR DESCRIPTION
Problem: if you are using policies to ensure that all workloads in your cluster have resources limits & request (e.x. [gatekeeper](https://github.com/open-policy-agent/gatekeeper)) you need to be able to set those limits on all release workloads otherwise they simply will not be permitted to start with errors like:
`  Warning  FailedCreate  42s (x4 over 92s)  job-controller  Error creating: admission webhook "validation.gatekeeper.sh" denied the request: [requiredresources] container <main> does not have <{"cpu", "memory"}> limits defined
[requiredresources] container <main> does not have <{"cpu", "memory"}> requests defined
`
Solution: allow to set resources for webhook jobs. Related issues: #1300, #1429.

Tested cases:
- `helm template charts/spark-operator-chart/`  - ok
- `helm template --set webhook.enable=true --set webhook.cleanupResources.requests.cpu='100m' --set webhook.cleanupResources.limits.cpu='100m' --set webhook.cleanupResources.requests.memory='100M' --set webhook.cleanupResources.limits.memory='100M' --set webhook.initResources.requests.cpu='100M' --set webhook.initResources.limits.cpu='100m' --set webhook.initResources.requests.memory='100M' --set webhook.initResources.limits.memory='100M' charts/spark-operator-chart/` - ok