### PR TITLE
Robustness to driver pod taking time to create

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -86,6 +86,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.replicas | int | `1` | Number of replicas of controller. |
 | controller.workers | int | `10` | Reconcile concurrency, higher values might increase memory usage. |
 | controller.logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |
+| controller.driverPodCreationGracePeriod | string | `"10s"` | Grace period after a successful spark-submit when driver pod not found errors will be retried. Useful if the driver pod can take some time to be created. |
 | controller.maxTrackedExecutorPerApp | int | `1000` | Specifies the maximum number of Executor pods that can be tracked by the controller per SparkApplication. |
 | controller.uiService.enable | bool | `true` | Specifies whether to create service for Spark web UI. |
 | controller.uiIngress.enable | bool | `false` | Specifies whether to create ingress for Spark web UI. `controller.uiService.enable` must be `true` to enable ingress. |

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -100,6 +100,9 @@ spec:
         {{- if .Values.controller.workqueueRateLimiter.maxDelay.enable }}
         - --workqueue-ratelimiter-max-delay={{ .Values.controller.workqueueRateLimiter.maxDelay.duration }}
         {{- end }}
+        {{- if .Values.controller.driverPodCreationGracePeriod }}
+        - --driver-pod-creation-grace-period={{ .Values.controller.driverPodCreationGracePeriod }}
+        {{- end }}
         {{- if .Values.controller.maxTrackedExecutorPerApp }}
         - --max-tracked-executor-per-app={{ .Values.controller.maxTrackedExecutorPerApp }}
         {{- end }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -651,6 +651,14 @@ tests:
       - notContains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --workqueue-ratelimiter-max-delay=1h
+  - it: Should contain `driver-pod-creation-grace-period` arg if `controller.driverPodCreationGracePeriod` is set
+    set:
+      controller:
+        driverPodCreationGracePeriod: 30s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --driver-pod-creation-grace-period=30s
   - it: Should contain `--max-tracked-executor-per-app` arg if `controller.maxTrackedExecutorPerApp` is set
     set:
       controller:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -651,6 +651,7 @@ tests:
       - notContains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --workqueue-ratelimiter-max-delay=1h
+
   - it: Should contain `driver-pod-creation-grace-period` arg if `controller.driverPodCreationGracePeriod` is set
     set:
       controller:
@@ -659,6 +660,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --driver-pod-creation-grace-period=30s
+
   - it: Should contain `--max-tracked-executor-per-app` arg if `controller.maxTrackedExecutorPerApp` is set
     set:
       controller:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -51,6 +51,9 @@ controller:
   # -- Configure the verbosity of logging, can be one of `debug`, `info`, `error`.
   logLevel: info
 
+  # -- Grace period after a successful spark-submit when driver pod not found errors will be retried. Useful if the driver pod can take some time to be created.
+  driverPodCreationGracePeriod: 10s
+
   # -- Specifies the maximum number of Executor pods that can be tracked by the controller per SparkApplication.
   maxTrackedExecutorPerApp: 1000
 

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -398,15 +398,15 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		sparkExecutorMetrics.Register()
 	}
 	options := sparkapplication.Options{
-		Namespaces:               namespaces,
-		EnableUIService:          enableUIService,
-		IngressClassName:         ingressClassName,
-		IngressURLFormat:         ingressURLFormat,
-		DefaultBatchScheduler:    defaultBatchScheduler,
+		Namespaces:                   namespaces,
+		EnableUIService:              enableUIService,
+		IngressClassName:             ingressClassName,
+		IngressURLFormat:             ingressURLFormat,
+		DefaultBatchScheduler:        defaultBatchScheduler,
 		DriverPodCreationGracePeriod: driverPodCreationGracePeriod,
-		SparkApplicationMetrics:  sparkApplicationMetrics,
-		SparkExecutorMetrics:     sparkExecutorMetrics,
-		MaxTrackedExecutorPerApp: maxTrackedExecutorPerApp,
+		SparkApplicationMetrics:      sparkApplicationMetrics,
+		SparkExecutorMetrics:         sparkExecutorMetrics,
+		MaxTrackedExecutorPerApp:     maxTrackedExecutorPerApp,
 	}
 	if enableBatchScheduler {
 		options.KubeSchedulerNames = kubeSchedulerNames

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -165,7 +165,7 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 14*time.Second, "Leader election renew deadline.")
 	command.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 4*time.Second, "Leader election retry period.")
 
-	command.Flags().DurationVar(&driverPodCreationGracePeriod, "driver-pod-creation-grace-period", 10*time.Second, "Grace period after a successful spark-submit when driver pod not found errors will be retried.")
+	command.Flags().DurationVar(&driverPodCreationGracePeriod, "driver-pod-creation-grace-period", 10*time.Second, "Grace period after a successful spark-submit when driver pod not found errors will be retried. Useful if the driver pod can take some time to be created.")
 
 	command.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics.")
 	command.Flags().StringVar(&metricsBindAddress, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -100,6 +100,8 @@ var (
 	leaderElectionRenewDeadline time.Duration
 	leaderElectionRetryPeriod   time.Duration
 
+	driverPodCreationGracePeriod time.Duration
+
 	// Metrics
 	enableMetrics                 bool
 	metricsBindAddress            string
@@ -162,6 +164,8 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "Leader election lease duration.")
 	command.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 14*time.Second, "Leader election renew deadline.")
 	command.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 4*time.Second, "Leader election retry period.")
+
+	command.Flags().DurationVar(&driverPodCreationGracePeriod, "driver-pod-creation-grace-period", 10*time.Second, "Grace period after a successful spark-submit when driver pod not found errors will be retried.")
 
 	command.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics.")
 	command.Flags().StringVar(&metricsBindAddress, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
@@ -399,6 +403,7 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		IngressClassName:         ingressClassName,
 		IngressURLFormat:         ingressURLFormat,
 		DefaultBatchScheduler:    defaultBatchScheduler,
+		DriverPodCreationGracePeriod: driverPodCreationGracePeriod,
 		SparkApplicationMetrics:  sparkApplicationMetrics,
 		SparkExecutorMetrics:     sparkExecutorMetrics,
 		MaxTrackedExecutorPerApp: maxTrackedExecutorPerApp,

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -63,6 +63,8 @@ type Options struct {
 	IngressURLFormat      string
 	DefaultBatchScheduler string
 
+	DriverPodCreationGracePeriod time.Duration
+
 	KubeSchedulerNames []string
 
 	SparkApplicationMetrics *metrics.SparkApplicationMetrics
@@ -773,7 +775,7 @@ func (r *Reconciler) updateDriverState(_ context.Context, app *v1beta2.SparkAppl
 	}
 
 	if driverPod == nil {
-		if metav1.Now().Sub(app.Status.LastSubmissionAttemptTime.Time) > 10*time.Second {
+		if metav1.Now().Sub(app.Status.LastSubmissionAttemptTime.Time) > r.options.DriverPodCreationGracePeriod {
 			app.Status.AppState.State = v1beta2.ApplicationStateFailing
 			app.Status.AppState.ErrorMessage = "driver pod not found"
 			app.Status.TerminationTime = metav1.Now()

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -781,7 +781,7 @@ func (r *Reconciler) updateDriverState(_ context.Context, app *v1beta2.SparkAppl
 			app.Status.TerminationTime = metav1.Now()
 			return nil
 		}
-		return fmt.Errorf("driver pod not found, while inside the grace period")
+		return fmt.Errorf("driver pod not found, while inside the grace period. Grace period of %v expires at %v", r.options.DriverPodCreationGracePeriod, app.Status.LastSubmissionAttemptTime.Add(r.options.DriverPodCreationGracePeriod))
 	}
 
 	app.Status.SparkApplicationID = util.GetSparkApplicationID(driverPod)

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -773,10 +773,13 @@ func (r *Reconciler) updateDriverState(_ context.Context, app *v1beta2.SparkAppl
 	}
 
 	if driverPod == nil {
-		app.Status.AppState.State = v1beta2.ApplicationStateFailing
-		app.Status.AppState.ErrorMessage = "driver pod not found"
-		app.Status.TerminationTime = metav1.Now()
-		return nil
+		if metav1.Now().Sub(app.Status.LastSubmissionAttemptTime.Time) > 10*time.Second {
+			app.Status.AppState.State = v1beta2.ApplicationStateFailing
+			app.Status.AppState.ErrorMessage = "driver pod not found"
+			app.Status.TerminationTime = metav1.Now()
+			return nil
+		}
+		return fmt.Errorf("driver pod not found, give it some time")
 	}
 
 	app.Status.SparkApplicationID = util.GetSparkApplicationID(driverPod)

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -775,7 +775,7 @@ func (r *Reconciler) updateDriverState(_ context.Context, app *v1beta2.SparkAppl
 	}
 
 	if driverPod == nil {
-		if metav1.Now().Sub(app.Status.LastSubmissionAttemptTime.Time) > r.options.DriverPodCreationGracePeriod {
+		if app.Status.AppState.State != v1beta2.ApplicationStateSubmitted || metav1.Now().Sub(app.Status.LastSubmissionAttemptTime.Time) > r.options.DriverPodCreationGracePeriod {
 			app.Status.AppState.State = v1beta2.ApplicationStateFailing
 			app.Status.AppState.ErrorMessage = "driver pod not found"
 			app.Status.TerminationTime = metav1.Now()

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -781,7 +781,7 @@ func (r *Reconciler) updateDriverState(_ context.Context, app *v1beta2.SparkAppl
 			app.Status.TerminationTime = metav1.Now()
 			return nil
 		}
-		return fmt.Errorf("driver pod not found, give it some time")
+		return fmt.Errorf("driver pod not found, while inside the grace period")
 	}
 
 	app.Status.SparkApplicationID = util.GetSparkApplicationID(driverPod)

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -91,9 +91,6 @@ var _ = Describe("SparkApplication Controller", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      appName,
 						Namespace: appNamespace,
-						Labels: map[string]string{
-							common.LabelSparkAppName: app.Name,
-						},
 					},
 					Spec: v1beta2.SparkApplicationSpec{
 						MainApplicationFile: util.StringPtr("local:///dummy.jar"),
@@ -171,9 +168,6 @@ var _ = Describe("SparkApplication Controller", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      appName,
 						Namespace: appNamespace,
-						Labels: map[string]string{
-							common.LabelSparkAppName: app.Name,
-						},
 					},
 					Spec: v1beta2.SparkApplicationSpec{
 						MainApplicationFile: util.StringPtr("local:///dummy.jar"),

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -125,7 +125,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				sparkapplication.Options{Namespaces: []string{appNamespace}, DriverPodCreationGracePeriod: 10 * time.Second},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
-			Expect(err).To(MatchError("driver pod not found, while inside the grace period"))
+			Expect(err).To(MatchError(ContainSubstring("driver pod not found, while inside the grace period. Grace period of")))
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
 			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateSubmitted))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR
Improve reliability. 
Closes: #2302

**Proposed changes:**
- Add a grace period for the driver pod to be created. 
- Grace period is controlled by a new config option `driver-pod-creation-grace-period`. Default is 10 seconds. 
- Add 3 new tests around reconciling submitted status, including the new grace period functionality. This is the majority of the lines changed. 
- Expose the new config option in the helm chart and add a helm test

## Change Category
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly - I think its sufficient just to add a description on the new argument on the helm chart and regenerate the helm docs. 
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes
Some logs of a real example on our prod cluster where the spark application was saved by the grace period added in this PR. 
[Explore-logs-2024-11-11 12_09_13.txt](https://github.com/user-attachments/files/17702165/Explore-logs-2024-11-11.12_09_13.txt)
