### PR TITLE
fix: add containerPort declaration for webhook in helm chart

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.2
+version: 1.2.3
 appVersion: v1beta2-1.3.8-3.5.0
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.1
+version: 1.2.2
 appVersion: v1beta2-1.3.8-3.5.0
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -140,6 +140,7 @@ All charts linted successfully
 | webhook.initResources | object | `{}` | Resources applied to init job |
 | webhook.namespaceSelector | string | `""` | The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2. Empty string (default) will operate on all namespaces |
 | webhook.port | int | `8080` | Webhook service port |
+| webhook.portName | string | `"webhook"` | Webhook container port name and service target port name |
 | webhook.timeout | int | `30` |  |
 
 ## Maintainers

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           {{- toYaml .Values.envFrom | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        {{- if or .Values.metrics.enable .Values.metrics.enable }}
+        {{- if or .Values.metrics.enable .Values.webhook.enable }}
         ports:
           {{ if .Values.metrics.enable }}
           - name: {{ .Values.metrics.portName | quote }}

--- a/charts/spark-operator-chart/templates/deployment.yaml
+++ b/charts/spark-operator-chart/templates/deployment.yaml
@@ -51,10 +51,16 @@ spec:
           {{- toYaml .Values.envFrom | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        {{- if .Values.metrics.enable }}
+        {{- if or .Values.metrics.enable .Values.metrics.enable }}
         ports:
+          {{ if .Values.metrics.enable }}
           - name: {{ .Values.metrics.portName | quote }}
             containerPort: {{ .Values.metrics.port }}
+          {{ end }}
+          {{ if .Values.webhook.enable }}
+          - name: {{ .Values.webhook.portName | quote }}
+            containerPort: {{ .Values.webhook.port }}
+          {{ end }}
         {{ end }}
         args:
         - -v={{ .Values.logLevel }}

--- a/charts/spark-operator-chart/templates/webhook-service.yaml
+++ b/charts/spark-operator-chart/templates/webhook-service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: {{ .Values.webhook.port }}
+    targetPort: {{ .Values.webhook.portName | quote }}
     name: webhook
   selector:
     {{- include "spark-operator.selectorLabels" . | nindent 4 }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -96,6 +96,8 @@ webhook:
   enable: false
   # -- Webhook service port
   port: 8080
+  # -- Webhook container port name and service target port name
+  portName: webhook
   # -- The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2.
   # Empty string (default) will operate on all namespaces
   namespaceSelector: ""
@@ -175,7 +177,8 @@ podLabels: {}
 # Note, that each job submission will spawn a JVM within the Spark Operator Pod using "/usr/local/openjdk-11/bin/java -Xmx128m".
 # Kubernetes may kill these Java processes at will to enforce resource limits. When that happens, you will see the following error:
 # 'failed to run spark-submit for SparkApplication [...]: signal: killed' - when this happens, you may want to increase memory limits.
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 300Mi

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -177,8 +177,7 @@ podLabels: {}
 # Note, that each job submission will spawn a JVM within the Spark Operator Pod using "/usr/local/openjdk-11/bin/java -Xmx128m".
 # Kubernetes may kill these Java processes at will to enforce resource limits. When that happens, you will see the following error:
 # 'failed to run spark-submit for SparkApplication [...]: signal: killed' - when this happens, you may want to increase memory limits.
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 300Mi


### PR DESCRIPTION
Adds a missing port declaration for the container port serving the webhook to the helm chart. Bumps the chart version for this fix. 

Notice that this port _is correctly declared_ in the kustomize patches, it's just the helm chart that didn't expose this. 

Here's the port being declared for the kustomize manifests that enable the webhook: 
https://github.com/kubeflow/spark-operator/blob/252eddd2fac294de0fff6dc9e14e23574221f960/manifest/spark-operator-with-webhook.yaml#L51-L52

But here, the helm chart only creates a port for metrics, with no condition to add a port when `.Values.webhook.enable` is true 

https://github.com/kubeflow/spark-operator/blob/252eddd2fac294de0fff6dc9e14e23574221f960/charts/spark-operator-chart/templates/deployment.yaml#L49-L53

Closes: #1962 