### PR TITLE
Adding support for setting spark job namespaces to all namespaces

### DIFF
--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -59,7 +59,11 @@ spec:
         - --zap-log-level={{ . }}
         {{- end }}
         {{- with .Values.spark.jobNamespaces }}
+        {{- if has "" . }}
+        - --namespaces=""
+        {{- else }}
         - --namespaces={{ . | join "," }}
+        {{- end }}
         {{- end }}
         - --controller-threads={{ .Values.controller.workers }}
         {{- with .Values.controller.uiService.enable }}

--- a/charts/spark-operator-chart/templates/spark/rbac.yaml
+++ b/charts/spark-operator-chart/templates/spark/rbac.yaml
@@ -16,7 +16,7 @@ limitations under the License.
 
 {{- if .Values.spark.rbac.create -}}
 {{- range $jobNamespace := .Values.spark.jobNamespaces | default list }}
-{{- if $jobNamespace }}
+{{- if ne $jobNamespace "" }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/spark-operator-chart/templates/spark/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/spark/serviceaccount.yaml
@@ -15,16 +15,19 @@ limitations under the License.
 */}}
 
 {{- if .Values.spark.serviceAccount.create }}
-{{- range $sparkJobNamespace := .Values.spark.jobNamespaces | default list }}
+{{- range $jobNamespace := .Values.spark.jobNamespaces | default list }}
+{{- if ne $jobNamespace "" }}
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-operator.spark.serviceAccountName" $ }}
-  namespace: {{ $sparkJobNamespace }}
+  namespace: {{ $jobNamespace }}
   labels: {{ include "spark-operator.labels" $ | nindent 4 }}
   {{- with $.Values.spark.serviceAccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -52,7 +52,11 @@ spec:
         - --zap-log-level={{ . }}
         {{- end }}
         {{- with .Values.spark.jobNamespaces }}
+        {{- if has "" . }}
+        - --namespaces=""
+        {{- else }}
         - --namespaces={{ . | join "," }}
+        {{- end }}
         {{- end }}
         - --webhook-secret-name={{ include "spark-operator.webhook.secretName" . }}
         - --webhook-secret-namespace={{ .Release.Namespace }}

--- a/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -33,15 +33,17 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- if .Values.spark.jobNamespaces }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name
       operator: In
       values:
-      {{- range .Values.spark.jobNamespaces }}
-      - {{ . }}
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   objectSelector:
     matchLabels:
@@ -66,15 +68,17 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- if .Values.spark.jobNamespaces }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name
       operator: In
       values:
-      {{- range .Values.spark.jobNamespaces }}
-      - {{ . }}
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]
@@ -96,15 +100,17 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- if .Values.spark.jobNamespaces }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name
       operator: In
       values:
-      {{- range .Values.spark.jobNamespaces }}
-      - {{ . }}
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]

--- a/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
@@ -33,15 +33,17 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- if .Values.spark.jobNamespaces }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name
       operator: In
       values:
-      {{- range .Values.spark.jobNamespaces }}
-      - {{ . }}
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]
@@ -63,15 +65,17 @@ webhooks:
   {{- with .Values.webhook.failurePolicy }}
   failurePolicy: {{ . }}
   {{- end }}
-  {{- if .Values.spark.jobNamespaces }}
+  {{- with .Values.spark.jobNamespaces }}
+  {{- if not (has "" .) }}
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name
       operator: In
       values:
-      {{- range .Values.spark.jobNamespaces }}
-      - {{ . }}
+      {{- range $jobNamespace := . }}
+      - {{ $jobNamespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   rules:
   - apiGroups: ["sparkoperator.k8s.io"]

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -110,13 +110,25 @@ tests:
 
   - it: Should contain `--namespaces` arg if `spark.jobNamespaces` is set
     set:
-      spark.jobNamespaces:
-        - ns1
-        - ns2
+      spark:
+        jobNamespaces:
+          - ns1
+          - ns2
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --namespaces=ns1,ns2
+
+  - it: Should set namespaces to all namespaces (`""`) if `spark.jobNamespaces` contains empty string
+    set:
+      spark:
+        jobNamespaces:
+          - ""
+          - default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --namespaces=""
 
   - it: Should contain `--controller-threads` arg if `controller.workers` is set
     set:

--- a/charts/spark-operator-chart/tests/spark/serviceaccount_test.yaml
+++ b/charts/spark-operator-chart/tests/spark/serviceaccount_test.yaml
@@ -66,59 +66,36 @@ tests:
           path: metadata.annotations.key2
           value: value2
 
-  - it: Should create multiple service accounts if `spark.jobNamespaces` is set
+  - it: Should create service account for every non-empty spark job namespace if `spark.jobNamespaces` is set with multiple values
     set:
       spark:
-        serviceAccount:
-          name: spark
         jobNamespaces:
+          - ""
           - ns1
           - ns2
-          - ns3
     documentIndex: 0
     asserts:
       - hasDocuments:
-          count: 3
+          count: 2
       - containsDocument:
           apiVersion: v1
           kind: ServiceAccount
-          name: spark
+          name: spark-operator-spark
           namespace: ns1
 
-  - it: Should create multiple service accounts if `spark.jobNamespaces` is set
+  - it: Should create service account for every non-empty spark job namespace if `spark.jobNamespaces` is set with multiple values
     set:
       spark:
-        serviceAccount:
-          name: spark
         jobNamespaces:
+          - ""
           - ns1
           - ns2
-          - ns3
     documentIndex: 1
     asserts:
       - hasDocuments:
-          count: 3
+          count: 2
       - containsDocument:
           apiVersion: v1
           kind: ServiceAccount
-          name: spark
+          name: spark-operator-spark
           namespace: ns2
-
-  - it: Should create multiple service accounts if `spark.jobNamespaces` is set
-    set:
-      spark:
-        serviceAccount:
-          name: spark
-        jobNamespaces:
-          - ns1
-          - ns2
-          - ns3
-    documentIndex: 2
-    asserts:
-      - hasDocuments:
-          count: 3
-      - containsDocument:
-          apiVersion: v1
-          kind: ServiceAccount
-          name: spark
-          namespace: ns3

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -107,6 +107,17 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
           content: --namespaces=ns1,ns2
 
+  - it: Should set namespaces to all namespaces (`""`) if `spark.jobNamespaces` contains empty string
+    set:
+      spark:
+        jobNamespaces:
+          - ""
+          - default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --namespaces=""
+
   - it: Should contain `--enable-metrics` arg if `prometheus.metrics.enable` is set to `true`
     set:
       prometheus:

--- a/charts/spark-operator-chart/tests/webhook/mutatingwebhookconfiguration_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/mutatingwebhookconfiguration_test.yaml
@@ -49,7 +49,7 @@ tests:
           path: webhooks[*].failurePolicy
           value: Fail
 
-  - it: Should set namespaceSelector if sparkJobNamespaces is not empty
+  - it: Should set namespaceSelector if `spark.jobNamespaces` is set with non-empty strings
     set:
       spark:
         jobNamespaces:
@@ -67,6 +67,19 @@ tests:
                   - ns1
                   - ns2
                   - ns3
+
+  - it: Should not set namespaceSelector if `spark.jobNamespaces` contains empty string
+    set:
+      spark:
+        jobNamespaces:
+          - ""
+          - ns1
+          - ns2
+          - ns3
+    asserts:
+      - notExists:
+          path: webhooks[*].namespaceSelector
+
 
   - it: Should should use the specified timeoutSeconds
     set:

--- a/charts/spark-operator-chart/tests/webhook/validatingwebhookconfiguration_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/validatingwebhookconfiguration_test.yaml
@@ -49,7 +49,7 @@ tests:
           path: webhooks[*].failurePolicy
           value: Fail
 
-  - it: Should set namespaceSelector if `spark.jobNamespaces` is not empty
+  - it: Should set namespaceSelector if `spark.jobNamespaces` is set with non-empty strings
     set:
       spark.jobNamespaces:
         - ns1
@@ -66,6 +66,18 @@ tests:
                   - ns1
                   - ns2
                   - ns3
+
+  - it: Should not set namespaceSelector if `spark.jobNamespaces` contains empty string
+    set:
+      spark:
+        jobNamespaces:
+          - ""
+          - ns1
+          - ns2
+          - ns3
+    asserts:
+      - notExists:
+          path: webhooks[*].namespaceSelector
 
   - it: Should should use the specified timeoutSeconds
     set:

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -124,7 +124,7 @@ func NewStartCommand() *cobra.Command {
 	}
 
 	command.Flags().IntVar(&controllerThreads, "controller-threads", 10, "Number of worker threads used by the SparkApplication controller.")
-	command.Flags().StringSliceVar(&namespaces, "namespaces", []string{""}, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
+	command.Flags().StringSliceVar(&namespaces, "namespaces", []string{}, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset or contains empty string.")
 	command.Flags().DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 30*time.Second, "Informer cache sync timeout.")
 
 	command.Flags().BoolVar(&enableBatchScheduler, "enable-batch-scheduler", false, "Enable batch schedulers.")

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -130,7 +130,7 @@ func NewStartCommand() *cobra.Command {
 	}
 
 	command.Flags().IntVar(&controllerThreads, "controller-threads", 10, "Number of worker threads used by the SparkApplication controller.")
-	command.Flags().StringSliceVar(&namespaces, "namespaces", []string{""}, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset.")
+	command.Flags().StringSliceVar(&namespaces, "namespaces", []string{}, "The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if unset or contains empty string.")
 	command.Flags().StringVar(&labelSelectorFilter, "label-selector-filter", "", "A comma-separated list of key=value, or key labels to filter resources during watch and list based on the specified labels.")
 	command.Flags().DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 30*time.Second, "Informer cache sync timeout.")
 

--- a/internal/controller/scheduledsparkapplication/event_filter.go
+++ b/internal/controller/scheduledsparkapplication/event_filter.go
@@ -35,9 +35,14 @@ var _ predicate.Predicate = &EventFilter{}
 // NewEventFilter creates a new EventFilter instance.
 func NewEventFilter(namespaces []string) *EventFilter {
 	nsMap := make(map[string]bool)
-	for _, ns := range namespaces {
-		nsMap[ns] = true
+	if len(namespaces) == 0 {
+		nsMap[metav1.NamespaceAll] = true
+	} else {
+		for _, ns := range namespaces {
+			nsMap[ns] = true
+		}
 	}
+
 	return &EventFilter{
 		namespaces: nsMap,
 	}

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -42,8 +42,12 @@ var _ predicate.Predicate = &sparkPodEventFilter{}
 // newSparkPodEventFilter creates a new SparkPodEventFilter instance.
 func newSparkPodEventFilter(namespaces []string) *sparkPodEventFilter {
 	nsMap := make(map[string]bool)
-	for _, ns := range namespaces {
-		nsMap[ns] = true
+	if len(namespaces) == 0 {
+		nsMap[metav1.NamespaceAll] = true
+	} else {
+		for _, ns := range namespaces {
+			nsMap[ns] = true
+		}
 	}
 
 	return &sparkPodEventFilter{
@@ -118,8 +122,12 @@ var _ predicate.Predicate = &EventFilter{}
 
 func NewSparkApplicationEventFilter(client client.Client, recorder record.EventRecorder, namespaces []string) *EventFilter {
 	nsMap := make(map[string]bool)
-	for _, ns := range namespaces {
-		nsMap[ns] = true
+	if len(namespaces) == 0 {
+		nsMap[metav1.NamespaceAll] = true
+	} else {
+		for _, ns := range namespaces {
+			nsMap[ns] = true
+		}
 	}
 
 	return &EventFilter{


### PR DESCRIPTION
## Purpose of this PR

Add support for setting `spark.jobNamespaces` to all namespaces (`""`).

- controller/webhook should watch all namespaces if `spark.jobNamespaces` is empty list or contains `""`
- should not create spark service account and rbac resources for empty namespace
- mutating/validating webhook configurations should not add `namespaceSelector` when `spark.jobNamespaces` is empty list or contains `""`

1. If we want to watch all namespaces, then we can install the spark operator as follows:

```bash
helm install spark-operator charts/spark-operator-chart \
    --create-namespace \
    --namespace spark-operator \
    --set 'spark.jobNamespaces={}'
```

but this will not create rbac resources for spark in any namespaces.

2. If we want to watch all namespaces and also create rbac resources for spark in namespace `default` and `spark-operaotr`, then we can do as follows:

```bash
helm install spark-operator charts/spark-operator-chart \
    --create-namespace \
    --namespace spark-operator \
    --set 'spark.jobNamespaces={,default,spark-operator}'
```

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

If we set `spark.jobNamespaces` to `["","spark-operator"]`, then it will failes:

```bash
$ helm install spark-operator spark-operator/spark-operator \
    --version 2.0.0-rc.0 \
    --create-namespace \
    --namespace spark-operator \
    --set 'spark.jobNamespaces={,spark-operator}'
Error: INSTALLATION FAILED: 1 error occurred:
	* serviceaccounts "spark-operator-spark" already exists
```

