### PR TITLE
Increase frequency for Stale bot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-    - cron: "0 */5 * * *"
+    - cron: "0 */2 * * *"
 
 jobs:
   stale:
@@ -18,6 +18,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90
           days-before-close: 20
+          operations-per-run: 200
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
I increased frequency for Stale bot (run every 2 hours) and number of operations per run.
This should help us to faster process 517 open issues and PRs.

/assign @vara-bonthu @yuchaoran2011 @ChenYi015 