### PR TITLE
Update Golang to 1.23 and Spark to 3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=spark:3.5.0
+ARG SPARK_IMAGE=spark:3.5.2
 
-FROM golang:1.23.0 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG SPARK_IMAGE=spark:3.5.0
 
-FROM golang:1.22.5 AS builder
+FROM golang:1.23.0 AS builder
 
 WORKDIR /workspace
 

--- a/config/samples/v1beta1_sparkapplication.yaml
+++ b/config/samples/v1beta1_sparkapplication.yaml
@@ -8,16 +8,16 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1

--- a/config/samples/v1beta2_scheduledsparkapplication.yaml
+++ b/config/samples/v1beta2_scheduledsparkapplication.yaml
@@ -11,23 +11,23 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: spark:3.5.0
+    image: spark:3.5.2
     imagePullPolicy: IfNotPresent
     mainClass: org.apache.spark.examples.SparkPi
-    mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-    sparkVersion: 3.5.0
+    mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+    sparkVersion: 3.5.2
     restartPolicy:
       type: Never
     driver:
       labels:
-        version: 3.5.0
+        version: 3.5.2
       cores: 1
       coreLimit: 1200m
       memory: 512m
       serviceAccount: spark-operator-spark
     executor:
       labels:
-        version: 3.5.0
+        version: 3.5.2
       instances: 1
       cores: 1
       coreLimit: 1200m

--- a/config/samples/v1beta2_sparkapplication.yaml
+++ b/config/samples/v1beta2_sparkapplication.yaml
@@ -8,16 +8,16 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1

--- a/examples/spark-pi-configmap.yaml
+++ b/examples/spark-pi-configmap.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   restartPolicy:
     type: Never
   volumes:
@@ -34,7 +34,7 @@ spec:
       name: test-configmap
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
@@ -44,7 +44,7 @@ spec:
       mountPath: /opt/spark/config
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1
     cores: 1
     memory: 512m

--- a/examples/spark-pi-custom-resource.yaml
+++ b/examples/spark-pi-custom-resource.yaml
@@ -21,11 +21,11 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   restartPolicy:
     type: Never
   volumes:
@@ -35,7 +35,7 @@ spec:
       type: Directory
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
@@ -45,7 +45,7 @@ spec:
       mountPath: /tmp
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1
     cores: 1
     memory: 512m

--- a/examples/spark-pi-dynamic-allocation.yaml
+++ b/examples/spark-pi-dynamic-allocation.yaml
@@ -21,23 +21,23 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   arguments:
   - "50000"
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1
     cores: 1
     coreLimit: 1200m

--- a/examples/spark-pi-kube-scheduler.yaml
+++ b/examples/spark-pi-kube-scheduler.yaml
@@ -21,21 +21,21 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 2
     cores: 1
     coreLimit: 1200m

--- a/examples/spark-pi-python.yaml
+++ b/examples/spark-pi-python.yaml
@@ -22,20 +22,20 @@ spec:
   type: Python
   pythonVersion: "3"
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainApplicationFile: local:///opt/spark/examples/src/main/python/pi.py
-  sparkVersion: 3.5.0
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1
     cores: 1
     coreLimit: 1200m

--- a/examples/spark-pi-scheduled.yaml
+++ b/examples/spark-pi-scheduled.yaml
@@ -25,23 +25,23 @@ spec:
   template:
     type: Scala
     mode: cluster
-    image: spark:3.5.0
+    image: spark:3.5.2
     imagePullPolicy: IfNotPresent
     mainClass: org.apache.spark.examples.SparkPi
-    mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-    sparkVersion: 3.5.0
+    mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+    sparkVersion: 3.5.2
     restartPolicy:
       type: Never
     driver:
       labels:
-        version: 3.5.0
+        version: 3.5.2
       cores: 1
       coreLimit: 1200m
       memory: 512m
       serviceAccount: spark-operator-spark
     executor:
       labels:
-        version: 3.5.0
+        version: 3.5.2
       instances: 1
       cores: 1
       coreLimit: 1200m

--- a/examples/spark-pi-volcano.yaml
+++ b/examples/spark-pi-volcano.yaml
@@ -21,21 +21,21 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 2
     cores: 1
     coreLimit: 1200m

--- a/examples/spark-pi-yunikorn.yaml
+++ b/examples/spark-pi-yunikorn.yaml
@@ -21,21 +21,21 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 2
     cores: 1
     coreLimit: 1200m

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -21,21 +21,21 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.0
+  image: spark:3.5.2
   imagePullPolicy: IfNotPresent
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.0.jar
-  sparkVersion: 3.5.0
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
+  sparkVersion: 3.5.2
   driver:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     cores: 1
     coreLimit: 1200m
     memory: 512m
     serviceAccount: spark-operator-spark
   executor:
     labels:
-      version: 3.5.0
+      version: 3.5.2
     instances: 1
     cores: 1
     coreLimit: 1200m

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/spark-operator
 
-go 1.22.5
+go 1.23.0
 
 require (
 	cloud.google.com/go/storage v1.43.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/spark-operator
 
-go 1.23.0
+go 1.23
 
 require (
 	cloud.google.com/go/storage v1.43.0


### PR DESCRIPTION
## Purpose

Upgrade Golang from 1.22.5 to 1.23 and Spark from 3.5.0 to 3.5.2, which includes both the Dockerfile and the examples.

## Testing

* The example JAR is present on the 3.5.2 images and `examples/spark-pi-python.yaml` ran on Kind. 
* There is nothing in particular I can see in the Spark 3.5.1 or 3.5.2 changelogs that would impact how the operator works (there is https://github.com/apache/spark/pull/43536 but this flag isn't used when constructing the `spark-submit` command internally)

![Screenshot 2024-09-04 at 21 51 57](https://github.com/user-attachments/assets/4dcc30b6-dd47-4df4-8df2-d8d024b9990c)

![Screenshot 2024-09-04 at 21 57 02](https://github.com/user-attachments/assets/7a53ddbf-187a-4edf-a2a0-99add1ce97e9)

## Change Category

Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.