### PR TITLE
fix RBAC error in helm charts 

### DIFF
--- a/charts/spark-operator-chart/templates/controller/rbac.yaml
+++ b/charts/spark-operator-chart/templates/controller/rbac.yaml
@@ -47,6 +47,24 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
+- apiGroups:
+    - sparkoperator.k8s.io
+  resources:
+    - sparkapplications
+    - scheduledsparkapplications
+    - sparkapplications/status
+    - scheduledsparkapplications/status
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
+    - patch
+- apiGroups: [""]
+  resources: ["pods","pod/status","services","endpoints","configmaps",]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 {{- if not .Values.spark.jobNamespaces | or (has "" .Values.spark.jobNamespaces) }}
 {{ include "spark-operator.controller.policyRules" . }}
 {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

fix RBAC error

**Proposed changes:**

add more resource in clusterrole of spark-operator-controller

## Change Category



- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Errors are below


crd needed
```plain text

2025-01-22T11:10:30.384Z        ERROR   controller/controller.go:329    Reconciler error        {"controller": "spark-application-controller", "namespace": "basemind-test", "name": "test-spark", "reconcileID": "841930ad-7ade-46e0-97d0-0b16cd099f3b", "error": "sparkapplications.sparkoperator.k8s.io \"test-spark\" is forbidden: User \"system:serviceaccount:spark:spark-operator-controller\" cannot update resource \"sparkapplications/status\" in API group \"sparkoperator.k8s.io\" in the namespace \"basemind-test\""}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:227
```
```plaintext
25/01/22 11:14:40 INFO KerberosConfDriverFeatureStep: You have not specified a krb5.conf file locally or via a ConfigMap. Make sure that you have the krb5.conf locally on the driver image.
Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://10.68.0.1:443/api/v1/namespaces/basemind-test/services/test-spark-64f718948db8b569-driver-svc?fieldManager=fabric8&force=true. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "test-spark-64f718948db8b569-driver-svc" is forbidden: User "system:serviceaccount:spark:spark-operator-controller" cannot patch resource "services" in API group "" in the namespace "basemind-test".
```
pod get needed
```plaintext
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/api/v1/namespaces/default/pods/test-spark-driver. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. pods "test-spark-driver" is forbidden: User "system:serviceaccount:default:spark" cannot get resource "pods" in API group "" in the namespace "default".
        at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:238)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:518)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:535)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleGet(OperationSupport.java:478)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handleGet(BaseOperation.java:741)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.requireFromServer(BaseOperation.java:185)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.get(BaseOperation.java:141)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.get(BaseOperation.java:92)
        at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$driverPod$1(ExecutorPodsAllocator.scala:96)
        at scala.Option.map(Option.scala:230)
        at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.<init>(ExecutorPodsAllocator.scala:94)
        ... 21 more
```
cm patch needed
```plaintext
25/01/22 11:25:26 INFO KerberosConfDriverFeatureStep: You have not specified a krb5.conf file locally or via a ConfigMap. Make sure that you have the krb5.conf locally on the driver image.
Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://10.68.0.1:443/api/v1/namespaces/basemind-test/configmaps/spark-drv-17401d948dc29240-conf-map?fieldManager=fabric8&force=true. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. configmaps "spark-drv-17401d948dc29240-conf-map" is forbidden: User "system:serviceaccount:spark:spark-operator-controller" cannot patch resource "configmaps" in API group "" in the namespace "basemind-test".
        at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:238)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:518)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:535)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handlePatch(OperationSupport.java:430)
        at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handlePatch(OperationSupport.java:408)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handlePatch(BaseOperation.java:713)
        at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.lambda$patch$2(HasMetadataOperation.java:232)
        at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.patch(HasMetadataOperation.java:237)
        at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.patch(HasMetadataOperation.java:252)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.serverSideApply(BaseOperation.java:1132)
        at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.serverSideApply(BaseOperation.java:92)
        at io.fabric8.kubernetes.client.extension.ResourceAdapter.serverSideApply(ResourceAdapter.java:325)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
        at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
        at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source)
        at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.performOperation(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:294)
        at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.serverSideApply(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:324)
        at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.serverSideApply(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:55)
        at org.apache.spark.deploy.k8s.submit.Client.run(KubernetesClientApplication.scala:176)
        at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.$anonfun$run$6(KubernetesClientApplication.scala:256)
        at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.$anonfun$run$6$adapted(KubernetesClientApplication.scala:250)
        at org.apache.spark.util.SparkErrorUtils.tryWithResource(SparkErrorUtils.scala:48)
        at org.apache.spark.util.SparkErrorUtils.tryWithResource$(SparkErrorUtils.scala:46)
        at org.apache.spark.util.Utils$.tryWithResource(Utils.scala:94)
        at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.run(KubernetesClientApplication.scala:250)
        at org.apache.spark.deploy.k8s.submit.KubernetesClientApplication.start(KubernetesClientApplication.scala:223)
        at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
        at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
        at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
        at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
        at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://10.68.0.1:443/api/v1/namespaces/basemind-test/configmaps/spark-drv-17401d948dc29240-conf-map?fieldManager=fabric8&force=true. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. configmaps "spark-drv-17401d948dc29240-conf-map" is forbidden: User "system:serviceaccount:spark:spark-operator-controller" cannot patch resource "configmaps" in API group "" in the namespace "basemind-test".
```
service patch needed
```plaintext
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: https://10.68.0.1:443/api/v1/namespaces/basemind-test/services/test-spark-64f718948db8b569-driver-svc?fieldManager=fabric8&force=true. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "test-spark-64f718948db8b569-driver-svc" is forbidden: User "system:serviceaccount:spark:spark-operator-controller" cannot patch resource "services" in API group "" in the namespace "basemind-test".
  at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:671)
  at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:651)
  at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.assertResponseCode(OperationSupport.java:597)
  at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.lambda$handleResponse$0(OperationSupport.java:560)
  at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
  at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$10(StandardHttpClient.java:140)
  at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
  at io.fabric8.kubernetes.client.http.ByteArrayBodyHandler.onBodyDone(ByteArrayBodyHandler.java:52)
  at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
  at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
  at io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl$OkHttpAsyncBody.doConsume(OkHttpClientImpl.java:137)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
  at java.base/java.lang.Thread.run(Unknown Source)
```
## Checklist



- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
