### PR TITLE
Add emptyDir sizeLimit support for local dirs

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.11
+version: 1.2.12
 appVersion: v1beta2-1.4.3-3.5.0
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.2.12
-appVersion: v1beta2-1.4.3-3.5.0
+appVersion: v1beta2-1.4.4-3.5.0
 keywords:
   - spark
 home: https://github.com/kubeflow/spark-operator

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,6 +1,6 @@
 # spark-operator
 
-![Version: 1.2.11](https://img.shields.io/badge/Version-1.2.11-informational?style=flat-square) ![AppVersion: v1beta2-1.4.3-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.3--3.5.0-informational?style=flat-square)
+![Version: 1.2.12](https://img.shields.io/badge/Version-1.2.12-informational?style=flat-square) ![AppVersion: v1beta2-1.4.3-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.3--3.5.0-informational?style=flat-square)
 
 A Helm chart for Spark on Kubernetes operator
 

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,6 +1,6 @@
 # spark-operator
 
-![Version: 1.2.12](https://img.shields.io/badge/Version-1.2.12-informational?style=flat-square) ![AppVersion: v1beta2-1.4.3-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.3--3.5.0-informational?style=flat-square)
+![Version: 1.2.12](https://img.shields.io/badge/Version-1.2.12-informational?style=flat-square) ![AppVersion: v1beta2-1.4.4-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.4--3.5.0-informational?style=flat-square)
 
 A Helm chart for Spark on Kubernetes operator
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -360,7 +360,8 @@ spec:
       persistentVolumeClaim:
         claimName: my-pvc
     - name: spark-work
-      emptyDir: {}
+      emptyDir:
+        sizeLimit: 5Gi
   driver:
     volumeMounts:
       - name: spark-work

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -516,6 +516,9 @@ func buildLocalVolumeOptions(prefix string, volume v1.Volume, volumeMount v1.Vol
 		}
 	case volume.EmptyDir != nil:
 		options = append(options, fmt.Sprintf(VolumeMountPathTemplate, "emptyDir", volume.Name, volumeMount.MountPath))
+		if volume.EmptyDir.SizeLimit != nil {
+			options = append(options, fmt.Sprintf(VolumeMountOptionTemplate, "emptyDir", volume.Name, "sizeLimit", volume.EmptyDir.SizeLimit.String()))
+		}
 	case volume.PersistentVolumeClaim != nil:
 		options = append(options, fmt.Sprintf(VolumeMountPathTemplate, "persistentVolumeClaim", volume.Name, volumeMount.MountPath))
 		options = append(options, fmt.Sprintf(VolumeMountOptionTemplate, "persistentVolumeClaim", volume.Name, "claimName", volume.PersistentVolumeClaim.ClaimName))


### PR DESCRIPTION
## Purpose of this PR

* Support the `sizeLimit` field for `emptyDir` volume types that are prefixed with `spark-local-dir-...`

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

* If creating an `emptyDir` volume without a `spark-local-dir-...` prefix, the webhook will patch the appropriate volume onto the pod spec, but Spark will still create an `emptyDir` volume anyway https://github.com/apache/spark/blob/fd3f70c74ba63a0209a4a48a387048ef40380e0f/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala#L38-L40
* However if using a `spark-local-dir-...`, which the operator doesn't consider in the webhook and instead supplies at submission time, the sizeLimit is not carried through to the resulting volume in K8s
* It may be desirable to set a size limit if using an `emptyDir` volume e.g. if on an NVME node to prevent a node disk pressure condition

## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

