### PR TITLE
Remove dependency on `k8s.io/kubernetes`

### DIFF
--- a/cmd/sparkctl/app/event.go
+++ b/cmd/sparkctl/app/event.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	clientWatch "k8s.io/client-go/tools/watch"
-	"k8s.io/kubernetes/pkg/util/interrupt"
 
 	crdclientset "github.com/kubeflow/spark-operator/pkg/client/clientset/versioned"
+	"github.com/kubeflow/spark-operator/pkg/util"
 )
 
 var FollowEvents bool
@@ -147,7 +147,7 @@ func streamEvents(events watch.Interface, streamSince int64) error {
 
 	// Set 10 minutes inactivity timeout
 	watchExpire := 10 * time.Minute
-	intr := interrupt.New(nil, events.Stop)
+	intr := util.NewInterruptHandler(nil, events.Stop)
 	return intr.Run(func() error {
 		// Start rendering contents of the table without table header as it is already printed
 		table = prepareNewTable()

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v1.5.2
-	k8s.io/kubernetes v1.30.2
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.17.5
 	sigs.k8s.io/scheduler-plugins v0.29.8

--- a/go.sum
+++ b/go.sum
@@ -729,8 +729,6 @@ k8s.io/kube-openapi v0.0.0-20240709000822-3c01b740850f h1:2sXuKesAYbRHxL3aE2PN6z
 k8s.io/kube-openapi v0.0.0-20240709000822-3c01b740850f/go.mod h1:UxDHUPsUwTOOxSU+oXURfFBcAS6JwiRXTYqYwfuGowc=
 k8s.io/kubectl v0.29.3 h1:RuwyyIU42MAISRIePaa8Q7A3U74Q9P4MoJbDFz9o3us=
 k8s.io/kubectl v0.29.3/go.mod h1:yCxfY1dbwgVdEt2zkJ6d5NNLOhhWgTyrqACIoFhpdd4=
-k8s.io/kubernetes v1.30.2 h1:11WhS78OYX/lnSy6TXxPO6Hk+E5K9ZNrEsk9JgMSX8I=
-k8s.io/kubernetes v1.30.2/go.mod h1:yPbIk3MhmhGigX62FLJm+CphNtjxqCvAIFQXup6RKS0=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 oras.land/oras-go v1.2.5 h1:XpYuAwAb0DfQsunIyMfeET92emK8km3W4yEzZvUbsTo=

--- a/pkg/util/interrupt.go
+++ b/pkg/util/interrupt.go
@@ -1,17 +1,23 @@
 /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+*/
+
+/*
+Original code from Kubernetes (https://github.com/kubernetes/kubernetes)
+https://github.com/kubernetes/kubernetes/blob/master/pkg/util/interrupt/interrupt.go
+Only naming has been changed from the original implementation.
 */
 
 package util
@@ -27,7 +33,7 @@ import (
 // supported platforms (linux, darwin, windows).
 var terminationSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
 
-// Handler guarantees execution of notifications after a critical section (the function passed
+// InterruptHandler Handler guarantees execution of notifications after a critical section (the function passed
 // to a Run method), even in the presence of process termination. It guarantees exactly once
 // invocation of the provided notify functions.
 type InterruptHandler struct {
@@ -36,7 +42,7 @@ type InterruptHandler struct {
 	once   sync.Once
 }
 
-// New creates a new handler that guarantees all notify functions are run after the critical
+// NewInterruptHandler New creates a new handler that guarantees all notify functions are run after the critical
 // section exits (or is interrupted by the OS), then invokes the final handler. If no final
 // handler is specified, the default final is `os.Exit(1)`. A handler can only be used for
 // one critical section.

--- a/pkg/util/interrupt.go
+++ b/pkg/util/interrupt.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// terminationSignals are signals that cause the program to exit in the
+// supported platforms (linux, darwin, windows).
+var terminationSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
+
+// Handler guarantees execution of notifications after a critical section (the function passed
+// to a Run method), even in the presence of process termination. It guarantees exactly once
+// invocation of the provided notify functions.
+type InterruptHandler struct {
+	notify []func()
+	final  func(os.Signal)
+	once   sync.Once
+}
+
+// New creates a new handler that guarantees all notify functions are run after the critical
+// section exits (or is interrupted by the OS), then invokes the final handler. If no final
+// handler is specified, the default final is `os.Exit(1)`. A handler can only be used for
+// one critical section.
+func NewInterruptHandler(final func(os.Signal), notify ...func()) *InterruptHandler {
+	return &InterruptHandler{
+		final:  final,
+		notify: notify,
+	}
+}
+
+// Close executes all the notification handlers if they have not yet been executed.
+func (h *InterruptHandler) Close() {
+	h.once.Do(func() {
+		for _, fn := range h.notify {
+			fn()
+		}
+	})
+}
+
+// Signal is called when an os.Signal is received, and guarantees that all notifications
+// are executed, then the final handler is executed. This function should only be called once
+// per Handler instance.
+func (h *InterruptHandler) Signal(s os.Signal) {
+	h.once.Do(func() {
+		for _, fn := range h.notify {
+			fn()
+		}
+		if h.final == nil {
+			os.Exit(1)
+		}
+		h.final(s)
+	})
+}
+
+// Run ensures that any notifications are invoked after the provided fn exits (even if the
+// process is interrupted by an OS termination signal). Notifications are only invoked once
+// per Handler instance, so calling Run more than once will not behave as the user expects.
+func (h *InterruptHandler) Run(fn func() error) error {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, terminationSignals...)
+	defer func() {
+		signal.Stop(ch)
+		close(ch)
+	}()
+	go func() {
+		sig, ok := <-ch
+		if !ok {
+			return
+		}
+		h.Signal(sig)
+	}()
+	defer h.Close()
+	return fn()
+}


### PR DESCRIPTION
## Purpose of this PR

* Remove dependency on `k8s.io/kubernetes` by bringing the interrupt handler structure into the repo. 
* `k8s.io/kubernretes` is not intended to be used by any external projects, causes headaches when trying to upgrade `k8s.io` dependencies and requires `replace` directives in the `go.mod`.

https://github.com/kubernetes/kubernetes/issues/79384

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.