### PR TITLE
Add option to override driver + executor memory limit using webhook

### DIFF
--- a/api/v1beta2/sparkapplication_types.go
+++ b/api/v1beta2/sparkapplication_types.go
@@ -524,6 +524,10 @@ type DriverSpec struct {
 	// Maps to `spark.kubernetes.driver.request.cores` that is available since Spark 3.0.
 	// +optional
 	CoreRequest *string `json:"coreRequest,omitempty"`
+	// MemoryLimit is overriding the driver pod memory limit.
+	// By default, the memory limit and request are equal - use carefully.
+	// +optional
+	MemoryLimit *string `json:"memoryLimit,omitempty"`
 	// JavaOptions is a string of extra JVM options to pass to the driver. For instance,
 	// GC settings or other logging.
 	// +optional
@@ -562,6 +566,10 @@ type ExecutorSpec struct {
 	// Maps to `spark.kubernetes.executor.request.cores` that is available since Spark 2.4.
 	// +optional
 	CoreRequest *string `json:"coreRequest,omitempty"`
+	// MemoryLimit is overriding the executor pod memory limit.
+	// By default, the memory limit and request are equal - use carefully.
+	// +optional
+	MemoryLimit *string `json:"memoryLimit,omitempty"`
 	// JavaOptions is a string of extra JVM options to pass to the executors. For instance,
 	// GC settings or other logging.
 	// +optional

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -210,6 +210,11 @@ func (in *DriverSpec) DeepCopyInto(out *DriverSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		*out = new(string)
+		**out = **in
+	}
 	if in.JavaOptions != nil {
 		in, out := &in.JavaOptions, &out.JavaOptions
 		*out = new(string)
@@ -307,6 +312,11 @@ func (in *ExecutorSpec) DeepCopyInto(out *ExecutorSpec) {
 	}
 	if in.CoreRequest != nil {
 		in, out := &in.CoreRequest, &out.CoreRequest
+		*out = new(string)
+		**out = **in
+	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
 		*out = new(string)
 		**out = **in
 	}

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -2970,6 +2970,11 @@ spec:
                         description: Memory is the amount of memory to request for
                           the pod.
                         type: string
+                      memoryLimit:
+                        description: |-
+                          MemoryLimit is overriding the driver pod memory limit.
+                          By default, the memory limit and request are equal - use carefully.
+                        type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory
                           to allocate in cluster mode, in MiB unless otherwise specified.
@@ -7755,6 +7760,11 @@ spec:
                       memory:
                         description: Memory is the amount of memory to request for
                           the pod.
+                        type: string
+                      memoryLimit:
+                        description: |-
+                          MemoryLimit is overriding the executor pod memory limit.
+                          By default, the memory limit and request are equal - use carefully.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -2919,6 +2919,11 @@ spec:
                     description: Memory is the amount of memory to request for the
                       pod.
                     type: string
+                  memoryLimit:
+                    description: |-
+                      MemoryLimit is overriding the driver pod memory limit.
+                      By default, the memory limit and request are equal - use carefully.
+                    type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to
                       allocate in cluster mode, in MiB unless otherwise specified.
@@ -7674,6 +7679,11 @@ spec:
                   memory:
                     description: Memory is the amount of memory to request for the
                       pod.
+                    type: string
+                  memoryLimit:
+                    description: |-
+                      MemoryLimit is overriding the executor pod memory limit.
+                      By default, the memory limit and request are equal - use carefully.
                     type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -2970,6 +2970,11 @@ spec:
                         description: Memory is the amount of memory to request for
                           the pod.
                         type: string
+                      memoryLimit:
+                        description: |-
+                          MemoryLimit is overriding the driver pod memory limit.
+                          By default, the memory limit and request are equal - use carefully.
+                        type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory
                           to allocate in cluster mode, in MiB unless otherwise specified.
@@ -7755,6 +7760,11 @@ spec:
                       memory:
                         description: Memory is the amount of memory to request for
                           the pod.
+                        type: string
+                      memoryLimit:
+                        description: |-
+                          MemoryLimit is overriding the executor pod memory limit.
+                          By default, the memory limit and request are equal - use carefully.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory

--- a/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
@@ -2919,6 +2919,11 @@ spec:
                     description: Memory is the amount of memory to request for the
                       pod.
                     type: string
+                  memoryLimit:
+                    description: |-
+                      MemoryLimit is overriding the driver pod memory limit.
+                      By default, the memory limit and request are equal - use carefully.
+                    type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to
                       allocate in cluster mode, in MiB unless otherwise specified.
@@ -7674,6 +7679,11 @@ spec:
                   memory:
                     description: Memory is the amount of memory to request for the
                       pod.
+                    type: string
+                  memoryLimit:
+                    description: |-
+                      MemoryLimit is overriding the executor pod memory limit.
+                      By default, the memory limit and request are equal - use carefully.
                     type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -559,6 +559,19 @@ Maps to <code>spark.kubernetes.driver.request.cores</code> that is available sin
 </tr>
 <tr>
 <td>
+<code>memoryLimit</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MemoryLimit is overriding the driver pod memory limit.
+By default, the memory limit and request are equal - use carefully.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>javaOptions</code><br/>
 <em>
 string
@@ -808,6 +821,19 @@ string
 <em>(Optional)</em>
 <p>CoreRequest is the physical CPU core request for the executors.
 Maps to <code>spark.kubernetes.executor.request.cores</code> that is available since Spark 2.4.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>memoryLimit</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MemoryLimit is overriding the executor pod memory limit.
+By default, the memory limit and request are equal - use carefully.</p>
 </td>
 </tr>
 <tr>

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -133,6 +133,10 @@ func addMemoryLimit(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
 		return fmt.Errorf("failed to parse memory limit %s: %v", *memoryLimit, err)
 	}
 
+	if pod.Spec.Containers[i].Resources.Limits == nil {
+		pod.Spec.Containers[i].Resources.Limits = corev1.ResourceList{}
+	}
+
 	// Apply the memory limit to the container's resources
 	logger.Info(fmt.Sprintf("Adding memory limit %s to container in pod %s", *memoryLimit, pod.Name))
 	pod.Spec.Containers[i].Resources.Limits[corev1.ResourceMemory] = limitQuantity


### PR DESCRIPTION


## Purpose of this PR

Add an option to override the driver and executor memory limit as by default spark uses equal limit and request.
It is Done by webhook as the pod template does not support overriding the memory limit.



## Change Category


- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

For many use cases, it makes sense to share memory between pods as they don't all peak simultaneously. Limit allows better resources allocation

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.


