### PR TITLE
Add  field to SparkApplication CRDs

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.15
+version: 1.2.16
 appVersion: v1beta2-1.4.6-3.5.0
 keywords:
   - spark

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,6 +1,6 @@
 # spark-operator
 
-![Version: 1.2.15](https://img.shields.io/badge/Version-1.2.15-informational?style=flat-square) ![AppVersion: v1beta2-1.4.6-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.6--3.5.0-informational?style=flat-square)
+![Version: 1.2.16](https://img.shields.io/badge/Version-1.2.16-informational?style=flat-square) ![AppVersion: v1beta2-1.4.6-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.6--3.5.0-informational?style=flat-square)
 
 A Helm chart for Spark on Kubernetes operator
 

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -917,6 +917,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   seccompProfile:
@@ -2748,6 +2750,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   seccompProfile:

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -903,6 +903,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               seccompProfile:
@@ -2734,6 +2736,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               seccompProfile:

--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -917,6 +917,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   seccompProfile:
@@ -2748,6 +2750,8 @@ spec:
                                       x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
+                              restartPolicy:
+                                type: string
                               securityContext:
                                 properties:
                                   seccompProfile:

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -903,6 +903,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               seccompProfile:
@@ -2734,6 +2736,8 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          restartPolicy:
+                            type: string
                           securityContext:
                             properties:
                               seccompProfile:


### PR DESCRIPTION
## Purpose of this PR
InitContainers can now specify a `restartPolicy` with a value of `Always` to make the init container act like a sidecar. This PR updates the CRDs to allow this field to be present. 

https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle
https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

**Proposed changes:**
- Adds `restartPolicy` to `driver.initContainers` and `executor.initContainers` for both `SparkApplication` and `ScheduledSparkApplication`.

## Change Category
Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

This allows users of the helm chart to set `restartPolicy: "Always"` for init containers on the executor and driver pods. 

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

