### PR TITLE
Added the  new CNCF slack channel to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,5 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 ## Community
 
 * Join [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
-* Check out our blog post on [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community] (https://github.com/kubeflow/blog/blob/master/_posts/2024-04-15-kubeflow-spark-operator.md)
+* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://github.com/kubeflow/blog/blob/master/_posts/2024-04-15-kubeflow-spark-operator.md)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join the [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) and then join ```#kubeflow-spark-operator``` Channel.
-* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://blog.kubeflow.org/operators/2024/04/15/kubeflow-spark-operator.html)
+* Join the [CNCF Slack Workspace](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) on Slack and then join ```#kubeflow-spark-operator``` Channel for collaboration on the Spark Operator.
+* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://blog.kubeflow.org/operators/2024/04/15/kubeflow-spark-operator.html).
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join the [CNCF Slack Workspace](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) on Slack and then join ```#kubeflow-spark-operator``` Channel for collaboration on the Spark Operator.
-* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://blog.kubeflow.org/operators/2024/04/15/kubeflow-spark-operator.html).
+* Join the [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) and then join ```#kubeflow-spark-operator``` Channel.
+* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://blog.kubeflow.org/operators/2024/04/15/kubeflow-spark-operator.html)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join our [Kubeflow Slack Channel](https://app.slack.com/client/T08PSQ7BQ/C074588U7EG)
+* Join our [Kubeflow Slack Channel](https://cloud-native.slack.com/archives/C074588U7EG)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
-* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://github.com/kubeflow/blog/blob/master/_posts/2024-04-15-kubeflow-spark-operator.md)
+* Join the [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) and then join ```#kubeflow-spark-operator``` Channel.
+* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://blog.kubeflow.org/operators/2024/04/15/kubeflow-spark-operator.html)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/README.md
+++ b/README.md
@@ -91,5 +91,6 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join our [Kubeflow Slack Channel](https://cloud-native.slack.com/archives/C074588U7EG)
+* Join [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
+* Check out our blog post on [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community] (https://github.com/kubeflow/blog/blob/master/_posts/2024-04-15-kubeflow-spark-operator.md)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join our [Kubeflow Slack Channel](https://kubeflow.slack.com/archives/C06627U3XU3)
+* Join our [Kubeflow Slack Channel](https://app.slack.com/client/T08PSQ7BQ/C074588U7EG)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,6 +1,6 @@
 # spark-operator
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: v1beta2-1.6.0-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.6.0--3.5.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: v1beta2-1.6.0-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.6.0--3.5.0-informational?style=flat-square)
 
 A Helm chart for Spark on Kubernetes operator
 
@@ -110,7 +110,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | podMonitor.labels | object | `{}` | Pod monitor labels |
 | podMonitor.podMetricsEndpoint | object | `{"interval":"5s","scheme":"http"}` | Prometheus metrics endpoint properties. `metrics.portName` will be used as a port |
 | podSecurityContext | object | `{}` | Pod security context |
-| priorityClassName | string | `""` | Priority class to be used for running spark-operator pod. This helps in managing the pods during preemption. |
+| priorityClassName | string | `""` | A priority class to be used for running spark-operator pod. |
 | rbac.annotations | object | `{}` | Optional annotations for rbac |
 | rbac.create | bool | `false` | **DEPRECATED** use `createRole` and `createClusterRole` |
 | rbac.createClusterRole | bool | `true` | Create and use RBAC `ClusterRole` resources |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -1,10 +1,6 @@
 # spark-operator
 
-<<<<<<< HEAD
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: v1beta2-1.6.0-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.6.0--3.5.0-informational?style=flat-square)
-=======
 ![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: v1beta2-1.6.1-3.5.0](https://img.shields.io/badge/AppVersion-v1beta2--1.6.1--3.5.0-informational?style=flat-square)
->>>>>>> origin/master
 
 A Helm chart for Spark on Kubernetes operator
 


### PR DESCRIPTION
### 🛑 Important:
This PR is for the change proposed in https://github.com/kubeflow/spark-operator/issues/2061

## Purpose of this PR
The PR aims at providing the new CNCF slack Channel details so that new users can go to new slack channel instead of old slack channel which is going to be archived soon.  See details here (https://github.com/kubeflow/spark-operator/issues/2061)

**Proposed changes:**
- Update slack channel to CNCF Slack channel

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

Users are currentl joining the old slack channel instead of the new one


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.


