### PR TITLE
publish chart independently, incremented both chart and image versions to trigger build of both

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
       - name: Check if build should be skipped
         id: skip-check
         run: |
@@ -55,7 +55,6 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           echo "SCOPE=${platform//\//-}" >> $GITHUB_ENV
-
       - name: Set up QEMU
         timeout-minutes: 1
         uses: docker/setup-qemu-action@v3
@@ -93,7 +92,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-  publish:
+  publish-image:
     runs-on: ubuntu-latest
     needs:
       - release
@@ -128,6 +127,16 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+  publish-chart:
+    runs-on: ubuntu-latest
+    if: needs.publish-image.result == 'success' || needs.publish-image.result == 'skipped'
+    needs:
+      - publish-image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.2.3
-appVersion: v1beta2-1.4.0-3.5.0
+appVersion: v1beta2-1.4.1-3.5.0
 keywords:
   - spark
 home: https://github.com/kubeflow/spark-operator

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.3
+version: 1.2.4
 appVersion: v1beta2-1.4.1-3.5.0
 keywords:
   - spark


### PR DESCRIPTION
moved chart publishing to a separate job which runs after publish image is skipped or succeeded 