### PR TITLE
fix: spark-submission failed due to lack of permission by user `spark`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get update \
     && apt-get install -y tini \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /etc/k8s-webhook-server/serving-certs && \
+RUN mkdir -p /etc/k8s-webhook-server/serving-certs /home/spark && \
     chmod -R g+rw /etc/k8s-webhook-server/serving-certs && \
-    chown -R spark /etc/k8s-webhook-server/serving-certs
+    chown -R spark /etc/k8s-webhook-server/serving-certs /home/spark
 
 USER spark
 


### PR DESCRIPTION
## Purpose of this PR

fixes #2208 error: `Exception in thread "main" java.io.FileNotFoundException: /home/spark/.ivy2/cache/resolved-org.apache.spark-spark-submit-parent-511288aa-ce7c-4a38-9c8e-4869b71c68fa-1.0.xml (No such file or directory)`

**Proposed changes:**
change ownership of `/home/spark` to user `spark`

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

the issue was introduced by PR #2171 

