### PR TITLE
Remove `cap_net_bind_service` from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ FROM golang:1.23.1 AS builder
 
 WORKDIR /workspace
 
-RUN apt-get update \
-    && apt-get install -y libcap2-bin \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,source=go.mod,target=go.mod \
     --mount=type=bind,source=go.sum,target=go.sum \
@@ -36,7 +32,6 @@ ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on make build-operator
-RUN setcap 'cap_net_bind_service=+ep' /workspace/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 


### PR DESCRIPTION
## Purpose of this PR

* Remove `setcap 'cap_net_bind_service=+ep'` from the build so the container can be run with all capabilities dropped on a non-privileged port
* Looking at other open source components, it seems more common to run on a non-privileged port and require either root or `NET_BIND_SERVICE` to run on a privileged port e.g. 443
  * e.g. https://open-policy-agent.github.io/gatekeeper/website/docs/vendor-specific/#running-on-private-gke-cluster-nodes
* The webhook runs on port 9443 by default which doesn't require any privilege escalation

Run the operator with the following values:

```yaml
controller:
  securityContext:
    capabilities:
      drop: ["ALL"]
webhook:
  securityContext:
    capabilities:
      drop: ["ALL"]
```

https://github.com/kubeflow/spark-operator/issues/2211

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist
Before submitting your PR, please review the following:

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.