### PR TITLE
Upgrade to Spark 3.5.2(#2012)

### DIFF
--- a/examples/spark-pi-prometheus.yaml
+++ b/examples/spark-pi-prometheus.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: spark:3.5.2-gcs-prometheus
+  image: {IMAGE_REGISTRY}/{IMAGE_REPOSITORY}/spark:3.5.2-gcs-prometheus
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar

--- a/examples/spark-pi-prometheus.yaml
+++ b/examples/spark-pi-prometheus.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: gcr.io/spark-operator/spark:v3.5.2-gcs-prometheus
+  image: spark:3.5.2-gcs-prometheus
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
   mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar

--- a/examples/spark-pi-prometheus.yaml
+++ b/examples/spark-pi-prometheus.yaml
@@ -22,13 +22,13 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: gcr.io/spark-operator/spark:v3.1.1-gcs-prometheus
+  image: gcr.io/spark-operator/spark:v3.5.2-gcs-prometheus
   imagePullPolicy: Always
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.1.1.jar
+  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.12-3.5.2.jar
   arguments:
   - "100000"
-  sparkVersion: 3.1.1
+  sparkVersion: 3.5.2
   restartPolicy:
     type: Never
   driver:
@@ -36,14 +36,14 @@ spec:
     coreLimit: 1200m
     memory: 512m
     labels:
-      version: 3.1.1
+      version: 3.5.2
     serviceAccount: spark-operator-spark
   executor:
     cores: 1
     instances: 1
     memory: 512m
     labels:
-      version: 3.1.1
+      version: 3.5.2
   monitoring:
     exposeDriverMetrics: true
     exposeExecutorMetrics: true

--- a/spark-docker/Dockerfile
+++ b/spark-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG SPARK_IMAGE=gcr.io/spark-operator/spark:v3.1.1
+ARG SPARK_IMAGE=spark:3.5.2
 FROM ${SPARK_IMAGE}
 
 # Switch to user root so we can add additional jars and configuration files.


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
#2012 Problem resolved.
"gcr.io/spark-operator/spark:v3.1.1" is used as the base image, but the image is a legacy image and can no longer be used.
So I changed it to spark:3.5.2.
I tested it locally and it worked fine.

**Proposed changes:**
- Prometheus-related content has been upgraded to Spark version 3.5.2.

## Change Category
Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->


## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

