### PR TITLE
Add chart spark-history-server

### DIFF
--- a/charts/spark-history-server/.helmignore
+++ b/charts/spark-history-server/.helmignore
@@ -1,0 +1,55 @@
+#
+# Copyright 2024 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+
+# CI
+ci/
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# MacOS
+.DS_Store
+
+# helm-unittest
+./tests
+.debug
+__snapshot__
+
+# helm-docs
+README.md.gotmpl

--- a/charts/spark-history-server/Chart.yaml
+++ b/charts/spark-history-server/Chart.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright 2024 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v2
+
+name: spark-history-server
+
+description: A Helm chart for Spark history server
+
+type: application
+
+version: 0.1.0
+
+appVersion: 3.5.0
+
+keywords:
+- spark
+- spark history server
+
+home: https://github.com/kubeflow/spark-operator
+
+maintainers:
+- name: ChenYi015
+  email: github@chenyicn.net

--- a/charts/spark-history-server/README.md
+++ b/charts/spark-history-server/README.md
@@ -1,0 +1,72 @@
+# spark-history-server
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0](https://img.shields.io/badge/AppVersion-3.5.0-informational?style=flat-square)
+
+A Helm chart for Spark history server
+
+**Homepage:** <https://github.com/kubeflow/spark-operator>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| ChenYi015 | <github@chenyicn.net> |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Pod affinity |
+| env | list | `[]` | List of environment variables to set in the container. |
+| envFrom | list | `[]` | List of sources to populate environment variables in the container. |
+| fullnameOverride | string | `""` | String to fully override `spark-history-server.fullname` template |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.pullSecrets | list | `[]` | Image pull secrets |
+| image.registry | string | `"docker.io"` | Image registry |
+| image.repository | string | `"kubeflow/spark-history-server"` | Image repository |
+| image.tag | string | `""` | Image tag, if set, overrides the image tag whose default is the chart appVersion. |
+| ingress.annotations | object | `{}` | Annotations to add to the ingress |
+| ingress.className | string | `""` | Ingress class name |
+| ingress.enable | bool | `false` | Specifies whether an ingress resource should be created |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` | String to partially override `spark-history-server.fullname` template (will maintain the release name) |
+| nodeSelector | object | `{}` | Node selector |
+| podAnnotations | object | `{}` | Annotations to add to the pod |
+| podSecurityContext | object | `{}` | Pod security context |
+| replicaCount | int | `1` | Desired number of pods |
+| resources | object | `{}` | Pod resources |
+| securityContext | object | `{}` | Container security context |
+| service.port | int | `18080` | Service port |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| sparkConf."spark.history.fs.logDirectory" | string | `"file:///tmp/spark-events"` |  |
+| storage.abs.createSecret | object | `{"azureStorageAccessKey":"","azureStorageConnectionString":""}` | If ABS is enabled as artifact store backend and no existing secret is specified, create the secret used to connect to Azure. |
+| storage.abs.enable | bool | `false` | Specifies whether to enable Azure Blob Storage (ABS) as event log storage. |
+| storage.abs.existingSecret | string | `""` | Name of an existing secret containing the key `AZURE_STORAGE_CONNECTION_STRING` or `AZURE_STORAGE_ACCESS_KEY` to store credentials to access ABS. |
+| storage.gcs.createSecret | object | `{"keyFile":""}` | If GCS is enabled and no existing secret is specified, create the secret used to connect to GCS. |
+| storage.gcs.createSecret.keyFile | string | `""` | Content of key file |
+| storage.gcs.enable | bool | `false` | Specifies whether to enable Google Cloud Storage (GCS) as event log storage. |
+| storage.gcs.existingSecret | string | `""` | Name of an existing secret containing the key `keyfile.json` used to store credentials to access GCS. |
+| storage.oss.createSecret | object | `{"accessKeyId":"","accessKeySecret":""}` | If OSS is enabled and no existing secret is specified, create the secret used to store OSS access credentials. |
+| storage.oss.createSecret.accessKeyId | string | `""` | Alibaba Cloud access key ID |
+| storage.oss.createSecret.accessKeySecret | string | `""` | Alibaba Cloud access key secret |
+| storage.oss.enable | bool | `false` | Specifies whether to enable Alibaba Cloud Object Storage Service (OSS) as event log storage. |
+| storage.oss.endpoint | string | `""` | Endpoint of OSS e.g. `oss-cn-beijing-internal.aliyuncs.com`. |
+| storage.oss.existingSecret | string | `""` | Name of an existing secret containing the key `OSS_ACCESS_KEY_ID` and `OSS_ACCESS_KEY_SECRET` to store credentials to access OSS. |
+| storage.s3.createCaSecret | object | `{"caBundle":""}` | If S3 is enabled and no existing CA secret is specified, create the secret used to secure connection to S3 / Minio. |
+| storage.s3.createCaSecret.caBundle | string | `""` | Content of CA bundle |
+| storage.s3.createSecret | object | `{"accessKeyId":"","secretAccessKey":""}` | If S3 is enabled and no existing secret is specified, create the secret used to connect to S3 / Minio. |
+| storage.s3.createSecret.accessKeyId | string | `""` | AWS access key ID |
+| storage.s3.createSecret.secretAccessKey | string | `""` | AWS secret access key |
+| storage.s3.enable | bool | `false` | Specifies whether to enable AWS S3 / Minio as event log storage. |
+| storage.s3.existingCaSecret | string | `""` | Name of an existing secret containing the key `ca-bundle.crt` used to store the CA certificate for TLS connections. |
+| storage.s3.existingSecret | string | `""` | Name of an existing secret containing the keys `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to access artifact storage on AWS S3 / MINIO. |
+| tolerations | list | `[]` | Pod tolerations |
+| volumeMounts | list | `[]` | List of volume mounts that can be referenced by the containers. |
+| volumes | list | `[]` | List of volumes that can be mounted by the containers. |
+

--- a/charts/spark-history-server/templates/NOTES.txt
+++ b/charts/spark-history-server/templates/NOTES.txt
@@ -1,0 +1,40 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "spark-history-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "spark-history-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "spark-history-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "spark-history-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/spark-history-server/templates/_helpers.tpl
+++ b/charts/spark-history-server/templates/_helpers.tpl
@@ -1,0 +1,101 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spark-history-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "spark-history-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "spark-history-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "spark-history-server.labels" -}}
+helm.sh/chart: {{ include "spark-history-server.chart" . }}
+{{ include "spark-history-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "spark-history-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spark-history-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to be used by spark history server.
+*/}}
+{{- define "spark-history-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "spark-history-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the image to be used by spark history server.
+*/}}
+{{- define "spark-history-server.imageName" }}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Create the name of the configmap to be used by spark history server.
+*/}}
+{{- define "spark-history-server.configMapName" }}
+{{- include "spark-history-server.fullname" . }}-configmap
+{{- end -}}
+
+{{/*
+Create the name of the secret to be used by spark history server.
+*/}}
+{{- define "spark-history-server.secretName" }}
+{{- include "spark-history-server.fullname" . }}-secret
+{{- end -}}

--- a/charts/spark-history-server/templates/configmap.yaml
+++ b/charts/spark-history-server/templates/configmap.yaml
@@ -1,0 +1,65 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "spark-history-server.configMapName" . }}
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+data:
+  spark-defaults.conf: |
+    #
+    # Licensed to the Apache Software Foundation (ASF) under one or more
+    # contributor license agreements.  See the NOTICE file distributed with
+    # this work for additional information regarding copyright ownership.
+    # The ASF licenses this file to You under the Apache License, Version 2.0
+    # (the "License"); you may not use this file except in compliance with
+    # the License.  You may obtain a copy of the License at
+    #
+    #    http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    #
+
+    {{- if .Values.storage.s3.enable }}
+    spark.hadoop.fs.s3a.impl org.apache.hadoop.fs.s3a.S3AFileSystem
+    spark.hadoop.fs.s3a.endpoint s3.amazonaws.com
+    {{- else if .Values.storage.gcs.enable }}
+    spark.hadoop.fs.AbstractFileSystem.gs.impl com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS
+    spark.hadoop.fs.gs.impl com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
+    spark.hadoop.fs.gs.auth.service.account.enable true
+    spark.hadoop.fs.gs.auth.service.account.json.keyfile /etc/gcs/keyfile.json
+    {{- else if .Values.storage.abs.enable }}
+    spark.hadoop.fs.AbstractFileSystem.wasbs.impl org.apache.hadoop.fs.azure.Wasbs
+    spark.hadoop.fs.wasbs.impl org.apache.hadoop.fs.azure.NativeAzureFileSystem
+    {{- else if .Values.storage.oss.enable }}
+    {{- required "storage.oss.endpoint is required when storage.oss.enable is true" .Values.storage.oss.endpoint }}
+    spark.hadoop.fs.AbstractFileSystem.oss.impl org.apache.hadoop.fs.aliyun.oss.OSS
+    spark.hadoop.fs.oss.impl org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem
+    spark.hadoop.fs.oss.endpoint {{ .Values.storage.oss.endpoint }}
+    spark.hadoop.fs.oss.credentials.provider com.aliyun.oss.common.auth.EnvironmentVariableCredentialsProvider
+    {{- end }}
+
+    {{- with .Values.sparkConf }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/spark-history-server/templates/deployment.yaml
+++ b/charts/spark-history-server/templates/deployment.yaml
@@ -1,0 +1,127 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spark-history-server.fullname" . }}
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "spark-history-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spark-history-server.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ include "spark-history-server.imageName" . }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        args:
+        - history-server
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.port }}
+          protocol: TCP
+        env:
+        - name: HADOOP_CONF_DIR
+          value: /etc/hadoop
+        - name: SPARK_NO_DAEMONIZE
+          value: "true"
+        {{- with .Values.env }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ include "spark-history-server.secretName" . }}
+        {{- if .Values.storage.s3.enable | and .Values.storage.s3.existingSecret | and .Values.storage.s3.existingCaSecret }}
+        - secretRef:
+            name: {{ .Values.storage.s3.existingSecret }}
+        - secretRef:
+            name: {{ .Values.storage.s3.existingCaSecret }}
+        {{- else if .Values.storage.abs.enable | and .Values.storage.abs.existingSecret }}
+        - secretRef:
+            name: {{ .Values.storage.abs.existingSecret }}
+        {{- else if .Values.storage.oss.enable | and .Values.storage.oss.existingSecret }}
+        - secretRef:
+            name: {{ .Values.storage.oss.existingSecret }}
+        {{- end }}
+        {{- with .Values.envFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: spark-history-server-conf
+          mountPath: /opt/spark/conf
+        {{- if .Values.storage.gcs.enable | and .Values.storage.gcs.existingSecret }}
+        - name: gcs-keyfile
+          mountPath: /etc/gcs/keyfile.json
+        {{- end }}
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      volumes:
+      - name: spark-history-server-conf
+        configMap:
+          name: {{ include "spark-history-server.configMapName" . }}
+      {{- if .Values.storage.gcs.enable | and .Values.storage.gcs.existingSecret }}
+      - name: gcs-keyfile
+        secretRef:
+          name: {{ .Values.storage.gcs.existingSecret }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      serviceAccountName: {{ include "spark-history-server.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:

--- a/charts/spark-history-server/templates/ingress.yaml
+++ b/charts/spark-history-server/templates/ingress.yaml
@@ -1,0 +1,79 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "spark-history-server.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/spark-history-server/templates/secret.yaml
+++ b/charts/spark-history-server/templates/secret.yaml
@@ -1,0 +1,66 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spark-history-server.secretName" . }}
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+data:
+  {{/* AWS S3 / Minio */}}
+  {{- if .Values.storage.s3.enable }}
+  {{- if not .Values.storage.s3.existingSecret }}
+  {{- required "storage.s3.createSecret.accessKeyId is required when storage.s3.enable is true" .Values.storage.s3.createSecret.accessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ .Values.storage.s3.createSecret.accessKeyId }}
+  {{- required "storage.s3.createSecret.secretAccessKey is required when storage.s3.enable is true" .Values.storage.s3.createSecret.secretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.storage.s3.createSecret.secretAccessKey }}
+  {{- end }}
+  {{- if not .Values.storage.s3.existingCaSecret }}
+  {{- required "storage.s3.createCaSecret.caBundle is required when storage.s3.enable is true" .Values.storage.s3.createCaSecret.caBundle }}
+  caBundle: {{ .Values.storage.s3.createCaSecret.caBundle }}
+  {{- end }}
+  {{- end }}
+
+  {{/* Google Cloud Storage (GCS) */}}
+  {{- if .Values.storage.gcs.enable }}
+  {{- if not .Values.storage.gcs.existingSecret }}
+  {{- required "storage.gcs.createSecret.keyFile is required when storage.gcs.enable is true" .Values.storage.gcs.createSecret.keyFile }}
+  keyFile: {{ .Values.storage.gcs.createSecret.keyFile }}
+  {{- end }}
+  {{- end }}
+
+  {{/* Azure Blob Storage (ABS) */}}
+  {{- if .Values.storage.abs.enable }}
+  {{- if not .Values.storage.abs.existingSecret }}
+  {{- required "storage.abs.createSecret.azureStorageConnectionString is required when storage.abs.enable is true" .Values.storage.abs.createSecret.azureStorageConnectionString }}
+  AZURE_STORAGE_CONNECTION_STRING: {{ .Values.storage.abs.createSecret.azureStorageConnectionString }}
+  {{- required "storage.abs.createSecret.azureStorageAccessKey is required when storage.abs.enable is true" .Values.storage.abs.createSecret.azureStorageAccessKey }}
+  AZURE_STORAGE_ACCESS_KEY: {{ .Values.storage.abs.createSecret.azureStorageAccessKey }}
+  {{- end }}
+  {{- end }}
+
+  {{/* Alibaba Cloud Object Storage Service (OSS) */}}
+  {{- if .Values.storage.oss.enable }}
+  {{- if not .Values.storage.oss.existingSecret }}
+  {{- required "storage.oss.createSecret.accessKeyId is required when storage.oss.enable is true" .Values.storage.oss.createSecret.accessKeyId }}
+  OSS_ACCESS_KEY_ID: {{ .Values.storage.oss.createSecret.accessKeyId }}
+  {{- required "storage.oss.createSecret.accessKeySecret is required when storage.oss.enable is true" .Values.storage.oss.createSecret.accessKeySecret }}
+  OSS_ACCESS_KEY_SECRET: {{ .Values.storage.oss.createSecret.accessKeySecret }}
+  {{- end }}
+  {{- end }}

--- a/charts/spark-history-server/templates/service.yaml
+++ b/charts/spark-history-server/templates/service.yaml
@@ -1,0 +1,33 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spark-history-server.fullname" . }}
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "spark-history-server.selectorLabels" . | nindent 4 }}

--- a/charts/spark-history-server/templates/serviceaccount.yaml
+++ b/charts/spark-history-server/templates/serviceaccount.yaml
@@ -1,0 +1,30 @@
+{{/*
+
+Copyright 2024 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spark-history-server.serviceAccountName" . }}
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/spark-history-server/templates/tests/test-connection.yaml
+++ b/charts/spark-history-server/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "spark-history-server.fullname" . }}-test-connection"
+  labels:
+    {{- include "spark-history-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "spark-history-server.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/spark-history-server/values.yaml
+++ b/charts/spark-history-server/values.yaml
@@ -1,0 +1,198 @@
+#
+# Copyright 2024 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default values for spark-history-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- String to partially override `spark-history-server.fullname` template (will maintain the release name)
+nameOverride: ""
+
+# -- String to fully override `spark-history-server.fullname` template
+fullnameOverride: ""
+
+# -- Desired number of pods
+replicaCount: 1
+
+image:
+  # -- Image registry
+  registry: docker.io
+  # -- Image repository
+  repository: kubeflow/spark-history-server
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image tag, if set, overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  # -- Image pull secrets
+  pullSecrets: []
+  # - name: custom-secret
+
+sparkConf:
+  # The URL to the directory containing application event logs to load.
+  spark.history.fs.logDirectory: file:///tmp/spark-events
+
+  # How often to reload log data from storage
+  # spark.history.fs.update.interval: 10
+
+storage:
+  s3:
+    # -- Specifies whether to enable AWS S3 / Minio as event log storage.
+    enable: false
+    # -- Name of an existing secret containing the keys `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to access artifact storage on AWS S3 / MINIO.
+    existingSecret: ""
+    # -- If S3 is enabled and no existing secret is specified, create the secret used to connect to S3 / Minio.
+    createSecret:
+      # -- AWS access key ID
+      accessKeyId: ""
+      # -- AWS secret access key
+      secretAccessKey: ""
+    # -- Name of an existing secret containing the key `ca-bundle.crt` used to store the CA certificate for TLS connections.
+    existingCaSecret: ""
+    # -- If S3 is enabled and no existing CA secret is specified, create the secret used to secure connection to S3 / Minio.
+    createCaSecret:
+      # -- Content of CA bundle
+      caBundle: ""
+
+  gcs:
+    # -- Specifies whether to enable Google Cloud Storage (GCS) as event log storage.
+    enable: false
+    # -- Name of an existing secret containing the key `keyfile.json` used to store credentials to access GCS.
+    existingSecret: ""
+    # -- If GCS is enabled and no existing secret is specified, create the secret used to connect to GCS.
+    createSecret:
+      # -- Content of key file
+      keyFile: ""
+
+  abs:
+    # -- Specifies whether to enable Azure Blob Storage (ABS) as event log storage.
+    enable: false
+    # -- Name of an existing secret containing the key `AZURE_STORAGE_CONNECTION_STRING` or `AZURE_STORAGE_ACCESS_KEY` to store credentials to access ABS.
+    existingSecret: ""
+    # -- If ABS is enabled as artifact store backend and no existing secret is specified, create the secret used to connect to Azure.
+    createSecret:
+      # Azure blob storage connection string
+      azureStorageConnectionString: ""
+      # Azure blob storage access key
+      azureStorageAccessKey: ""
+
+  oss:
+    # -- Specifies whether to enable Alibaba Cloud Object Storage Service (OSS) as event log storage.
+    enable: false
+    # -- Endpoint of OSS e.g. `oss-cn-beijing-internal.aliyuncs.com`.
+    endpoint: ""
+    # -- Name of an existing secret containing the key `OSS_ACCESS_KEY_ID` and `OSS_ACCESS_KEY_SECRET` to store credentials to access OSS.
+    existingSecret: ""
+    # -- If OSS is enabled and no existing secret is specified, create the secret used to store OSS access credentials.
+    createSecret:
+      # -- Alibaba Cloud access key ID
+      accessKeyId: ""
+      # -- Alibaba Cloud access key secret
+      accessKeySecret: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created.
+  create: true
+  # -- Annotations to add to the service account.
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# -- List of volumes that can be mounted by the containers.
+volumes: []
+# - name: spark-history-server-vol
+#   persistentVolumeClaim:
+#     claimName: spark-history-server-pvc
+#     readOnly: true
+
+# -- List of volume mounts that can be referenced by the containers.
+volumeMounts: []
+# - name: spark-history-server-vol
+#   mountPath: /mnt/history
+#   subPath: ""
+
+# -- List of environment variables to set in the container.
+env: []
+# - name: ENV_NAME
+#   value: ENV_VALUE
+
+# -- List of sources to populate environment variables in the container.
+envFrom: []
+# - configMapRef:
+#     name: configmap-name
+#     optional: false
+# - secretRef:
+#     name: secret-name
+#     optional: false
+
+# -- Annotations to add to the pod
+podAnnotations: {}
+
+# -- Pod security context
+podSecurityContext: {}
+# fsGroup: 2000
+
+# -- Container security context
+securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Pod affinity
+affinity: {}
+
+# -- Pod tolerations
+tolerations: []
+
+# -- Pod resources
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 18080
+
+ingress:
+  # -- Specifies whether an ingress resource should be created
+  enable: false
+  # -- Ingress class name
+  className: ""
+  # -- Annotations to add to the ingress
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+  - host: chart-example.local
+    paths:
+    - path: /
+      pathType: ImplementationSpecific
+  tls: []
+  # - secretName: chart-example-tls
+  #   hosts:
+  #     - chart-example.local

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -5,8 +5,7 @@
 # -- Common labels to add to the resources
 commonLabels: {}
 
-# replicaCount -- Desired number of pods, leaderElection will be enabled
-# if this is greater than 1
+# replicaCount -- Desired number of pods
 replicaCount: 1
 
 image:

--- a/docker/spark-history-server/Dockerfile
+++ b/docker/spark-history-server/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright 2024 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG SPARK_IMAGE=spark:3.5.0
+
+FROM ${SPARK_IMAGE}
+
+# Add dependency for AWS S3 support
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar ${SPARK_HOME}/jars
+ADD https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar ${SPARK_HOME}/jars
+
+# Add dependency for Google Cloud Storage support
+ADD https://repo1.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar ${SPARK_HOME}/jars
+ADD https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar ${SPARK_HOME}/jars
+
+# Add dependency for Azure Blob Storage support
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar ${SPARK_HOME}/jars
+ADD https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/7.0.1/azure-storage-7.0.1.jar ${SPARK_HOME}/jars
+
+# Add dependency for Alibaba Cloud OSS support
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aliyun/3.3.4/hadoop-aliyun-3.3.4.jar ${SPARK_HOME}/jars
+ADD https://repo1.maven.org/maven2/com/aliyun/oss/aliyun-sdk-oss/3.18.0/aliyun-sdk-oss-3.18.0.jar ${SPARK_HOME}/jars
+
+COPY entrypoint.sh /opt
+
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/docker/spark-history-server/entrypoint.sh
+++ b/docker/spark-history-server/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# echo commands to the terminal output
+set -ex
+
+# Check whether there is a passwd entry for the container UID
+uid=$(id -u)
+gid=$(id -g)
+
+# turn off -e for getent because it will return error code in anonymous uid case
+set +e
+uid_entry=$(getent passwd "${uid}")
+set -e
+
+# If there is no passwd entry for the container UID, attempt to create one
+if [[ -z "${uid_entry}" ]]; then
+    if [[ -w /etc/passwd ]]; then
+        echo "$uid:x:$uid:$gid:anonymous uid:${SPARK_HOME}:/bin/false" >>/etc/passwd
+    else
+        echo "Container entrypoint.sh failed to add passwd entry for anonymous UID"
+    fi
+fi
+
+case "$1" in
+history-server)
+    shift 1
+    CMD=(
+        "$SPARK_HOME/bin/spark-class"
+        "org.apache.spark.deploy.history.HistoryServer"
+        "$@"
+    )
+    ;;
+*)
+    echo "Non-spark-history-server command provided, proceeding in pass-through mode..."
+    CMD=("$@")
+    ;;
+esac
+
+# Execute the container CMD under tini for better hygiene
+exec $(which tini) -s -- "${CMD[@]}"


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR

**Proposed changes:**
- Add a separated Helm chart for Spark history server
- Supported cloud storage: S3、GCS、Azure Blob Storage、Alibaba Cloud OSS

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

