### PR TITLE
Fix: should not add emptyDir sizeLimit conf on executor pods if it is nil

### DIFF
--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -840,20 +840,22 @@ func executorVolumeMountsOption(app *v1beta2.SparkApplication) ([]string, error)
 		}
 		switch volumeType {
 		case common.VolumeTypeEmptyDir:
-			args = append(
-				args,
-				"--conf",
-				fmt.Sprintf(
-					"%s=%s",
+			if volume.EmptyDir.SizeLimit != nil {
+				args = append(
+					args,
+					"--conf",
 					fmt.Sprintf(
-						common.SparkKubernetesExecutorVolumesOptionsTemplate,
-						common.VolumeTypeEmptyDir,
-						volume.Name,
-						"sizeLimit",
+						"%s=%s",
+						fmt.Sprintf(
+							common.SparkKubernetesExecutorVolumesOptionsTemplate,
+							common.VolumeTypeEmptyDir,
+							volume.Name,
+							"sizeLimit",
+						),
+						volume.EmptyDir.SizeLimit.String(),
 					),
-					volume.EmptyDir.SizeLimit.String(),
-				),
-			)
+				)
+			}
 		case common.VolumeTypeHostPath:
 			args = append(
 				args,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

This is a follow up fix from work already done in https://github.com/kubeflow/spark-operator/pull/2305 by @ChenYi015 

This PR adds a check at submission on executors pods if an emptyDir `sizeLimit` is `nil`.  

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Following some further testing of an older `SparkApplication` template wherein the volumeName (see issue https://github.com/kubeflow/spark-operator/issues/2199 for more details) had not been changed, I noticed behaviour wherein only the driver pod would get created and no executor pods would spawn. I believe this is due to the same issue outlined in https://github.com/kubeflow/spark-operator/pull/2305 which would make sense, as the check was only added on the driver pod submission, and not the executors.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
