### PR TITLE
Update minikube version in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -127,10 +127,10 @@ jobs:
         run: make detect-crds-drift
 
       - name: setup minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2.11.0
         with:
-          minikube version: v1.32.0
-          kubernetes version: v1.28.8
+          minikube version: v1.33.0
+          kubernetes version: v1.30.0
           start args: --memory 6g --cpus=2 --addons ingress
           github token: ${{ inputs.github-token }}
 
@@ -154,10 +154,10 @@ jobs:
           go-version-file: "go.mod"
 
       - name: setup minikube
-        uses: manusa/actions-setup-minikube@v2.10.0
+        uses: manusa/actions-setup-minikube@v2.11.0
         with:
-          minikube version: v1.32.0
-          kubernetes version: v1.28.8
+          minikube version: v1.33.0
+          kubernetes version: v1.30.0
           start args: --memory 6g --cpus=2 --addons ingress
           github token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
Following on from discussion [here](https://github.com/kubeflow/spark-operator/pull/2058#issuecomment-2166301679), this PR intends to update the `minikube` version in CI to the latest. This is to fix an issue on the current version of minikube in [use](https://github.com/kubeflow/spark-operator/actions/runs/9506313545/job/26203210211?pr=2058).

**Proposed changes:**
- Update `minikube` action to latest version - `2.11.0`, as well as the minikube version.


## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

