### PR TITLE
Modified README.MD as per changes discussed on https://github.com/kubeflow/spark-operator/pull/2062

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,6 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) and the [Developer Guide](docs/d
 
 ## Community
 
-* Join our [Kubeflow Slack Channel](https://kubeflow.slack.com/archives/C06627U3XU3)
+* Join the [CNCF Slack Channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) and then join ```#kubeflow-spark-operator``` Channel.
+* Check out our blog post [Announcing the Kubeflow Spark Operator: Building a Stronger Spark on Kubernetes Community](https://blog.kubeflow.org/operators/2024/04/15/kubeflow-spark-operator.html)
 * Check out [who is using the Kubernetes Operator for Apache Spark](docs/who-is-using.md).


### PR DESCRIPTION

### 🛑 Important:
This PR is for the change proposed in https://github.com/kubeflow/spark-operator/issues/2061

## Purpose of this PR
The PR aims at providing the new CNCF slack Channel details so that new users can go to new slack channel instead of old slack channel which is going to be archived soon.  See details here (https://github.com/kubeflow/spark-operator/issues/2061)

**Proposed changes:**
- Update slack channel to CNCF Slack channel

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

Users are currentl joining the old slack channel instead of the new one


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.


