### PR TITLE
fix: unable to set controller/webhook replicas to zero

### DIFF
--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -21,9 +21,7 @@ metadata:
   labels:
     {{- include "spark-operator.controller.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.controller.replicas }}
-  replicas: {{ . }}
-  {{- end }}
+  replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
       {{- include "spark-operator.controller.selectorLabels" . | nindent 6 }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -22,9 +22,7 @@ metadata:
   labels:
     {{- include "spark-operator.webhook.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.webhook.replicas }}
-  replicas: {{ . }}
-  {{- end }}
+  replicas: {{ .Values.webhook.replicas }}
   selector:
     matchLabels:
       {{- include "spark-operator.webhook.selectorLabels" . | nindent 6 }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -53,6 +53,15 @@ tests:
           path: spec.replicas
           value: 10
 
+  - it: Should set replicas if `controller.replicas` is set
+    set:
+      controller:
+        replicas: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: Should add pod labels if `controller.labels` is set
     set:
       controller:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -48,6 +48,15 @@ tests:
           path: spec.replicas
           value: 10
 
+  - it: Should set replicas if `webhook.replicas` is set
+    set:
+      webhook:
+        replicas: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: Should add pod labels if `webhook.labels` is set
     set:
       webhook:


### PR DESCRIPTION
## Purpose of this PR

**Proposed changes:**
- The helm should set controller/webook replicas to `0` if `[controller|webhook].replicas` is `0`

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The `replicas` field of the deployment is missing when setting `[controller|webhook].replicas` to `0`, so the replicas will default to `1`.

## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

