### PR TITLE
Run e2e tests with Kubernetes version matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -209,6 +209,9 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: [v1.28.13, v1.29.8, v1.30.4, v1.31.1]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -221,7 +224,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Create a Kind cluster
-        run: make kind-create-cluster
+        run: make kind-create-cluster KIND_K8S_VERSION=${{ matrix.k8s_version }}
 
       - name: Build and load image to Kind cluster
         run: |

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ LOCALBIN ?= $(shell pwd)/bin
 KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 KIND_VERSION ?= v0.23.0
+KIND_K8S_VERSION ?= v1.29.3
 ENVTEST_VERSION ?= release-0.18
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.29.3
@@ -249,7 +250,12 @@ endif
 .PHONY: kind-create-cluster
 kind-create-cluster: kind ## Create a kind cluster for integration tests.
 	if ! $(KIND) get clusters 2>/dev/null | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
-		$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config $(KIND_CONFIG_FILE) --kubeconfig $(KIND_KUBE_CONFIG) --wait=1m; \
+		$(KIND) create cluster \
+			--name $(KIND_CLUSTER_NAME) \
+			--config $(KIND_CONFIG_FILE) \
+			--image kindest/node:$(KIND_K8S_VERSION) \
+			--kubeconfig $(KIND_KUBE_CONFIG) \
+			--wait=1m; \
 	fi
 
 .PHONY: kind-load-image

--- a/charts/spark-operator-chart/ci/kind-config.yaml
+++ b/charts/spark-operator-chart/ci/kind-config.yaml
@@ -2,6 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.29.2
   - role: worker
-    image: kindest/node:v1.29.2


### PR DESCRIPTION
## Purpose of this PR

* Run e2e tests with Kubernetes version matrix containing n-3 of the current Kubernetes versions
## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.