### PR TITLE
prevent driver pod from being deleted before its status is processed by the operator (#2054)

### DIFF
--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -179,7 +179,7 @@ func TestMutatePod(t *testing.T) {
 	assert.True(t, len(response.Patch) > 0)
 	var patchOps []*patchOperation
 	json.Unmarshal(response.Patch, &patchOps)
-	assert.Equal(t, 6, len(patchOps))
+	assert.Equal(t, 7, len(patchOps))
 }
 
 func serializePod(pod *corev1.Pod) ([]byte, error) {


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
 The backgroud of this pr is discribed in [#2054](https://github.com/kubeflow/spark-operator/issues/2054), driver pod is deleted before it should be use in operator, now the sparkapp state transformation is trigger by list-watch. 
For example, if a new sparkapp submit successfully and driver pod has deleted after compeleted status but before operator start handling sparkapp state transformation to SubmittedState, the code is in here [getAndUpdateAppState](https://github.com/kubeflow/spark-operator/blob/16cd35a0a220da0304383517c73a5fdb36f4213c/pkg/controller/sparkapplication/controller.go#L612C15-L612C35), the function getAndUpdateAppState need to get driver pod but it was deleted, and sparkapp become failed and error message show 'driver pod not found'.
So to add finalier to driver pod to prevent it

**Proposed changes:**
- Add finalizer to driver pod and remove it in suitable time

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

