### PR TITLE
fix: webhook not working when settings spark job namespaces to empty

### DIFF
--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,15 +50,19 @@ type SparkPodDefaulter struct {
 var _ admission.CustomDefaulter = &SparkPodDefaulter{}
 
 // NewSparkPodDefaulter creates a new SparkPodDefaulter instance.
-func NewSparkPodDefaulter(client client.Client, sparkJobNamespaces []string) *SparkPodDefaulter {
-	m := make(map[string]bool)
-	for _, ns := range sparkJobNamespaces {
-		m[ns] = true
+func NewSparkPodDefaulter(client client.Client, namespaces []string) *SparkPodDefaulter {
+	nsMap := make(map[string]bool)
+	if len(namespaces) == 0 {
+		nsMap[metav1.NamespaceAll] = true
+	} else {
+		for _, ns := range namespaces {
+			nsMap[ns] = true
+		}
 	}
 
 	return &SparkPodDefaulter{
 		client:             client,
-		sparkJobNamespaces: m,
+		sparkJobNamespaces: nsMap,
 	}
 }
 
@@ -93,7 +98,7 @@ func (d *SparkPodDefaulter) Default(ctx context.Context, obj runtime.Object) err
 }
 
 func (d *SparkPodDefaulter) isSparkJobNamespace(ns string) bool {
-	return d.sparkJobNamespaces[ns]
+	return d.sparkJobNamespaces[metav1.NamespaceAll] || d.sparkJobNamespaces[ns]
 }
 
 type mutateSparkPodOption func(pod *corev1.Pod, app *v1beta2.SparkApplication) error


### PR DESCRIPTION
## Purpose of this PR

Close #2162

**Proposed changes:**
- Update Spark pod defaulter to correctly filter out spark pods when settings spark job namespaces to namespaceAll (`""`)

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

