### PR TITLE
(#2020) Bump to Spark 3.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=spark:3.5.0
+ARG SPARK_IMAGE=spark:3.5.1
 
 FROM golang:1.22-alpine as builder
 

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.2.15
-appVersion: v1beta2-1.4.6-3.5.0
+version: 1.2.16
+appVersion: v1beta2-1.4.6-3.5.1
 keywords:
   - spark
 home: https://github.com/kubeflow/spark-operator

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,6 +1,6 @@
 # spark-operator
 
-![Version: 1.2.15](https://img.shields.io/badge/Version-1.2.15-informational?style=flat-square) ![AppVersion: v1beta2-1.4.6-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.4.6--3.5.0-informational?style=flat-square)
+![Version: 1.2.16](https://img.shields.io/badge/Version-1.2.16-informational?style=flat-square) ![AppVersion: v1beta2-1.4.6-3.5.1](https://img.shields.io/badge/AppVersion-v1beta2--1.4.6--3.5.1-informational?style=flat-square)
 
 A Helm chart for Spark on Kubernetes operator
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -33,7 +33,7 @@ The easiest way to build the operator without worrying about its dependencies is
 docker build -t <image-tag> .
 ```
 
-The operator image is built upon a base Spark image that defaults to `spark:3.5.0`. If you want to use your own Spark image (e.g., an image with a different version of Spark or some custom dependencies), specify the argument `SPARK_IMAGE` as the following example shows:
+The operator image is built upon a base Spark image that defaults to `spark:3.5.1`. If you want to use your own Spark image (e.g., an image with a different version of Spark or some custom dependencies), specify the argument `SPARK_IMAGE` as the following example shows:
 
 ```bash
 docker build --build-arg SPARK_IMAGE=<your Spark image> -t <image-tag> .

--- a/examples/spark-pi-configmap.yaml
+++ b/examples/spark-pi-configmap.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "spark:3.5.0"
+  image: "spark:3.5.1"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar"
-  sparkVersion: "3.5.0"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.1.jar"
+  sparkVersion: "3.5.1"
   restartPolicy:
     type: Never
   volumes:
@@ -37,7 +37,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     serviceAccount: spark-operator-spark
     volumeMounts:
       - name: config-vol
@@ -47,7 +47,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     volumeMounts:
       - name: config-vol
         mountPath: /opt/spark/mycm

--- a/examples/spark-pi-custom-resource.yaml
+++ b/examples/spark-pi-custom-resource.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "spark:3.5.0"
+  image: "spark:3.5.1"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar"
-  sparkVersion: "3.5.0"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.1.jar"
+  sparkVersion: "3.5.1"
   restartPolicy:
     type: Never
   volumes:
@@ -38,7 +38,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     serviceAccount: spark-operator-spark
     volumeMounts:
       - name: "test-volume"
@@ -48,7 +48,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-pi-schedule.yaml
+++ b/examples/spark-pi-schedule.yaml
@@ -25,11 +25,11 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: "spark:3.5.0"
+    image: "spark:3.5.1"
     imagePullPolicy: Always
     mainClass: org.apache.spark.examples.SparkPi
-    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar"
-    sparkVersion: "3.5.0"
+    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.1.jar"
+    sparkVersion: "3.5.1"
     restartPolicy:
       type: Never
     driver:
@@ -37,11 +37,11 @@ spec:
       coreLimit: "1200m"
       memory: "512m"
       labels:
-        version: 3.5.0
+        version: 3.5.1
       serviceAccount: spark-operator-spark
     executor:
       cores: 1
       instances: 1
       memory: "512m"
       labels:
-        version: 3.5.0
+        version: 3.5.1

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: "spark:3.5.0"
+  image: "spark:3.5.1"
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar"
-  sparkVersion: "3.5.0"
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.1.jar"
+  sparkVersion: "3.5.1"
   sparkUIOptions:
     serviceLabels:
       test-label/v1: 'true'
@@ -41,7 +41,7 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     serviceAccount: spark-operator-spark
     volumeMounts:
       - name: "test-volume"
@@ -51,7 +51,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-py-pi.yaml
+++ b/examples/spark-py-pi.yaml
@@ -22,10 +22,10 @@ spec:
   type: Python
   pythonVersion: "3"
   mode: cluster
-  image: "spark:3.5.0"
+  image: "spark:3.5.1"
   imagePullPolicy: Always
   mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
-  sparkVersion: "3.5.0"
+  sparkVersion: "3.5.1"
   restartPolicy:
     type: OnFailure
     onFailureRetries: 3
@@ -37,11 +37,11 @@ spec:
     coreLimit: "1200m"
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1
     serviceAccount: spark-operator-spark
   executor:
     cores: 1
     instances: 1
     memory: "512m"
     labels:
-      version: 3.5.0
+      version: 3.5.1


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
Resolves #2020 by updating the default Spark version.

**Proposed changes:**
- Bumps the default Spark version to 3.5.1

## Change Category
Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that could affect existing functionality)
- [X] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->
Integrates bug fixes and IA fixes from upstream Spark

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

