### PR TITLE
Set readOnlyRootFilesystem: true for the controller and webhook containers to improve default security posture

### DIFF
--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -120,10 +120,13 @@ spec:
         {{- end }}
         {{- with .Values.controller.volumeMounts }}
         volumeMounts:
+          {{- if .Values.controller.controllerTmpDirectory.enable }}
           - name: "tmp"
             mountPath: "/tmp"
+          {{- end }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        
         {{- with .Values.controller.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -151,9 +154,11 @@ spec:
       {{- end }}
       {{- with .Values.controller.volumes }}
       volumes:
+        {{- if .Values.controller.controllerTmpDirectory.enable }}
         - name: tmp
           emptyDir:
-            sizeLimit: 500Mi
+            sizeLimit: {{ .Values.controller.controllerTmpDirectory.sizeLimit }}
+        {{- end }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -120,13 +120,12 @@ spec:
         {{- end }}
         {{- with .Values.controller.volumeMounts }}
         volumeMounts:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
           {{- if .Values.controller.controllerTmpDirectory.enable }}
           - name: "tmp"
             mountPath: "/tmp"
           {{- end }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        
         {{- with .Values.controller.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -154,13 +153,13 @@ spec:
       {{- end }}
       {{- with .Values.controller.volumes }}
       volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
         {{- if .Values.controller.controllerTmpDirectory.enable }}
         - name: tmp
           emptyDir:
             sizeLimit: {{ .Values.controller.controllerTmpDirectory.sizeLimit }}
         {{- end }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -118,8 +118,8 @@ spec:
         envFrom:
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.controller.volumeMounts }}
         volumeMounts:
+        {{- with .Values.controller.volumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
           {{- if .Values.controller.controllerTmpDirectory.enable }}
@@ -151,8 +151,8 @@ spec:
       imagePullSecrets:
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.controller.volumes }}
       volumes:
+      {{- with .Values.controller.volumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
         {{- if .Values.controller.controllerTmpDirectory.enable }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -120,6 +120,8 @@ spec:
         {{- end }}
         {{- with .Values.controller.volumeMounts }}
         volumeMounts:
+          - name: "tmp"
+            mountPath: "/tmp"
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.controller.resources }}
@@ -149,6 +151,9 @@ spec:
       {{- end }}
       {{- with .Values.controller.volumes }}
       volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 500Mi
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         {{- end }}
         {{- with .Values.webhook.volumeMounts }}
         volumeMounts:
-          {{- if .Values.controller.webhookCertsDirectory.enable }}
+          {{- if .Values.webhook.webhookCertsDirectory.enable }}
           - name: serving-certs
             mountPath: /etc/k8s-webhook-server/serving-certs
             subPath: serving-certs
@@ -129,7 +129,7 @@ spec:
       {{- end }}
       {{- with .Values.webhook.volumes }}
       volumes:
-        {{- if .Values.controller.controllerTmpDirectory.enable }}
+        {{- if .Values.webhook.webhookCertsDirectory.enable }}
         - name: serving-certs
           emptyDir:
           sizeLimit: {{ .Values.webhook.webhookCertsDirectory.sizeLimit }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -94,14 +94,14 @@ spec:
         {{- end }}
         {{- with .Values.webhook.volumeMounts }}
         volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           {{- if .Values.webhook.webhookCertsDirectory.enable }}
           - name: serving-certs
             mountPath: /etc/k8s-webhook-server/serving-certs
             subPath: serving-certs
             readOnly: false
           {{- end }}
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         {{- with .Values.webhook.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -129,13 +129,13 @@ spec:
       {{- end }}
       {{- with .Values.webhook.volumes }}
       volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         {{- if .Values.webhook.webhookCertsDirectory.enable }}
         - name: serving-certs
           emptyDir:
           sizeLimit: {{ .Values.webhook.webhookCertsDirectory.sizeLimit }}
         {{- end }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -94,6 +94,10 @@ spec:
         {{- end }}
         {{- with .Values.webhook.volumeMounts }}
         volumeMounts:
+          - name: serving-certs
+            mountPath: /etc/k8s-webhook-server/serving-certs
+            subPath: serving-certs
+            readOnly: false
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.webhook.resources }}
@@ -123,6 +127,9 @@ spec:
       {{- end }}
       {{- with .Values.webhook.volumes }}
       volumes:
+        - name: serving-certs
+          emptyDir:
+            sizeLimit: 500Mi
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.webhook.nodeSelector }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -94,10 +94,12 @@ spec:
         {{- end }}
         {{- with .Values.webhook.volumeMounts }}
         volumeMounts:
+          {{- if .Values.controller.webhookCertsDirectory.enable }}
           - name: serving-certs
             mountPath: /etc/k8s-webhook-server/serving-certs
             subPath: serving-certs
             readOnly: false
+          {{- end }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.webhook.resources }}
@@ -127,9 +129,11 @@ spec:
       {{- end }}
       {{- with .Values.webhook.volumes }}
       volumes:
+        {{- if .Values.controller.controllerTmpDirectory.enable }}
         - name: serving-certs
           emptyDir:
-            sizeLimit: 500Mi
+          sizeLimit: {{ .Values.webhook.webhookCertsDirectory.sizeLimit }}
+        {{- end }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.webhook.nodeSelector }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -316,6 +316,11 @@ tests:
           content:
             name: volume2
             mountPath: /volume2
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
 
   - it: Should add resources if `controller.resources` is set
     set:
@@ -408,6 +413,13 @@ tests:
           content:
             name: volume2
             emptyDir: {}
+          count: 1
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 500Mi
           count: 1
 
   - it: Should add nodeSelector if `controller.nodeSelector` is set

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -345,7 +345,6 @@ tests:
           runAsUser: 1000
           runAsGroup: 2000
           fsGroup: 3000
-          readOnlyRootFilesystem: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -316,11 +316,25 @@ tests:
           content:
             name: volume2
             mountPath: /volume2
+  
+- it: Should add volume mounts if `controller.controllerTmpDirectory` is enabled
+    set:
+      controller:
+        controllerTmpDirectory:
+          enabled: true
+          sizeLimit: 1Gi
+    asserts:
       - contains:
-          path: spec.template.spec.containers[0].volumeMounts
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller"].volumeMounts
           content:
             name: tmp
             mountPath: /tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 1Gi
 
   - it: Should add resources if `controller.resources` is set
     set:
@@ -413,13 +427,6 @@ tests:
           content:
             name: volume2
             emptyDir: {}
-          count: 1
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: tmp
-            emptyDir:
-              sizeLimit: 500Mi
           count: 1
 
   - it: Should add nodeSelector if `controller.nodeSelector` is set

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -316,8 +316,8 @@ tests:
           content:
             name: volume2
             mountPath: /volume2
-  
-- it: Should add volume mounts if `controller.controllerTmpDirectory` is enabled
+
+  - it: Should add volume mounts if `controller.controllerTmpDirectory` is enabled
     set:
       controller:
         controllerTmpDirectory:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -345,6 +345,7 @@ tests:
           runAsUser: 1000
           runAsGroup: 2000
           fsGroup: 3000
+          readOnlyRootFilesystem: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext
@@ -352,6 +353,7 @@ tests:
             runAsUser: 1000
             runAsGroup: 2000
             fsGroup: 3000
+            readOnlyRootFilesystem: true
 
   - it: Should add sidecars if `controller.sidecars` is set
     set:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -274,6 +274,27 @@ tests:
             mountPath: /volume2
           count: 1
 
+    - it: Should add volume and volume mounts if `webhook.webhookCertsDirectory` is enabled
+    set:
+      webhook:
+        webhookCertsDirectory:
+          enabled: true
+          sizeLimit: 100Mi
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook"].volumeMounts
+          content:
+            name: serving-certs
+            mountPath: /etc/k8s-webhook-server/serving-certs
+            subPath: serving-certs
+            readOnly: false
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: serving-certs
+            emptyDir:
+              sizeLimit: 100Mi
+
   - it: Should add resources if `webhook.resources` is set
     set:
       webhook:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -274,7 +274,7 @@ tests:
             mountPath: /volume2
           count: 1
 
-    - it: Should add volume and volume mounts if `webhook.webhookCertsDirectory` is enabled
+  - it: Should add volume and volume mounts if `webhook.webhookCertsDirectory` is enabled
     set:
       webhook:
         webhookCertsDirectory:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -159,6 +159,15 @@ controller:
     # runAsGroup: 2000
     # fsGroup: 3000
 
+  # -- Create volume and volumeMount to download Spark artifacts for running Spark Applications
+  # This is required if setting controller.securityContext.readOnlyRootFilesystem: true or 
+  # controller.podSecurityContext.readOnlyRootFilesystem: true
+  controllerTmpDirectory:
+    # -- Specifies whether to create the volume and volumeMount
+    enable: true
+    # -- Specifies the size of the emptyDir to create
+    sizeLimit: 500Mi
+
   # -- Sidecar containers for controller pods.
   sidecars: []
 
@@ -302,6 +311,15 @@ webhook:
     # runAsUser: 1000
     # runAsGroup: 2000
     # fsGroup: 3000
+
+  # -- Create volume and volumeMount to generate certificates in
+  # This is required if setting webhook.securityContext.readOnlyRootFilesystem: true or 
+  # webhook.podSecurityContext.readOnlyRootFilesystem: true
+  webhookCertsDirectory:
+    # -- Specifies whether to create the volume and volumeMount
+    enable: true
+    # -- Specifies the size of the emptyDir to create
+    sizeLimit: 50Mi
 
   # Pod disruption budget for webhook to avoid service degradation.
   podDisruptionBudget:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -153,7 +153,8 @@ controller:
     #   memory: 300Mi
 
   # -- Security context for controller containers.
-  securityContext: {}
+  securityContext:
+    readOnlyRootFilesystem: true
     # runAsUser: 1000
     # runAsGroup: 2000
     # fsGroup: 3000
@@ -296,7 +297,8 @@ webhook:
     #   memory: 300Mi
 
   # -- Security context for webhook containers.
-  securityContext: {}
+  securityContext:
+    readOnlyRootFilesystem: true
     # runAsUser: 1000
     # runAsGroup: 2000
     # fsGroup: 3000


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions.

By default, the controller and webhook containers write to their filesystems. DevOpSec at multiple organizations using the spark-operator chart require Kubernetes container security contexts to prohibit writing to the root filesystem ( [Slack Conversation](https://cloud-native.slack.com/archives/C074588U7EG/p1727852883726249), [Issue for Improved Security](https://github.com/kubeflow/spark-operator/issues/2218#issue-2565007558))

This PR will allow the spark-operator chart to be deployed with a read-only root filesystem to improve the default security posture and meet the requirements of users.

**Proposed changes:**
- Add an empty directory onto the webhook containers to create certs in
- Add an empty directory onto the controller containers to write Spark artifacts for Spark apps
- Set the default container security context for the webhook and controller to readOnlyRootFilesystem

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->
Multiple users of the Helm chart require an increased security posture in their Kubernetes deployments.

## Checklist
Before submitting your PR, please review the following:

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

