### PR TITLE
Fix ingress capability discovery

### DIFF
--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -25,17 +25,18 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	"golang.org/x/time/rate"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -225,6 +226,17 @@ func start() {
 	})
 	if err != nil {
 		logger.Error(err, "failed to create manager")
+		os.Exit(1)
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		logger.Error(err, "failed to create clientset")
+		os.Exit(1)
+	}
+
+	if err = util.InitializeIngressCapabilities(clientset); err != nil {
+		logger.Error(err, "failed to retrieve cluster ingress capabilities")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Purpose of this PR

Fix ingress API discovery so that driver UI ingresses can be created. This was broken in 2.0.0 because the initialisation function isn't called.

**Old code:**
https://github.com/kubeflow/spark-operator/blob/779ea3debc7885f422a759e6cac6cbcd466c8e5c/main.go#L163-L165

Close https://github.com/kubeflow/spark-operator/issues/2167 
Close https://github.com/kubeflow/spark-operator/issues/2194

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.