### PR TITLE
replace datamechanics -> spot.io as adopter (acquisition)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,7 +14,7 @@ Below are the adopters of project Spark Operator. If you are using Spark Operato
 | CloudZone | @iftachsc | Evaluation | Big Data Analytics Consultancy |
 | Cyren | @avnerl | Evaluation | Data pipelines |
 | [C2FO](https://www.c2fo.com/) | @vanhoale | Production | Data Platform / Data Infrastructure |
-| [Data Mechanics](https://www.datamechanics.co)  | @jrj-d | Production | Managed Spark Platform |
+| [Spot by Netapp](https://spot.io/product/ocean-apache-spark/)  | @ImpSy | Production | Managed Spark Platform |
 | [DeepCure](https://www.deepcure.ai) | @mschroering | Production | Spark / ML |
 | [DiDi](https://www.didiglobal.com) | @Run-Lin | Evaluation | Data Infrastructure |
 | Exacaster | @minutis | Evaluation | Data pipelines |


### PR DESCRIPTION
## Purpose of this PR

Following discussion on https://github.com/kubeflow/spark-operator/pull/2164

I've decided to open a new PR for the replacement of datamechanics.co (shutdown since May) by spot.io following the acquisition in 2021

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update


## Checklist
Before submitting your PR, please review the following:

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

