### PR TITLE
Fixes a bug with dynamic allocation forcing the executor count to be 1 even when minExecutors is set to 0

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.14
-appVersion: v1beta2-1.4.5-3.5.0
+version: 1.2.15
+appVersion: v1beta2-1.4.6-3.5.0
 keywords:
   - spark
 home: https://github.com/kubeflow/spark-operator

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,6 +1,6 @@
 # spark-operator
 
-![Version: 1.2.14](https://img.shields.io/badge/Version-1.2.14-informational?style=flat-square) ![AppVersion: v1beta2-1.4.5-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.5--3.5.0-informational?style=flat-square)
+![Version: 1.2.15](https://img.shields.io/badge/Version-1.2.15-informational?style=flat-square) ![AppVersion: v1beta2-1.4.6-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.6--3.5.0-informational?style=flat-square)
 
 A Helm chart for Spark on Kubernetes operator
 

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults_test.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults_test.go
@@ -199,4 +199,29 @@ func TestSetSparkApplicationDefaultsExecutorSpecDefaults(t *testing.T) {
 	assert.Nil(t, app.Spec.Executor.Memory)
 	assert.Nil(t, app.Spec.Executor.Instances)
 
+	//Case3: Dynamic allocation is enabled with minExecutors = 0
+	var minExecs = int32(0)
+	app = &SparkApplication{
+		Spec: SparkApplicationSpec{
+			DynamicAllocation: &DynamicAllocation{
+				Enabled:      true,
+				MinExecutors: &minExecs,
+			},
+		},
+	}
+
+	SetSparkApplicationDefaults(app)
+	assert.Nil(t, app.Spec.Executor.Instances)
+
+	//Case4: Dynamic allocation is enabled via SparkConf
+	app = &SparkApplication{
+		Spec: SparkApplicationSpec{
+			SparkConf: map[string]string{
+				"spark.dynamicallocation.enabled": "true",
+			},
+		},
+	}
+
+	SetSparkApplicationDefaults(app)
+	assert.Nil(t, app.Spec.Executor.Instances)
 }


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
Fixes a bug with dynamic allocation forcing the executor count to be 1 even when minExecutors is set to 0

## Change Category
Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Resolves otherwise unexpected behavior where the value of minExecutors was not fully respected.

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.
