### PR TITLE
Unit Tests for memoryLimit override feature

### DIFF
--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -2089,8 +2089,8 @@ func TestPatchSparkPod_ShareProcessNamespace(t *testing.T) {
 
 func TestPatchSparkPod_MemoryLimit(t *testing.T) {
 
-	var memory = "1G"
-	var memoryLimit = "10G"
+	var memory = "1Gi"
+	var memoryLimit = "10Gi"
 
 	app := &v1beta2.SparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2115,7 +2115,7 @@ func TestPatchSparkPod_MemoryLimit(t *testing.T) {
 
 	driverPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "spark-driver",
+			Name: "spark-test-memory",
 			Labels: map[string]string{
 				common.LabelSparkRole:               common.SparkRoleDriver,
 				common.LabelLaunchedBySparkOperator: "true",
@@ -2136,13 +2136,15 @@ func TestPatchSparkPod_MemoryLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//assert.Len(t, modifiedDriverPod.Spec.Containers[0].Ports, 2)
-	assert.Equal(t, "10G", modifiedDriverPod.Spec.Containers[0].Resources.Limits)
-	assert.NotEqual(t, modifiedDriverPod.Spec.Containers[0].Resources.Requests, modifiedDriverPod.Spec.Containers[0].Resources.Limits)
+	expectedDriverMemoryRequest := modifiedDriverPod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+	expectedDriverMemoryLimit := modifiedDriverPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+
+	assert.Equal(t, "10Gi", expectedDriverMemoryLimit.String())
+	assert.NotEqual(t, expectedDriverMemoryRequest.String(), expectedDriverMemoryLimit.String())
 
 	executorPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "spark-executor",
+			Name: "spark-test-memory",
 			Labels: map[string]string{
 				common.LabelSparkRole:               common.SparkRoleExecutor,
 				common.LabelLaunchedBySparkOperator: "true",
@@ -2162,7 +2164,11 @@ func TestPatchSparkPod_MemoryLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//assert.Len(t, modifiedExecutorPod.Spec.Containers[0].Ports, 2)
-	assert.Equal(t, "10G", modifiedExecutorPod.Spec.Containers[0].Resources.Limits)
-	assert.NotEqual(t, modifiedDriverPod.Spec.Containers[0].Resources.Requests, modifiedDriverPod.Spec.Containers[0].Resources.Limits)
+
+	expectedExecutorMemoryRequest := modifiedExecutorPod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+	expectedExecutorMemoryLimit := modifiedExecutorPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+
+	assert.Equal(t, "10Gi", expectedExecutorMemoryLimit.String())
+	assert.NotEqual(t, expectedExecutorMemoryRequest.String(), expectedExecutorMemoryLimit.String())
+
 }

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -2087,6 +2087,46 @@ func TestPatchSparkPod_ShareProcessNamespace(t *testing.T) {
 	}
 }
 
+func TestConvertJavaMemoryStringToK8sMemoryString(t *testing.T) {
+	tests := map[string]struct {
+		input  string
+		result string
+	}{
+		"Memory g": {
+			input:  "1g",
+			result: "1Gi",
+		},
+		"Memory Gi": {
+			input:  "1Gi",
+			result: "1Gi",
+		},
+		"Memory m": {
+			input:  "1m",
+			result: "1Mi",
+		},
+		"Memory Mi": {
+			input:  "1Mi",
+			result: "1Mi",
+		},
+		"Memory invalid": {
+			input:  "1Y",
+			result: "1Y",
+		},
+		"Memory empty": {
+			input:  "",
+			result: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got, expected := convertJavaMemoryStringToK8sMemoryString(test.input), test.result; got != expected {
+				t.Fatalf("convertJavaMemoryStringToK8sMemoryString(%q) returned %q; expected %q", test.input, got, expected)
+			}
+		})
+	}
+}
+
 func TestPatchSparkPod_MemoryLimit(t *testing.T) {
 
 	var memory = "1Gi"

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -2086,3 +2086,83 @@ func TestPatchSparkPod_ShareProcessNamespace(t *testing.T) {
 		}
 	}
 }
+
+func TestPatchSparkPod_MemoryLimit(t *testing.T) {
+
+	var memory = "1G"
+	var memoryLimit = "10G"
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test-memory",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Memory: &memory,
+				},
+				MemoryLimit: &memoryLimit,
+			},
+			Executor: v1beta2.ExecutorSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Memory: &memory,
+				},
+				MemoryLimit: &memoryLimit,
+			},
+		},
+	}
+
+	driverPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-driver",
+			Labels: map[string]string{
+				common.LabelSparkRole:               common.SparkRoleDriver,
+				common.LabelLaunchedBySparkOperator: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  common.SparkDriverContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	modifiedDriverPod, err := getModifiedPod(driverPod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//assert.Len(t, modifiedDriverPod.Spec.Containers[0].Ports, 2)
+	assert.Equal(t, "10G", modifiedDriverPod.Spec.Containers[0].Resources.Limits)
+	assert.NotEqual(t, modifiedDriverPod.Spec.Containers[0].Resources.Requests, modifiedDriverPod.Spec.Containers[0].Resources.Limits)
+
+	executorPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-executor",
+			Labels: map[string]string{
+				common.LabelSparkRole:               common.SparkRoleExecutor,
+				common.LabelLaunchedBySparkOperator: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  common.SparkExecutorContainerName,
+					Image: "spark-executor:latest",
+				},
+			},
+		},
+	}
+
+	modifiedExecutorPod, err := getModifiedPod(executorPod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//assert.Len(t, modifiedExecutorPod.Spec.Containers[0].Ports, 2)
+	assert.Equal(t, "10G", modifiedExecutorPod.Spec.Containers[0].Resources.Limits)
+	assert.NotEqual(t, modifiedDriverPod.Spec.Containers[0].Resources.Requests, modifiedDriverPod.Spec.Containers[0].Resources.Limits)
+}


### PR DESCRIPTION
## Purpose of this PR

This PR includes Unit Tests for the features developed in https://github.com/kubeflow/spark-operator/pull/2383.

**Proposed changes:**

- Unit test for `convertJavaMemoryStringToK8sMemoryString`
- Unit test for `addMemoryLimit`

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The most upvoted issue in the SparkOperator repository relates to having the ability to define different `memory` and `memoryLimits` values. The feature has been covered in https://github.com/kubeflow/spark-operator/pull/2383. I am adding unit tests to it to increase the trust in the code.

## Checklist


- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

![Screenshot 2025-01-18 at 13 48 45](https://github.com/user-attachments/assets/6194081f-f4c8-4b54-a9d3-ac039bc30c22)

