### PR TITLE
Minor fixes to e2e test `make` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,15 +249,15 @@ endif
 .PHONY: kind-create-cluster
 kind-create-cluster: kind ## Create a kind cluster for integration tests.
 	if ! $(KIND) get clusters 2>/dev/null | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
-		kind create cluster --name $(KIND_CLUSTER_NAME) --config $(KIND_CONFIG_FILE) --kubeconfig $(KIND_KUBE_CONFIG) --wait=1m; \
+		$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config $(KIND_CONFIG_FILE) --kubeconfig $(KIND_KUBE_CONFIG) --wait=1m; \
 	fi
 
 .PHONY: kind-load-image
 kind-load-image: kind-create-cluster docker-build ## Load the image into the kind cluster.
 	$(KIND) load docker-image --name $(KIND_CLUSTER_NAME) $(IMAGE)
 
-.PHONY: kind-delete-custer
-kind-delete-custer: kind ## Delete the created kind cluster.
+.PHONY: kind-delete-cluster
+kind-delete-cluster: kind ## Delete the created kind cluster.
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME) --kubeconfig $(KIND_KUBE_CONFIG)
 
 .PHONY: install


### PR DESCRIPTION
## Purpose of this PR
Make it a little easier to get started running the e2e tests.

**Proposed changes:**
- Correct a typo so now it matches the docs https://www.kubeflow.org/docs/components/spark-operator/developer-guide/#run-e2e-tests.
- Use `$(KIND)` so it uses the `kind` that was automatically installed rather than trying to find it on system path.

## Change Category
Indicate the type of change by marking the applicable boxes:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update


## Checklist
Before submitting your PR, please review the following:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly - I don't think there is need for an update. 
- [x] I have added tests that prove my changes are effective or that my feature works - I don't think this is applicable. 
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

