### PR TITLE
Create role and rolebinding for controller/webhook in every spark job namespace if not watching all namespaces

### DIFF
--- a/charts/spark-operator-chart/templates/controller/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/controller/_helpers.tpl
@@ -49,6 +49,34 @@ Create the name of the service account to be used by the controller
 {{- end -}}
 
 {{/*
+Create the name of the cluster role to be used by the controller
+*/}}
+{{- define "spark-operator.controller.clusterRoleName" -}}
+{{ include "spark-operator.controller.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role binding to be used by the controller
+*/}}
+{{- define "spark-operator.controller.clusterRoleBindingName" -}}
+{{ include "spark-operator.controller.clusterRoleName" . }}
+{{- end }}
+
+{{/*
+Create the name of the role to be used by the controller
+*/}}
+{{- define "spark-operator.controller.roleName" -}}
+{{ include "spark-operator.controller.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the role binding to be used by the controller
+*/}}
+{{- define "spark-operator.controller.roleBindingName" -}}
+{{ include "spark-operator.controller.roleName" . }}
+{{- end }}
+
+{{/*
 Create the name of the deployment to be used by controller
 */}}
 {{- define "spark-operator.controller.deploymentName" -}}
@@ -67,4 +95,89 @@ Create the name of the pod disruption budget to be used by controller
 */}}
 {{- define "spark-operator.controller.podDisruptionBudgetName" -}}
 {{ include "spark-operator.controller.name" . }}-pdb
+{{- end -}}
+
+{{/*
+Create the role policy rules for the controller in every Spark job namespace
+*/}}
+{{- define "spark-operator.controller.policyRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - create
+  - delete
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  - scheduledsparkapplications
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications/status
+  - sparkapplications/finalizers
+  - scheduledsparkapplications/status
+  - scheduledsparkapplications/finalizers
+  verbs:
+  - get
+  - update
+  - patch
+{{- if .Values.controller.batchScheduler.enable }}
+{{/* required for the `volcano` batch scheduler */}}
+- apiGroups:
+  - scheduling.incubator.k8s.io
+  - scheduling.sigs.dev
+  - scheduling.volcano.sh
+  resources:
+  - podgroups
+  verbs:
+  - "*"
+{{- end }}
 {{- end -}}

--- a/charts/spark-operator-chart/templates/controller/rbac.yaml
+++ b/charts/spark-operator-chart/templates/controller/rbac.yaml
@@ -18,7 +18,8 @@ limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "spark-operator.controller.name" . }}
+  name: {{ include "spark-operator.controller.clusterRoleName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
   {{- with .Values.controller.rbac.annotations }}
@@ -26,50 +27,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - extensions
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - create
-  - delete
 - apiGroups:
   - ""
   resources:
@@ -90,63 +47,16 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
-- apiGroups:
-  - sparkoperator.k8s.io
-  resources:
-  - sparkapplications
-  - scheduledsparkapplications
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - sparkoperator.k8s.io
-  resources:
-  - sparkapplications/status
-  - scheduledsparkapplications/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - sparkoperator.k8s.io
-  resources:
-  - sparkapplications/finalizers
-  - scheduledsparkapplications/finalizers
-  verbs:
-  - update
-{{- if .Values.controller.batchScheduler.enable }}
-{{/* required for the `volcano` batch scheduler */}}
-- apiGroups:
-  - scheduling.incubator.k8s.io
-  - scheduling.sigs.dev
-  - scheduling.volcano.sh
-  resources:
-  - podgroups
-  verbs:
-  - "*"
-- apiGroups:
-  - scheduling.x-k8s.io
-  resources:
-  - podgroups
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
+{{- if not .Values.spark.jobNamespaces | or (has "" .Values.spark.jobNamespaces) }}
+{{ include "spark-operator.controller.policyRules" . }}
 {{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "spark-operator.controller.name" . }}
+  name: {{ include "spark-operator.controller.clusterRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
   {{- with .Values.controller.rbac.annotations }}
@@ -160,13 +70,14 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "spark-operator.controller.name" . }}
-
+  name: {{ include "spark-operator.controller.clusterRoleName" . }}
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "spark-operator.controller.name" . }}
+  name: {{ include "spark-operator.controller.roleName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
   {{- with .Values.controller.rbac.annotations }}
@@ -189,12 +100,16 @@ rules:
   verbs:
   - get
   - update
-
+{{- if has .Release.Namespace .Values.spark.jobNamespaces }}
+{{ include "spark-operator.controller.policyRules" . }}
+{{- end }}
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "spark-operator.controller.name" . }}
+  name: {{ include "spark-operator.controller.roleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
   {{- with .Values.controller.rbac.annotations }}
@@ -208,5 +123,48 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "spark-operator.controller.name" . }}
+  name: {{ include "spark-operator.controller.roleName" . }}
+
+{{- if and .Values.spark.jobNamespaces (not (has "" .Values.spark.jobNamespaces)) }}
+{{- range $jobNamespace := .Values.spark.jobNamespaces }}
+{{- if ne $jobNamespace $.Release.Namespace }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "spark-operator.controller.roleName" $ }}
+  namespace: {{ $jobNamespace }}
+  labels:
+    {{- include "spark-operator.controller.labels" $ | nindent 4 }}
+  {{- with $.Values.controller.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+{{ include "spark-operator.controller.policyRules" $ }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "spark-operator.controller.roleBindingName" $ }}
+  namespace: {{ $jobNamespace }}
+  labels:
+    {{- include "spark-operator.controller.labels" $ | nindent 4 }}
+  {{- with $.Values.controller.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "spark-operator.controller.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "spark-operator.controller.roleName" $ }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/controller/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/controller/serviceaccount.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-operator.controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
   {{- with .Values.controller.serviceAccount.annotations }}

--- a/charts/spark-operator-chart/templates/webhook/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/webhook/_helpers.tpl
@@ -49,18 +49,32 @@ Create the name of service account to be used by webhook
 {{- end -}}
 
 {{/*
-Create the name of the role to be used by webhook
+Create the name of the cluster role to be used by the webhook
 */}}
-{{- define "spark-operator.webhook.roleName" -}}
-{{- include "spark-operator.webhook.name" . }}
-{{- end -}}
+{{- define "spark-operator.webhook.clusterRoleName" -}}
+{{ include "spark-operator.webhook.name" . }}
+{{- end }}
 
 {{/*
-Create the name of the role binding to be used by webhook
+Create the name of the cluster role binding to be used by the webhook
+*/}}
+{{- define "spark-operator.webhook.clusterRoleBindingName" -}}
+{{ include "spark-operator.webhook.clusterRoleName" . }}
+{{- end }}
+
+{{/*
+Create the name of the role to be used by the webhook
+*/}}
+{{- define "spark-operator.webhook.roleName" -}}
+{{ include "spark-operator.webhook.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the role binding to be used by the webhook
 */}}
 {{- define "spark-operator.webhook.roleBindingName" -}}
-{{- include "spark-operator.webhook.name" . }}
-{{- end -}}
+{{ include "spark-operator.webhook.roleName" . }}
+{{- end }}
 
 {{/*
 Create the name of the secret to be used by webhook
@@ -110,4 +124,43 @@ Create the name of the pod disruption budget to be used by webhook
 */}}
 {{- define "spark-operator.webhook.podDisruptionBudgetName" -}}
 {{ include "spark-operator.webhook.name" . }}-pdb
+{{- end -}}
+
+{{/*
+Create the role policy rules for the webhook in every Spark job namespace
+*/}}
+{{- define "spark-operator.webhook.policyRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  - sparkapplications/status
+  - sparkapplications/finalizers
+  - scheduledsparkapplications
+  - scheduledsparkapplications/status
+  - scheduledsparkapplications/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 {{- end -}}

--- a/charts/spark-operator-chart/templates/webhook/rbac.yaml
+++ b/charts/spark-operator-chart/templates/webhook/rbac.yaml
@@ -19,7 +19,8 @@ limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "spark-operator.webhook.name" . }}
+  name: {{ include "spark-operator.webhook.clusterRoleName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
   {{- with .Values.webhook.rbac.annotations }}
@@ -27,22 +28,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - resourcequotas
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -69,29 +54,16 @@ rules:
   verbs:
   - get
   - update
-- apiGroups:
-  - sparkoperator.k8s.io
-  resources:
-  - sparkapplications
-  - sparkapplications/status
-  - sparkapplications/finalizers
-  - scheduledsparkapplications
-  - scheduledsparkapplications/status
-  - scheduledsparkapplications/finalizers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+{{- if not .Values.spark.jobNamespaces | or (has "" .Values.spark.jobNamespaces) }}
+{{ include "spark-operator.webhook.policyRules" . }}
+{{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "spark-operator.webhook.name" . }}
+  name: {{ include "spark-operator.webhook.clusterRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
   {{- with .Values.webhook.rbac.annotations }}
@@ -105,13 +77,14 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "spark-operator.webhook.name" . }}
-
+  name: {{ include "spark-operator.webhook.clusterRoleName" . }}
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "spark-operator.webhook.name" . }}
+  name: {{ include "spark-operator.webhook.roleName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
   {{- with .Values.webhook.rbac.annotations }}
@@ -149,12 +122,16 @@ rules:
   verbs:
   - get
   - update
+{{- if has .Release.Namespace .Values.spark.jobNamespaces }}
+{{ include "spark-operator.webhook.policyRules" . }}
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "spark-operator.webhook.name" . }}
+  name: {{ include "spark-operator.webhook.roleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
   {{- with .Values.webhook.rbac.annotations }}
@@ -168,6 +145,49 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "spark-operator.webhook.name" . }}
+  name: {{ include "spark-operator.webhook.roleName" . }}
+
+{{- if and .Values.spark.jobNamespaces (not (has "" .Values.spark.jobNamespaces)) }}
+{{- range $jobNamespace := .Values.spark.jobNamespaces }}
+{{- if ne $jobNamespace $.Release.Namespace }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "spark-operator.webhook.roleName" $ }}
+  namespace: {{ $jobNamespace }}
+  labels:
+    {{- include "spark-operator.webhook.labels" $ | nindent 4 }}
+  {{- with $.Values.webhook.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+{{ include "spark-operator.webhook.policyRules" $ }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "spark-operator.webhook.roleBindingName" $ }}
+  namespace: {{ $jobNamespace }}
+  labels:
+    {{- include "spark-operator.webhook.labels" $ | nindent 4 }}
+  {{- with $.Values.webhook.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "spark-operator.webhook.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "spark-operator.webhook.roleName" $ }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/webhook/serviceaccount.yaml
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spark-operator.webhook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
   {{- with .Values.webhook.serviceAccount.annotations }}

--- a/charts/spark-operator-chart/tests/webhook/rbac_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/rbac_test.yaml
@@ -14,45 +14,45 @@
 # limitations under the License.
 #
 
-suite: Test controller rbac
+suite: Test webhook rbac
 
 templates:
-  - controller/rbac.yaml
+  - webhook/rbac.yaml
 
 release:
   name: spark-operator
   namespace: spark-operator
 
 tests:
-  - it: Should not create controller RBAC resources if `controller.rbac.create` is false
+  - it: Should not create webhook RBAC resources if `webhook.rbac.create` is false
     set:
-      controller:
+      webhook:
         rbac:
           create: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: Should create controller ClusterRole by default
+  - it: Should create webhook ClusterRole by default
     documentIndex: 0
     asserts:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: ClusterRole
-          name: spark-operator-controller
+          name: spark-operator-webhook
 
-  - it: Should create controller ClusterRoleBinding by default
+  - it: Should create webhook ClusterRoleBinding by default
     documentIndex: 1
     asserts:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: ClusterRoleBinding
-          name: spark-operator-controller
+          name: spark-operator-webhook
       - contains:
           path: subjects
           content:
             kind: ServiceAccount
-            name: spark-operator-controller
+            name: spark-operator-webhook
             namespace: spark-operator
           count: 1
       - equal:
@@ -60,11 +60,11 @@ tests:
           value:
             apiGroup: rbac.authorization.k8s.io
             kind: ClusterRole
-            name: spark-operator-controller
+            name: spark-operator-webhook
 
-  - it: Should add extra annotations to controller ClusterRole if `controller.rbac.annotations` is set
+  - it: Should add extra annotations to webhook ClusterRole if `webhook.rbac.annotations` is set
     set:
-      controller:
+      webhook:
         rbac:
           annotations:
             key1: value1
@@ -77,28 +77,28 @@ tests:
           path: metadata.annotations.key2
           value: value2
 
-  - it: Should create role and rolebinding for controller in release namespace 
+  - it: Should create role and rolebinding for webhook in release namespace
     documentIndex: 2
     asserts:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
-          name: spark-operator-controller
+          name: spark-operator-webhook
           namespace: spark-operator
 
-  - it: Should create role and rolebinding for controller in release namespace
+  - it: Should create role and rolebinding for webhook in release namespace
     documentIndex: 3
     asserts:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
-          name: spark-operator-controller
+          name: spark-operator-webhook
           namespace: spark-operator
       - contains:
           path: subjects
           content:
             kind: ServiceAccount
-            name: spark-operator-controller
+            name: spark-operator-webhook
             namespace: spark-operator
           count: 1
       - equal:
@@ -106,9 +106,9 @@ tests:
           value:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: spark-operator-controller
+            name: spark-operator-webhook
 
-  - it: Should create roles and rolebindings for controller in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
+  - it: Should create roles and rolebindings for webhook in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
     set:
       spark:
         jobNamespaces:
@@ -119,10 +119,10 @@ tests:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
-          name: spark-operator-controller
+          name: spark-operator-webhook
           namespace: default
 
-  - it: Should create roles and rolebindings for controller in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
+  - it: Should create roles and rolebindings for webhook in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
     set:
       spark:
         jobNamespaces:
@@ -133,10 +133,10 @@ tests:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
-          name: spark-operator-controller
+          name: spark-operator-webhook
           namespace: default
 
-  - it: Should create roles and rolebindings for controller in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
+  - it: Should create roles and rolebindings for webhook in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
     set:
       spark:
         jobNamespaces:
@@ -147,10 +147,10 @@ tests:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
-          name: spark-operator-controller
+          name: spark-operator-webhook
           namespace: spark
 
-  - it: Should create roles and rolebindings for controller in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
+  - it: Should create roles and rolebindings for webhook in every spark job namespace if `spark.jobNamespaces` is set and does not contain empty string
     set:
       spark:
         jobNamespaces:
@@ -161,5 +161,5 @@ tests:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
-          name: spark-operator-controller
+          name: spark-operator-webhook
           namespace: spark


### PR DESCRIPTION
## Purpose of this PR

**Proposed changes:**
- To enhance RBAC security, when spark operator is not watching all namespaces, then it is better to create role and rolebinding for controller/webhook in every spark job namespace and remove the associated rbac rules from clusterrole.

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [] Documentation update

### Rationale

Enhance spark operator RBAC security.

## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

