### PR TITLE
FEATURE: add cli argument to modify controller workqueue ratelimiter

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -117,6 +117,10 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.pprof.enable | bool | `false` | Specifies whether to enable pprof. |
 | controller.pprof.port | int | `6060` | Specifies pprof port. |
 | controller.pprof.portName | string | `"pprof"` | Specifies pprof service port name. |
+| controller.workqueueRateLimiter.bucketQPS | int | `50` | Specifies the average rate of items process by the workqueue rate limiter. |
+| controller.workqueueRateLimiter.bucketSize | int | `500` | Specifies the maximum number of items that can be in the workqueue at any given time. |
+| controller.workqueueRateLimiter.maxDelay.enable | bool | `true` | Specifies whether to enable max delay for the workqueue rate limiter. This is useful to avoid losing events when the workqueue is full. |
+| controller.workqueueRateLimiter.maxDelay.duration | string | `"6h"` | Specifies the maximum delay duration for the workqueue rate limiter. |
 | webhook.enable | bool | `true` | Specifies whether to enable webhook. |
 | webhook.replicas | int | `1` | Number of replicas of webhook server. |
 | webhook.logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -94,6 +94,11 @@ spec:
         {{- if .Values.controller.pprof.enable }}
         - --pprof-bind-address=:{{ .Values.controller.pprof.port }}
         {{- end }}
+        - --workqueue-ratelimiter-bucket-qps={{ .Values.controller.workqueueRateLimiter.bucketQPS }}
+        - --workqueue-ratelimiter-bucket-size={{ .Values.controller.workqueueRateLimiter.bucketSize }}
+        {{- if .Values.controller.workqueueRateLimiter.maxDelay.enable }}
+        - --workqueue-ratelimiter-max-delay={{ .Values.controller.workqueueRateLimiter.maxDelay.duration }}
+        {{- end }}
         {{- if or .Values.prometheus.metrics.enable .Values.controller.pprof.enable }}
         ports:
         {{- if .Values.controller.pprof.enable }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -593,3 +593,34 @@ tests:
             name: pprof-test
             containerPort: 12345
           count: 1
+
+  - it: Should contain `--workqueue-ratelimiter-max-delay` arg if `controller.workqueueRateLimiter.maxDelay.enable` is set to `true`
+    set:
+      controller:
+        workqueueRateLimiter:
+          bucketQPS: 1
+          bucketSize: 2
+          maxDelay:
+            enable: true
+            duration: 3h
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --workqueue-ratelimiter-bucket-qps=1
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --workqueue-ratelimiter-bucket-size=2
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --workqueue-ratelimiter-max-delay=3h
+
+  - it: Should contain `--workqueue-ratelimiter-max-delay` arg if `controller.workqueueRateLimiter.maxDelay.enable` is set to `true`
+    set:
+      controller:
+          maxDelay:
+            enable: false
+            duration: 1h
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --workqueue-ratelimiter-max-delay=1h

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -178,6 +178,19 @@ controller:
     # -- Specifies pprof service port name.
     portName: pprof
 
+  # Workqueue rate limiter configuration forwarded to the controller-runtime Reconciler.
+  workqueueRateLimiter:
+    # -- Specifies the average rate of items process by the workqueue rate limiter.
+    bucketQPS: 50
+    # -- Specifies the maximum number of items that can be in the workqueue at any given time.
+    bucketSize: 500
+    maxDelay:
+      # -- Specifies whether to enable max delay for the workqueue rate limiter.
+      # This is useful to avoid losing events when the workqueue is full.
+      enable: true
+      # -- Specifies the maximum delay duration for the workqueue rate limiter.
+      duration: 6h
+
 webhook:
   # -- Specifies whether to enable webhook.
   enable: true

--- a/pkg/util/workqueue.go
+++ b/pkg/util/workqueue.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// This allow to create a new rate limiter while tuning the BucketRateLimiter parameters
+// This also prevent a "bug" in the BucketRateLimiter due to the fact that a BucketRateLimiter does not have a maxDelay parameter
+func NewRateLimiter(qps int, bucketSize int, maxDelay time.Duration) workqueue.RateLimiter {
+	ratelimiter := workqueue.NewWithMaxWaitRateLimiter(
+		workqueue.NewMaxOfRateLimiter(
+			workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
+			&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(qps), bucketSize)},
+		), maxDelay)
+	return ratelimiter
+}


### PR DESCRIPTION
## Purpose of this PR

Add the capacity to customize the controller workqueue ratelimiter and remove a potential bug on high usage cluster 

**Proposed changes:**
- cli argument to modify the default controller-runtime workqueue ratelimiter
- Keep the default value (from controller-runtime) in the code but set them in the chart


## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

#### 1- controler-runtime uses `workqueue.DefaultControllerRateLimiter` by default which has a rather low BucketRatelimiter
With only 10 QPS and 100 Bucket max size we easily reach those number, before migrating to `controller-runtime` the value was actually 50/500 (https://github.com/kubeflow/spark-operator/commit/0dc641bd1d7d262e4a8c5564c926fc4716bcf722#diff-915090b1cf1857dc448319dbbbc11699ba40e674744723a5772a4624a1c79282L59)

#### 2- BucketRatelimiter does not have a max delay
We encounter a bug on a high usage cluster a few years ago where we discover that `BucketRatelimiter` rely on `golang.org/x/time/rate` `Limiter.Reserve()` function that is not upperBound:
- If QPS > Bucket max size then the rateLimiter return `rate.InfDuration`

Being able to set a MaxDelay fix this

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

This changed has been implemented on our fork for almost 2 years -> https://github.com/spotinst/spark-on-k8s-operator/pull/5
