### PR TITLE
implement RuntimeClassName in SparkPodSpec

### DIFF
--- a/api/v1beta2/sparkapplication_types.go
+++ b/api/v1beta2/sparkapplication_types.go
@@ -508,6 +508,9 @@ type SparkPodSpec struct {
 	// ShareProcessNamespace settings for the pod, following the Kubernetes specifications.
 	// +optional
 	ShareProcessNamespace *bool `json:"shareProcessNamespace,omitempty"`
+	// RuntimeClassName settings for the pod, following the Kubernetes specifications.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 }
 
 // DriverSpec is specification of the driver.

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3402,6 +3402,10 @@ spec:
                         description: ShareProcessNamespace settings for the pod, following
                           the Kubernetes specifications.
                         type: boolean
+                      runtimeClassName:
+                        description: RuntimeClassName settings for the pod, following
+                          the Kubernetes specifications.
+                        type: string
                       sidecars:
                         description: Sidecars is a list of sidecar containers that
                           run along side the main Spark container.
@@ -8166,6 +8170,10 @@ spec:
                         description: ShareProcessNamespace settings for the pod, following
                           the Kubernetes specifications.
                         type: boolean
+                      runtimeClassName:
+                        description: RuntimeClassName settings for the pod, following
+                          the Kubernetes specifications.
+                        type: string
                       sidecars:
                         description: Sidecars is a list of sidecar containers that
                           run along side the main Spark container.

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3350,6 +3350,10 @@ spec:
                     description: ShareProcessNamespace settings for the pod, following
                       the Kubernetes specifications.
                     type: boolean
+                  runtimeClassName:
+                    description: RuntimeClassName settings for the pod, following
+                      the Kubernetes specifications.
+                    type: string
                   sidecars:
                     description: Sidecars is a list of sidecar containers that run
                       along side the main Spark container.
@@ -8084,6 +8088,10 @@ spec:
                     description: ShareProcessNamespace settings for the pod, following
                       the Kubernetes specifications.
                     type: boolean
+                  runtimeClassName:
+                    description: RuntimeClassName settings for the pod, following
+                      the Kubernetes specifications.
+                    type: string
                   sidecars:
                     description: Sidecars is a list of sidecar containers that run
                       along side the main Spark container.

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3402,6 +3402,10 @@ spec:
                         description: ShareProcessNamespace settings for the pod, following
                           the Kubernetes specifications.
                         type: boolean
+                      runtimeClassName:
+                        description: RuntimeClassName settings for the pod, following
+                          the Kubernetes specifications.
+                        type: string
                       sidecars:
                         description: Sidecars is a list of sidecar containers that
                           run along side the main Spark container.
@@ -8166,6 +8170,10 @@ spec:
                         description: ShareProcessNamespace settings for the pod, following
                           the Kubernetes specifications.
                         type: boolean
+                      runtimeClassName:
+                        description: RuntimeClassName settings for the pod, following
+                          the Kubernetes specifications.
+                        type: string
                       sidecars:
                         description: Sidecars is a list of sidecar containers that
                           run along side the main Spark container.

--- a/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3350,6 +3350,10 @@ spec:
                     description: ShareProcessNamespace settings for the pod, following
                       the Kubernetes specifications.
                     type: boolean
+                  runtimeClassName:
+                    description: RuntimeClassName settings for the pod, following
+                      the Kubernetes specifications.
+                    type: string
                   sidecars:
                     description: Sidecars is a list of sidecar containers that run
                       along side the main Spark container.
@@ -8084,6 +8088,10 @@ spec:
                     description: ShareProcessNamespace settings for the pod, following
                       the Kubernetes specifications.
                     type: boolean
+                  runtimeClassName:
+                    description: RuntimeClassName settings for the pod, following
+                      the Kubernetes specifications.
+                    type: string
                   sidecars:
                     description: Sidecars is a list of sidecar containers that run
                       along side the main Spark container.

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -3223,6 +3223,18 @@ bool
 <p>ShareProcessNamespace settings for the pod, following the Kubernetes specifications.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>runtimeClassName</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RuntimeClassName settings for the pod, following the Kubernetes specifications.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sparkoperator.k8s.io/v1beta2.SparkUIConfiguration">SparkUIConfiguration

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -130,6 +130,7 @@ func mutateSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
 		addTerminationGracePeriodSeconds,
 		addPodLifeCycleConfig,
 		addShareProcessNamespace,
+		addRuntimeClass,
 	}
 
 	for _, option := range options {
@@ -702,6 +703,22 @@ func addShareProcessNamespace(pod *corev1.Pod, app *v1beta2.SparkApplication) er
 	}
 
 	pod.Spec.ShareProcessNamespace = shareProcessNamespace
+	return nil
+}
+
+func addRuntimeClass(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
+	var runtimeClass *string
+	if util.IsDriverPod(pod) {
+		runtimeClass = app.Spec.Driver.RuntimeClassName
+	}
+	if util.IsExecutorPod(pod) {
+		runtimeClass = app.Spec.Executor.RuntimeClassName
+	}
+
+	if runtimeClass == nil {
+		return nil
+	}
+	pod.Spec.RuntimeClassName = runtimeClass
 	return nil
 }
 


### PR DESCRIPTION
Added support to set RuntimeClassName in SparkPodSpec.

This is useful when we want to use a different Kubernetes RuntimeClassName depending on whether the Spark pods would be running on CPU vs GPU VMs.
