### PR TITLE
fix the make kind-delete-custer to avoid accidental kubeconfig deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,7 @@ kind-load-image: kind-create-cluster docker-build ## Load the image into the kin
 
 .PHONY: kind-delete-custer
 kind-delete-custer: kind ## Delete the created kind cluster.
-	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME) && \
-	rm -f $(KIND_KUBE_CONFIG)
+	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME) --kubeconfig $(KIND_KUBE_CONFIG)
 
 .PHONY: install
 install-crd: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
## Purpose of this PR
Fix `make kind-delete-custer` to only delete the cluster context instead of the entire kube config

## Change Category
Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

I deleted my entire kubeconfig while debugging E2E tests for another PR 🙃 

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

