### PR TITLE
Allow the Controller and Webhook Containers to run with the securityContext: readOnlyRootfilesystem: true

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -102,7 +102,6 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.labels | object | `{}` | Extra labels for controller pods. |
 | controller.annotations | object | `{}` | Extra annotations for controller pods. |
 | controller.volumes | list | `[{"emptyDir":{"sizeLimit":"1Gi"},"name":"tmp"}]` | Volumes for controller pods. |
-| controller.volumes[0] | object | `{"emptyDir":{"sizeLimit":"1Gi"},"name":"tmp"}` | Create a tmp directory to write Spark artifacts to for deployed Spark apps. |
 | controller.nodeSelector | object | `{}` | Node selector for controller pods. |
 | controller.affinity | object | `{}` | Affinity for controller pods. |
 | controller.tolerations | list | `[]` | List of node taints to tolerate for controller pods. |
@@ -112,7 +111,6 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.env | list | `[]` | Environment variables for controller containers. |
 | controller.envFrom | list | `[]` | Environment variable sources for controller containers. |
 | controller.volumeMounts | list | `[{"mountPath":"/tmp","name":"tmp","readOnly":false}]` | Volume mounts for controller containers. |
-| controller.volumeMounts[0] | object | `{"mountPath":"/tmp","name":"tmp","readOnly":false}` | Mount a tmp directory to write Spark artifacts to for deployed Spark apps. |
 | controller.resources | object | `{}` | Pod resource requests and limits for controller containers. Note, that each job submission will spawn a JVM within the controller pods using "/usr/local/openjdk-11/bin/java -Xmx128m". Kubernetes may kill these Java processes at will to enforce resource limits. When that happens, you will see the following error: 'failed to run spark-submit for SparkApplication [...]: signal: killed' - when this happens, you may want to increase memory limits. |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security context for controller containers. |
 | controller.sidecars | list | `[]` | Sidecar containers for controller pods. |
@@ -142,7 +140,6 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.annotations | object | `{}` | Extra annotations for webhook pods. |
 | webhook.sidecars | list | `[]` | Sidecar containers for webhook pods. |
 | webhook.volumes | list | `[{"emptyDir":{"sizeLimit":"500Mi"},"name":"serving-certs"}]` | Volumes for webhook pods. |
-| webhook.volumes[0] | object | `{"emptyDir":{"sizeLimit":"500Mi"},"name":"serving-certs"}` | Create a dir for the webhook to generate its certificates in. |
 | webhook.nodeSelector | object | `{}` | Node selector for webhook pods. |
 | webhook.affinity | object | `{}` | Affinity for webhook pods. |
 | webhook.tolerations | list | `[]` | List of node taints to tolerate for webhook pods. |
@@ -152,7 +149,6 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.env | list | `[]` | Environment variables for webhook containers. |
 | webhook.envFrom | list | `[]` | Environment variable sources for webhook containers. |
 | webhook.volumeMounts | list | `[{"mountPath":"/etc/k8s-webhook-server/serving-certs","name":"serving-certs","readOnly":false,"subPath":"serving-certs"}]` | Volume mounts for webhook containers. |
-| webhook.volumeMounts[0] | object | `{"mountPath":"/etc/k8s-webhook-server/serving-certs","name":"serving-certs","readOnly":false,"subPath":"serving-certs"}` | Mount a dir for the webhook to generate its certificates in. |
 | webhook.resources | object | `{}` | Pod resource requests and limits for webhook pods. |
 | webhook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security context for webhook containers. |
 | webhook.podDisruptionBudget.enable | bool | `false` | Specifies whether to create pod disruption budget for webhook. Ref: [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -101,7 +101,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.rbac.annotations | object | `{}` | Extra annotations for the controller RBAC resources. |
 | controller.labels | object | `{}` | Extra labels for controller pods. |
 | controller.annotations | object | `{}` | Extra annotations for controller pods. |
-| controller.volumes | list | `[]` | Volumes for controller pods. |
+| controller.volumes | list | `[{"emptyDir":{"sizeLimit":"1Gi"},"name":"tmp"}]` | Volumes for controller pods. |
+| controller.volumes[0] | object | `{"emptyDir":{"sizeLimit":"1Gi"},"name":"tmp"}` | Create a tmp directory to write Spark artifacts to for deployed Spark apps. |
 | controller.nodeSelector | object | `{}` | Node selector for controller pods. |
 | controller.affinity | object | `{}` | Affinity for controller pods. |
 | controller.tolerations | list | `[]` | List of node taints to tolerate for controller pods. |
@@ -110,9 +111,10 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. Ref: [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The labelSelector field in topology spread constraint will be set to the selector labels for controller pods if not specified. |
 | controller.env | list | `[]` | Environment variables for controller containers. |
 | controller.envFrom | list | `[]` | Environment variable sources for controller containers. |
-| controller.volumeMounts | list | `[]` | Volume mounts for controller containers. |
+| controller.volumeMounts | list | `[{"mountPath":"/tmp","name":"tmp","readOnly":false}]` | Volume mounts for controller containers. |
+| controller.volumeMounts[0] | object | `{"mountPath":"/tmp","name":"tmp","readOnly":false}` | Mount a tmp directory to write Spark artifacts to for deployed Spark apps. |
 | controller.resources | object | `{}` | Pod resource requests and limits for controller containers. Note, that each job submission will spawn a JVM within the controller pods using "/usr/local/openjdk-11/bin/java -Xmx128m". Kubernetes may kill these Java processes at will to enforce resource limits. When that happens, you will see the following error: 'failed to run spark-submit for SparkApplication [...]: signal: killed' - when this happens, you may want to increase memory limits. |
-| controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsNonRoot":true}` | Security context for controller containers. |
+| controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security context for controller containers. |
 | controller.sidecars | list | `[]` | Sidecar containers for controller pods. |
 | controller.podDisruptionBudget.enable | bool | `false` | Specifies whether to create pod disruption budget for controller. Ref: [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | controller.podDisruptionBudget.minAvailable | int | `1` | The number of pods that must be available. Require `controller.replicas` to be greater than 1 |
@@ -139,7 +141,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.labels | object | `{}` | Extra labels for webhook pods. |
 | webhook.annotations | object | `{}` | Extra annotations for webhook pods. |
 | webhook.sidecars | list | `[]` | Sidecar containers for webhook pods. |
-| webhook.volumes | list | `[]` | Volumes for webhook pods. |
+| webhook.volumes | list | `[{"emptyDir":{"sizeLimit":"500Mi"},"name":"serving-certs"}]` | Volumes for webhook pods. |
+| webhook.volumes[0] | object | `{"emptyDir":{"sizeLimit":"500Mi"},"name":"serving-certs"}` | Create a dir for the webhook to generate its certificates in. |
 | webhook.nodeSelector | object | `{}` | Node selector for webhook pods. |
 | webhook.affinity | object | `{}` | Affinity for webhook pods. |
 | webhook.tolerations | list | `[]` | List of node taints to tolerate for webhook pods. |
@@ -148,9 +151,10 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. Ref: [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). The labelSelector field in topology spread constraint will be set to the selector labels for webhook pods if not specified. |
 | webhook.env | list | `[]` | Environment variables for webhook containers. |
 | webhook.envFrom | list | `[]` | Environment variable sources for webhook containers. |
-| webhook.volumeMounts | list | `[]` | Volume mounts for webhook containers. |
+| webhook.volumeMounts | list | `[{"mountPath":"/etc/k8s-webhook-server/serving-certs","name":"serving-certs","readOnly":false,"subPath":"serving-certs"}]` | Volume mounts for webhook containers. |
+| webhook.volumeMounts[0] | object | `{"mountPath":"/etc/k8s-webhook-server/serving-certs","name":"serving-certs","readOnly":false,"subPath":"serving-certs"}` | Mount a dir for the webhook to generate its certificates in. |
 | webhook.resources | object | `{}` | Pod resource requests and limits for webhook pods. |
-| webhook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsNonRoot":true}` | Security context for webhook containers. |
+| webhook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Security context for webhook containers. |
 | webhook.podDisruptionBudget.enable | bool | `false` | Specifies whether to create pod disruption budget for webhook. Ref: [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | webhook.podDisruptionBudget.minAvailable | int | `1` | The number of pods that must be available. Require `webhook.replicas` to be greater than 1 |
 | spark.jobNamespaces | list | `["default"]` | List of namespaces where to run spark jobs. If empty string is included, all namespaces will be allowed. Make sure the namespaces have already existed. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -124,7 +124,7 @@ spec:
         {{- end }}
         {{- with .Values.controller.volumeMounts }}
         volumeMounts:
-          {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.controller.resources }}
         resources:

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -124,7 +124,7 @@ spec:
         {{- end }}
         {{- with .Values.controller.volumeMounts }}
         volumeMounts:
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.controller.resources }}
         resources:
@@ -153,7 +153,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.volumes }}
       volumes:
-      {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -153,7 +153,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.volumes }}
       volumes:
-        {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         {{- end }}
         {{- with .Values.webhook.volumeMounts }}
         volumeMounts:
-          {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.webhook.resources }}
         resources:

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -123,7 +123,7 @@ spec:
       {{- end }}
       {{- with .Values.webhook.volumes }}
       volumes:
-        {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         {{- end }}
         {{- with .Values.webhook.volumeMounts }}
         volumeMounts:
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.webhook.resources }}
         resources:
@@ -123,7 +123,7 @@ spec:
       {{- end }}
       {{- with .Values.webhook.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -355,6 +355,7 @@ tests:
     set:
       controller:
         securityContext:
+          readOnlyRootFilesystem: true
           runAsUser: 1000
           runAsGroup: 2000
           fsGroup: 3000
@@ -362,6 +363,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext
           value:
+            readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 2000
             fsGroup: 3000

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -359,6 +359,12 @@ tests:
           runAsUser: 1000
           runAsGroup: 2000
           fsGroup: 3000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          privileged: false
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext
@@ -367,6 +373,12 @@ tests:
             runAsUser: 1000
             runAsGroup: 2000
             fsGroup: 3000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            privileged: false
 
   - it: Should add sidecars if `controller.sidecars` is set
     set:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -299,10 +299,14 @@ tests:
     set:
       webhook:
         securityContext:
+          readOnlyRootFilesystem: true
           runAsUser: 1000
           runAsGroup: 2000
           fsGroup: 3000
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1000

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -106,10 +106,10 @@ controller:
 
   # -- Volumes for controller pods.
   volumes:
-    # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
-    - name: tmp
-      emptyDir:
-        sizeLimit: 1Gi
+  # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
+  - name: tmp
+    emptyDir:
+      sizeLimit: 1Gi
 
   # -- Node selector for controller pods.
   nodeSelector: {}
@@ -146,10 +146,10 @@ controller:
 
   # -- Volume mounts for controller containers.
   volumeMounts:
-    # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
-    - name: tmp
-      mountPath: "/tmp"
-      readOnly: false
+  # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
+  - name: tmp
+    mountPath: "/tmp"
+    readOnly: false
 
   # -- Pod resource requests and limits for controller containers.
   # Note, that each job submission will spawn a JVM within the controller pods using "/usr/local/openjdk-11/bin/java -Xmx128m".
@@ -262,10 +262,10 @@ webhook:
 
   # -- Volumes for webhook pods.
   volumes:
-    # Create a dir for the webhook to generate its certificates in.
-    - name: serving-certs
-      emptyDir:
-        sizeLimit: 500Mi
+  # Create a dir for the webhook to generate its certificates in.
+  - name: serving-certs
+    emptyDir:
+      sizeLimit: 500Mi
 
   # -- Node selector for webhook pods.
   nodeSelector: {}
@@ -302,11 +302,11 @@ webhook:
 
   # -- Volume mounts for webhook containers.
   volumeMounts:
-    # Mount a dir for the webhook to generate its certificates in.
-    - name: serving-certs
-      mountPath: /etc/k8s-webhook-server/serving-certs
-      subPath: serving-certs
-      readOnly: false
+  # Mount a dir for the webhook to generate its certificates in.
+  - name: serving-certs
+    mountPath: /etc/k8s-webhook-server/serving-certs
+    subPath: serving-certs
+    readOnly: false
 
 
   # -- Pod resource requests and limits for webhook pods.

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -261,7 +261,11 @@ webhook:
   sidecars: []
 
   # -- Volumes for webhook pods.
-  volumes: []
+  volumes:
+    # -- Create a dir for the webhook to generate its certificates in.
+    - name: serving-certs
+      emptyDir:
+        sizeLimit: 500Mi
 
   # -- Node selector for webhook pods.
   nodeSelector: {}
@@ -297,7 +301,13 @@ webhook:
   envFrom: []
 
   # -- Volume mounts for webhook containers.
-  volumeMounts: []
+  volumeMounts:
+    # -- Mount a dir for the webhook to generate its certificates in.
+    - name: serving-certs
+      mountPath: /etc/k8s-webhook-server/serving-certs
+      subPath: serving-certs
+      readOnly: false
+
 
   # -- Pod resource requests and limits for webhook pods.
   resources: {}
@@ -310,6 +320,7 @@ webhook:
 
   # -- Security context for webhook containers.
   securityContext:
+    readOnlyRootFilesystem: true
     privileged: false
     allowPrivilegeEscalation: false
     runAsNonRoot: true

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -106,10 +106,10 @@ controller:
 
   # -- Volumes for controller pods.
   volumes:
-  # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
-  - name: tmp
-    emptyDir:
-      sizeLimit: 1Gi
+    # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
+    - name: tmp
+      emptyDir:
+        sizeLimit: 1Gi
 
   # -- Node selector for controller pods.
   nodeSelector: {}
@@ -146,10 +146,10 @@ controller:
 
   # -- Volume mounts for controller containers.
   volumeMounts:
-  # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
-  - name: tmp
-    mountPath: "/tmp"
-    readOnly: false
+    # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
+    - name: tmp
+      mountPath: "/tmp"
+      readOnly: false
 
   # -- Pod resource requests and limits for controller containers.
   # Note, that each job submission will spawn a JVM within the controller pods using "/usr/local/openjdk-11/bin/java -Xmx128m".
@@ -262,10 +262,10 @@ webhook:
 
   # -- Volumes for webhook pods.
   volumes:
-  # Create a dir for the webhook to generate its certificates in.
-  - name: serving-certs
-    emptyDir:
-      sizeLimit: 500Mi
+    # Create a dir for the webhook to generate its certificates in.
+    - name: serving-certs
+      emptyDir:
+        sizeLimit: 500Mi
 
   # -- Node selector for webhook pods.
   nodeSelector: {}
@@ -302,11 +302,11 @@ webhook:
 
   # -- Volume mounts for webhook containers.
   volumeMounts:
-  # Mount a dir for the webhook to generate its certificates in.
-  - name: serving-certs
-    mountPath: /etc/k8s-webhook-server/serving-certs
-    subPath: serving-certs
-    readOnly: false
+    # Mount a dir for the webhook to generate its certificates in.
+    - name: serving-certs
+      mountPath: /etc/k8s-webhook-server/serving-certs
+      subPath: serving-certs
+      readOnly: false
 
 
   # -- Pod resource requests and limits for webhook pods.

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -105,7 +105,11 @@ controller:
     # key2: value2
 
   # -- Volumes for controller pods.
-  volumes: []
+  volumes:
+    # -- Create a tmp directory to write Spark artifacts to for deployed Spark apps.
+    - name: tmp
+      emptyDir:
+        sizeLimit: 1Gi
 
   # -- Node selector for controller pods.
   nodeSelector: {}
@@ -141,7 +145,11 @@ controller:
   envFrom: []
 
   # -- Volume mounts for controller containers.
-  volumeMounts: []
+  volumeMounts:
+    # -- Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
+    - name: tmp
+      mountPath: "/tmp"
+      readOnly: false
 
   # -- Pod resource requests and limits for controller containers.
   # Note, that each job submission will spawn a JVM within the controller pods using "/usr/local/openjdk-11/bin/java -Xmx128m".
@@ -157,6 +165,7 @@ controller:
 
   # -- Security context for controller containers.
   securityContext:
+    readOnlyRootFilesystem: true
     privileged: false
     allowPrivilegeEscalation: false
     runAsNonRoot: true

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -106,7 +106,7 @@ controller:
 
   # -- Volumes for controller pods.
   volumes:
-    # -- Create a tmp directory to write Spark artifacts to for deployed Spark apps.
+    # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
     - name: tmp
       emptyDir:
         sizeLimit: 1Gi
@@ -146,7 +146,7 @@ controller:
 
   # -- Volume mounts for controller containers.
   volumeMounts:
-    # -- Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
+    # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
     - name: tmp
       mountPath: "/tmp"
       readOnly: false
@@ -262,7 +262,7 @@ webhook:
 
   # -- Volumes for webhook pods.
   volumes:
-    # -- Create a dir for the webhook to generate its certificates in.
+    # Create a dir for the webhook to generate its certificates in.
     - name: serving-certs
       emptyDir:
         sizeLimit: 500Mi
@@ -302,7 +302,7 @@ webhook:
 
   # -- Volume mounts for webhook containers.
   volumeMounts:
-    # -- Mount a dir for the webhook to generate its certificates in.
+    # Mount a dir for the webhook to generate its certificates in.
     - name: serving-certs
       mountPath: /etc/k8s-webhook-server/serving-certs
       subPath: serving-certs

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -302,11 +302,11 @@ webhook:
 
   # -- Volume mounts for webhook containers.
   volumeMounts:
-    # Mount a dir for the webhook to generate its certificates in.
-    - name: serving-certs
-      mountPath: /etc/k8s-webhook-server/serving-certs
-      subPath: serving-certs
-      readOnly: false
+  # Mount a dir for the webhook to generate its certificates in.
+  - name: serving-certs
+    mountPath: /etc/k8s-webhook-server/serving-certs
+    subPath: serving-certs
+    readOnly: false
 
 
   # -- Pod resource requests and limits for webhook pods.

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -262,10 +262,10 @@ webhook:
 
   # -- Volumes for webhook pods.
   volumes:
-    # Create a dir for the webhook to generate its certificates in.
-    - name: serving-certs
-      emptyDir:
-        sizeLimit: 500Mi
+  # Create a dir for the webhook to generate its certificates in.
+  - name: serving-certs
+    emptyDir:
+      sizeLimit: 500Mi
 
   # -- Node selector for webhook pods.
   nodeSelector: {}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -146,10 +146,10 @@ controller:
 
   # -- Volume mounts for controller containers.
   volumeMounts:
-    # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
-    - name: tmp
-      mountPath: "/tmp"
-      readOnly: false
+  # Mount a tmp directory to write Spark artifacts to for deployed Spark apps.
+  - name: tmp
+    mountPath: "/tmp"
+    readOnly: false
 
   # -- Pod resource requests and limits for controller containers.
   # Note, that each job submission will spawn a JVM within the controller pods using "/usr/local/openjdk-11/bin/java -Xmx128m".

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -106,10 +106,10 @@ controller:
 
   # -- Volumes for controller pods.
   volumes:
-    # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
-    - name: tmp
-      emptyDir:
-        sizeLimit: 1Gi
+  # Create a tmp directory to write Spark artifacts to for deployed Spark apps.
+  - name: tmp
+    emptyDir:
+      sizeLimit: 1Gi
 
   # -- Node selector for controller pods.
   nodeSelector: {}


### PR DESCRIPTION
### 🛑 Important:
Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!

For guidelines on how to contribute, please review the [CONTRIBUTING.md](CONTRIBUTING.md) document.

## Purpose of this PR
Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions.

Close [#2218 ](https://github.com/kubeflow/spark-operator/issues/2218#issue-2565007558)

**Proposed changes:**
- Mount an emptyDir onto the controller container to write Spark artifacts to
- Mount an emptyDir onto the webhook container to write certficates to
- Set the default securityContexts for the controller and webhook to readOnlyRootfilesystem: true

## Change Category
Indicate the type of change by marking the applicable boxes:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->
Please see this [issue](https://github.com/kubeflow/spark-operator/issues/2218#issue-2565007558) for discussion around this feature.
This feature improves the default security posture of the Spark Operator Helm Chart and allows organizations that require `readOnlyRootfilesystem: true` to deploy the helm chart.

## Checklist
Before submitting your PR, please review the following:

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

