### PR TITLE
Set schedulerName to Yunikorn

### DIFF
--- a/internal/scheduler/yunikorn/scheduler.go
+++ b/internal/scheduler/yunikorn/scheduler.go
@@ -109,6 +109,11 @@ func (s *Scheduler) Schedule(app *v1beta2.SparkApplication) error {
 		})
 	}
 
+	// Ensure that the driver and executors pods are scheduled by Yunikorn
+	// if it is installed with the admissions controller disabled
+	app.Spec.Driver.SchedulerName = util.StringPtr(SchedulerName)
+	app.Spec.Executor.SchedulerName = util.StringPtr(SchedulerName)
+
 	// Yunikorn re-uses the application ID set by the driver under the label "spark-app-selector",
 	// so there is no need to set an application ID
 	// https://github.com/apache/yunikorn-k8shim/blob/2278b3217c702ccb796e4d623bc7837625e5a4ec/pkg/common/utils/utils.go#L168-L171

--- a/internal/scheduler/yunikorn/scheduler_test.go
+++ b/internal/scheduler/yunikorn/scheduler_test.go
@@ -242,6 +242,9 @@ func TestSchedule(t *testing.T) {
 				assert.Equal(t, *options.Queue, tc.app.Spec.Driver.Labels[queueLabel])
 				assert.Equal(t, *options.Queue, tc.app.Spec.Executor.Labels[queueLabel])
 			}
+
+			assert.Equal(t, "yunikorn", *tc.app.Spec.Driver.SchedulerName)
+			assert.Equal(t, "yunikorn", *tc.app.Spec.Executor.SchedulerName)
 		})
 	}
 }


### PR DESCRIPTION
## Purpose

If an application's `batchScheduler` is set to `yunikorn`, set the `schedulerName` field of pods to `yunikorn` to ensure they are scheduler by Yunikorn if it is installed with the admissions controller disabled

## Testing

```bash
# Install Yunikorn without the admissions controller enabled
helm install yunikorn yunikorn/yunikorn --namespace yunikorn --create-namespace --set embedAdmissionController=false

# Create the Yunikorn example
kubectl apply -f examples/spark-pi-yunikorn.yaml
```

![Screenshot 2024-09-05 at 21 40 56](https://github.com/user-attachments/assets/eea002f0-1920-4350-b01a-ad4bffa758a6)

![Screenshot 2024-09-05 at 21 42 21](https://github.com/user-attachments/assets/3997d030-1292-4bb3-8ee1-18bfd4fc52fb)

## Change Category

Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.