### PR TITLE
Remove outdated PySpark experimental warning in example

### DIFF
--- a/examples/spark-py-pi.yaml
+++ b/examples/spark-py-pi.yaml
@@ -12,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Support for Python is experimental, and requires building SNAPSHOT image of Apache Spark,
-# with `imagePullPolicy` set to Always
 
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication


### PR DESCRIPTION
## Purpose of this PR
Confusing warning in the Python example that Python support is experimental. Python support seems stable in current versions, correct?

**Proposed changes:**
Remove outdated (?) warning in the pyspark example that Python support is experimental. (This was written 6 years ago)

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

This is confusing if no longer correct.

## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

