### PR TITLE
fix go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/spark-operator
 
-go 1.22
+go 1.22.1
 
 require (
 	cloud.google.com/go/storage v1.40.0


### PR DESCRIPTION
## Purpose of this PR

When trying to run `go` commands in the project on a previous version of Go, it tries to automatically download the desired version in `go.mod`. However, the entire version string is necessary for this to work.

before the change

```shell
$ go version
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

after the change

```shell
$ go version
go: downloading go1.22.0 (darwin/arm64)
go version go1.22.0 darwin/arm64
```

* relates to [cmd/go: download go1.22 for darwin/arm64: toolchain not available golang/go#65568](https://github.com/golang/go/issues/65568)

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

