### PR TITLE
FEATURE: build operator image as non-root

### DIFF
--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -134,7 +134,8 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&labelSelectorFilter, "label-selector-filter", "", "A comma-separated list of key=value, or key labels to filter resources during watch and list based on the specified labels.")
 	command.Flags().DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 30*time.Second, "Informer cache sync timeout.")
 
-	command.Flags().StringVar(&webhookCertDir, "webhook-cert-dir", "/etc/k8s-webhook-server/serving-certs", "The directory that contains the webhook server key and certificate")
+	command.Flags().StringVar(&webhookCertDir, "webhook-cert-dir", "/etc/k8s-webhook-server/serving-certs", "The directory that contains the webhook server key and certificate. "+
+		"When running as nonRoot, you must create and own this directory before running this command.")
 	command.Flags().StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The file name of webhook server certificate.")
 	command.Flags().StringVar(&webhookKeyName, "webhook-key-name", "tls.key", "The file name of webhook server key.")
 	command.Flags().StringVar(&mutatingWebhookName, "mutating-webhook-name", "spark-operator-webhook", "The name of the mutating webhook.")


### PR DESCRIPTION
## Purpose of this PR

Reduce the permission of the docker image by making it non-root (like the spark image it's build from)

**Proposed changes:**
- Re-enable go mod caching while building the image
- Make the image use the USER define in the base spark-image (UID: 185, NAME: spark)
- Use `setcap` on the binary to keep the ability to mount port <1024 (useful for people mounting webhook on 443)

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

If we aim to increase security of the project, making the image non root is a good 1st step

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

This change has been live on our product for more than 6 month
You can find the PR from our fork here -> https://github.com/spotinst/spark-on-k8s-operator/pull/10/files
