### PR TITLE
Allow setting automountServiceAccountToken

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -97,6 +97,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the controller. |
 | controller.serviceAccount.name | string | `""` | Optional name for the controller service account. |
 | controller.serviceAccount.annotations | object | `{}` | Extra annotations for the controller service account. |
+| controller.serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount service account token to the controller pods. |
 | controller.rbac.create | bool | `true` | Specifies whether to create RBAC resources for the controller. |
 | controller.rbac.annotations | object | `{}` | Extra annotations for the controller RBAC resources. |
 | controller.labels | object | `{}` | Extra labels for controller pods. |
@@ -134,6 +135,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the webhook. |
 | webhook.serviceAccount.name | string | `""` | Optional name for the webhook service account. |
 | webhook.serviceAccount.annotations | object | `{}` | Extra annotations for the webhook service account. |
+| webhook.serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount service account token to the webhook pods. |
 | webhook.rbac.create | bool | `true` | Specifies whether to create RBAC resources for the webhook. |
 | webhook.rbac.annotations | object | `{}` | Extra annotations for the webhook RBAC resources. |
 | webhook.labels | object | `{}` | Extra labels for webhook pods. |
@@ -157,6 +159,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | spark.serviceAccount.create | bool | `true` | Specifies whether to create a service account for spark applications. |
 | spark.serviceAccount.name | string | `""` | Optional name for the spark service account. |
 | spark.serviceAccount.annotations | object | `{}` | Optional annotations for the spark service account. |
+| spark.serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount service account token to the spark applications pods. |
 | spark.rbac.create | bool | `true` | Specifies whether to create RBAC resources for spark applications. |
 | spark.rbac.annotations | object | `{}` | Optional annotations for the spark application RBAC resources. |
 | prometheus.metrics.enable | bool | `true` | Specifies whether to enable prometheus metrics scraping. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -171,6 +171,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "spark-operator.controller.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.controller.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/templates/controller/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/controller/serviceaccount.yaml
@@ -17,6 +17,7 @@ limitations under the License.
 {{- if .Values.controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "spark-operator.controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/spark-operator-chart/templates/spark/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/spark/serviceaccount.yaml
@@ -21,6 +21,7 @@ limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ $.Values.spark.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "spark-operator.spark.serviceAccountName" $ }}
   namespace: {{ $jobNamespace }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -141,6 +141,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "spark-operator.webhook.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.webhook.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/spark-operator-chart/templates/webhook/serviceaccount.yaml
+++ b/charts/spark-operator-chart/templates/webhook/serviceaccount.yaml
@@ -18,6 +18,7 @@ limitations under the License.
 {{- if .Values.webhook.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "spark-operator.webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -87,6 +87,8 @@ controller:
     name: ""
     # -- Extra annotations for the controller service account.
     annotations: {}
+    # -- Auto-mount service account token to the controller pods.
+    automountServiceAccountToken: true
 
   rbac:
     # -- Specifies whether to create RBAC resources for the controller.
@@ -231,6 +233,8 @@ webhook:
     name: ""
     # -- Extra annotations for the webhook service account.
     annotations: {}
+    # -- Auto-mount service account token to the webhook pods.
+    automountServiceAccountToken: true
 
   rbac:
     # -- Specifies whether to create RBAC resources for the webhook.
@@ -331,6 +335,8 @@ spark:
     name: ""
     # -- Optional annotations for the spark service account.
     annotations: {}
+    # -- Auto-mount service account token to the spark applications pods.
+    automountServiceAccountToken: true
 
   rbac:
     # -- Specifies whether to create RBAC resources for spark applications.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

By default, kubernetes enables "automountServiceAccountToken" for all pods.
This poses a security risk, as pods might get kube-api permissions unintentionally.
More specifically, this fails security compliance tests:
https://learn.microsoft.com/en-us/azure/governance/policy/samples/built-in-policies
https://www.azadvertizer.net/azpolicyadvertizer/kubernetes_block-automount-token.html

Solution - Disable "automountServiceAccountToken", create projected volume for the token, and mount it on relevant containers

Fixes https://github.com/kubeflow/spark-operator/issues/1189

**Proposed changes:**

- Allow setting this field for all spark-operator workloads and serviceAccounts
- No further changes needed, as projected volume can already be added using exiting "volumes" and "volumeMounts" values

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->

While default behavior remains unchanged, and anyone disabling "automountServiceAccountToken" should know the consequences (as this is a standard k8s feature, not a spark-operator one), I am adding an example values file for deploying the operator with it disabled:
```
controller:
  serviceAccount:
    automountServiceAccountToken: false
  volumes:
    - name: kube-api-access
      projected:
        defaultMode: 420
        sources:
        - serviceAccountToken:
            expirationSeconds: 3607
            path: token
        - configMap:
            items:
            - key: ca.crt
              path: ca.crt
            name: kube-root-ca.crt
        - downwardAPI:
            items:
            - fieldRef:
                apiVersion: v1
                fieldPath: metadata.namespace
              path: namespace
  volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access
      readOnly: true

spark:
  serviceAccount:
    automountServiceAccountToken: false

webhook:
  serviceAccount:
    automountServiceAccountToken: false
  volumes:
    - name: kube-api-access
      projected:
        defaultMode: 420
        sources:
        - serviceAccountToken:
            expirationSeconds: 3607
            path: token
        - configMap:
            items:
            - key: ca.crt
              path: ca.crt
            name: kube-root-ca.crt
        - downwardAPI:
            items:
            - fieldRef:
                apiVersion: v1
                fieldPath: metadata.namespace
              path: namespace
  volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access
      readOnly: true
```