### PR TITLE
Add permissions to controller serviceaccount to list and watch ingresses

### DIFF
--- a/charts/spark-operator-chart/templates/controller/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/controller/_helpers.tpl
@@ -166,6 +166,8 @@ Create the role policy rules for the controller in every Spark job namespace
   - get
   - create
   - delete
+  - list
+  - watch
 - apiGroups:
   - sparkoperator.k8s.io
   resources:


### PR DESCRIPTION
## Purpose of this PR
When in UI ingress creation is enabled, we need the `list` and `watch` permissions for `Ingress` resources.

```
W1014 09:43:21.777501      10 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:spark-operator:spark-operator-controller" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope
E1014 09:43:21.777525      10 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Ingress: failed to list *v1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:spark-operator:spark-operator-controller" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope
```

## Change Category
Indicate the type of change by marking the applicable boxes:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update