### PR TITLE
Add default batch scheduler argument

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -90,6 +90,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.uiIngress.enable | bool | `false` | Specifies whether to create ingress for Spark web UI. `controller.uiService.enable` must be `true` to enable ingress. |
 | controller.uiIngress.urlFormat | string | `""` | Ingress URL format. Required if `controller.uiIngress.enable` is true. |
 | controller.batchScheduler.enable | bool | `false` | Specifies whether to enable batch scheduler for spark jobs scheduling. If enabled, users can specify batch scheduler name in spark application. |
+| controller.batchScheduler.default | string | `""` | Default batch scheduler to be used if not specified by the user. If specified, this value must be either "volcano" or "yunikorn". Specifying any other value will cause the controller to error on startup. |
 | controller.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the controller. |
 | controller.serviceAccount.name | string | `""` | Optional name for the controller service account. |
 | controller.serviceAccount.annotations | object | `{}` | Extra annotations for the controller service account. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -70,8 +70,9 @@ spec:
         - --ingress-url-format={{ . }}
         {{- end }}
         {{- end }}
-        {{- with .Values.controller.batchScheduler.enable }}
+        {{- if .Values.controller.batchScheduler.enable }}
         - --enable-batch-scheduler=true
+        - --default-batch-scheduler={{ .Values.controller.batchScheduler.default }}
         {{- end }}
         {{- if .Values.prometheus.metrics.enable }}
         - --enable-metrics=true

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -160,6 +160,17 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --enable-batch-scheduler=true
 
+  - it: Should contain `--default-batch-scheduler` arg if `controller.batchScheduler.default` is set
+    set:
+      controller:
+        batchScheduler:
+          enable: true
+          default: yunikorn
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --default-batch-scheduler=yunikorn
+
   - it: Should contain `--enable-metrics` arg if `prometheus.metrics.enable` is set to `true`
     set:
       prometheus:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -67,6 +67,10 @@ controller:
     # -- Specifies whether to enable batch scheduler for spark jobs scheduling.
     # If enabled, users can specify batch scheduler name in spark application.
     enable: false
+    # -- Default batch scheduler to be used if not specified by the user.
+    # If specified, this value must be either "volcano" or "yunikorn". Specifying any other
+    # value will cause the controller to error on startup.
+    default: ""
 
   serviceAccount:
     # -- Specifies whether to create a service account for the controller.


### PR DESCRIPTION
## Purpose

Allow users to specify a default batch scheduler for all applications on the cluster. This allows all applications to benefit from batch scheduling features e.g. gang scheduling without needing to change the spec of all applications.

Completes the second task in https://github.com/kubeflow/spark-operator/issues/2098

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.