### PR TITLE
Reintroduce option webhook.enable

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -112,6 +112,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.sidecars | list | `[]` | Sidecar containers for controller pods. |
 | controller.podDisruptionBudget.enable | bool | `false` | Specifies whether to create pod disruption budget for controller. Ref: [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | controller.podDisruptionBudget.minAvailable | int | `1` | The number of pods that must be available. Require `controller.replicas` to be greater than 1 |
+| webhook.enable | bool | `true` | Specifies whether to enable webhook. |
 | webhook.replicas | int | `1` | Number of replicas of webhook server. |
 | webhook.logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |
 | webhook.port | int | `9443` | Specifies webhook port. |

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -153,3 +154,4 @@ spec:
       - {{ mergeOverwrite . $labelSelectorDict | toYaml | nindent 8 | trim }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -114,3 +115,4 @@ webhooks:
   {{- with .Values.webhook.timeoutSeconds }}
   timeoutSeconds: {{ . }}
   {{- end }}
+{{- end }}

--- a/charts/spark-operator-chart/templates/webhook/poddisruptionbudget.yaml
+++ b/charts/spark-operator-chart/templates/webhook/poddisruptionbudget.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 {{- if .Values.webhook.podDisruptionBudget.enable }}
 {{- if le (int .Values.webhook.replicas) 1 }}
 {{- fail "webhook.replicas must be greater than 1 to enable pod disruption budget for webhook" }}
@@ -31,4 +32,5 @@ spec:
   {{- with .Values.webhook.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/rbac.yaml
+++ b/charts/spark-operator-chart/templates/webhook/rbac.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 {{- if .Values.webhook.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -168,4 +169,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "spark-operator.webhook.name" . }}
+{{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/service.yaml
+++ b/charts/spark-operator-chart/templates/webhook/service.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,3 +28,4 @@ spec:
   - port: {{ .Values.webhook.port }}
     targetPort: {{ .Values.webhook.portName | quote }}
     name: {{ .Values.webhook.portName }}
+{{- end }}

--- a/charts/spark-operator-chart/templates/webhook/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/webhook/serviceaccount.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 {{- if .Values.webhook.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -25,4 +26,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/charts/spark-operator-chart/templates/webhook/validatingwebhookconfiguration.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -81,3 +82,4 @@ webhooks:
   {{- with .Values.webhook.timeoutSeconds }}
   timeoutSeconds: {{ . }}
   {{- end }}
+{{- end }}

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -31,6 +31,14 @@ tests:
           kind: Deployment
           name: spark-operator-webhook
 
+  - it: Should not create webhook deployment if `webhook.enable` is `false`
+    set:
+      webhook:
+        enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should set replicas if `webhook.replicas` is set
     set:
       webhook:

--- a/charts/spark-operator-chart/tests/webhook/mutatingwebhookconfiguration_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/mutatingwebhookconfiguration_test.yaml
@@ -31,6 +31,14 @@ tests:
           kind: MutatingWebhookConfiguration
           name: spark-operator-webhook
 
+  - it: Should not create the mutating webhook configuration if `webhook.enable` is `false`
+    set:
+      webhook:
+        enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should use the specified webhook port
     set:
       webhook:

--- a/charts/spark-operator-chart/tests/webhook/poddisruptionbudget_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/poddisruptionbudget_test.yaml
@@ -24,6 +24,14 @@ release:
   namespace: spark-operator
 
 tests:
+  - it: Should not render podDisruptionBudget if `webhook.enable` is `false`
+    set:
+      webhook:
+        enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should not render podDisruptionBudget if `webhook.podDisruptionBudget.enable` is false
     set:
       webhook:
@@ -40,7 +48,7 @@ tests:
         podDisruptionBudget:
           enable: true
     asserts:
-      - failedTemplate: 
+      - failedTemplate:
           errorMessage: "webhook.replicas must be greater than 1 to enable pod disruption budget for webhook"
 
   - it: Should render spark operator podDisruptionBudget if `webhook.podDisruptionBudget.enable` is true

--- a/charts/spark-operator-chart/tests/webhook/service_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/service_test.yaml
@@ -24,6 +24,14 @@ release:
   namespace: spark-operator
 
 tests:
+  - it: Should not create webhook service if `webhook.enable` is `false`
+    set:
+      webhook:
+        enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should create the webhook service correctly
     set:
       webhook:

--- a/charts/spark-operator-chart/tests/webhook/validatingwebhookconfiguration_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/validatingwebhookconfiguration_test.yaml
@@ -31,6 +31,14 @@ tests:
           kind: ValidatingWebhookConfiguration
           name: spark-operator-webhook
 
+  - it: Should not create the validating webhook configuration if `webhook.enable` is `false`
+    set:
+      webhook:
+        enable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should use the specified webhook port
     set:
       webhook:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -164,6 +164,9 @@ controller:
     minAvailable: 1
 
 webhook:
+  # -- Specifies whether to enable webhook.
+  enable: true
+
   # -- Number of replicas of webhook server.
   replicas: 1
 


### PR DESCRIPTION
## Purpose of this PR

Close #2137.

**Proposed changes:**
- Reintroduce option `webhook.enable`
- The webhook is enabled by default, but users can choose to disable the webhook server when webhooks are forbidden in K8s


## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

