### PR TITLE
Fix: Spark role binding did not render properly when setting spark service account name

### DIFF
--- a/charts/spark-operator-chart/templates/spark/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/spark/_helpers.tpl
@@ -36,12 +36,12 @@ Create the name of the service account to be used by spark applications
 Create the name of the role to be used by spark service account
 */}}
 {{- define "spark-operator.spark.roleName" -}}
-{{- include "spark-operator.spark.name" . }}
+{{- include "spark-operator.spark.serviceAccountName" . }}
 {{- end -}}
 
 {{/*
 Create the name of the role binding to be used by spark service account
 */}}
 {{- define "spark-operator.spark.roleBindingName" -}}
-{{- include "spark-operator.spark.name" . }}
+{{- include "spark-operator.spark.serviceAccountName" . }}
 {{- end -}}

--- a/charts/spark-operator-chart/templates/spark/rbac.yaml
+++ b/charts/spark-operator-chart/templates/spark/rbac.yaml
@@ -67,7 +67,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "spark-operator.spark.serviceAccountName" $ }}
+  name: {{ include "spark-operator.spark.roleName" $ }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/tests/spark/rbac_test.yaml
+++ b/charts/spark-operator-chart/tests/spark/rbac_test.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-suite: Test spark rbac
+suite: Test Spark RBAC
 
 templates:
   - spark/rbac.yaml
@@ -24,7 +24,7 @@ release:
   namespace: spark-operator
 
 tests:
-  - it: Should not create spark RBAC resources if `spark.rbac.create` is false
+  - it: Should not create RBAC resources for Spark if `spark.rbac.create` is false
     set:
       spark:
         rbac:
@@ -33,48 +33,42 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: Should create spark role by default
+  - it: Should create RBAC resources for Spark in namespace `default` by default
     documentIndex: 0
     asserts:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           name: spark-operator-spark
+          namespace: default
 
-  - it: Should create spark role binding by default
-    set:
-      rbac:
-        spark:
-          create: true
+  - it: Should create RBAC resources for Spark in namespace `default` by default
     documentIndex: 1
     asserts:
       - containsDocument:
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
           name: spark-operator-spark
+          namespace: default
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: spark-operator-spark
+            namespace: default
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: spark-operator-spark
 
-  - it: Should create a single spark role with namespace "" by default
-    documentIndex: 0
-    asserts:
-      - containsDocument:
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: Role
-          name: spark-operator-spark
-
-  - it: Should create a single spark role binding with namespace "" by default
-    documentIndex: 1
-    asserts:
-      - containsDocument:
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: RoleBinding
-          name: spark-operator-spark
-          namespace: ""
-
-  - it: Should create multiple spark roles if `spark.jobNamespaces` is set with multiple values
+  - it: Should create RBAC resources for Spark in every Spark job namespace
     set:
-      spark.jobNamespaces:
-        - ns1
-        - ns2
+      spark:
+        jobNamespaces:
+          - ns1
+          - ns2
     documentIndex: 0
     asserts:
       - containsDocument:
@@ -83,11 +77,12 @@ tests:
           name: spark-operator-spark
           namespace: ns1
 
-  - it: Should create multiple spark role bindings if `spark.jobNamespaces` is set with multiple values
+  - it: Should create RBAC resources for Spark in every Spark job namespace
     set:
-      spark.jobNamespaces:
-        - ns1
-        - ns2
+      spark:
+        jobNamespaces:
+          - ns1
+          - ns2
     documentIndex: 1
     asserts:
       - containsDocument:
@@ -95,12 +90,25 @@ tests:
           kind: RoleBinding
           name: spark-operator-spark
           namespace: ns1
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: spark-operator-spark
+            namespace: ns1
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: spark-operator-spark
 
-  - it: Should create multiple spark roles if `spark.jobNamespaces` is set with multiple values
+  - it: Should create RBAC resources for Spark in every Spark job namespace
     set:
-      spark.jobNamespaces:
-        - ns1
-        - ns2
+      spark:
+        jobNamespaces:
+          - ns1
+          - ns2
     documentIndex: 2
     asserts:
       - containsDocument:
@@ -109,11 +117,12 @@ tests:
           name: spark-operator-spark
           namespace: ns2
 
-  - it: Should create multiple spark role bindings if `spark.jobNamespaces` is set with multiple values
+  - it: Should create RBAC resources for Spark in every Spark job namespace
     set:
-      spark.jobNamespaces:
-        - ns1
-        - ns2
+      spark:
+        jobNamespaces:
+          - ns1
+          - ns2
     documentIndex: 3
     asserts:
       - containsDocument:
@@ -121,3 +130,53 @@ tests:
           kind: RoleBinding
           name: spark-operator-spark
           namespace: ns2
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: spark-operator-spark
+            namespace: ns2
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: spark-operator-spark
+
+  - it: Should use the specified service account name if `spark.serviceAccount.name` is set
+    set:
+      spark:
+        serviceAccount:
+          name: spark
+    documentIndex: 0
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          name: spark
+          namespace: default
+
+  - it: Should use the specified service account name if `spark.serviceAccount.name` is set
+    set:
+      spark:
+        serviceAccount:
+          name: spark
+    documentIndex: 1
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          name: spark
+          namespace: default
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: spark
+            namespace: default
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: spark


### PR DESCRIPTION
## Purpose of this PR

Close #2134 

**Proposed changes:**
- Fix roleRef in Spark role binding

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

`roleRef` in Spark role binding did not refer to the correct Spark role name. Thus, driver pod failed to create executor pods:

```
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/api/v1/namespaces/bladerunner/pods/xxx-driver. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. pods "xxx" is forbidden: User "system:serviceaccount:test:spark-sa" cannot get resource "pods" in API group "" in the namespace "test": RBAC: role.rbac.authorization.k8s.io "spark-sa" not found.
```


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

