### PR TITLE
fix make deploy and install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ kind-delete-cluster: kind ## Delete the created kind cluster.
 
 .PHONY: install
 install-crd: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) replace -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) create -f - 2>/dev/null || $(KUSTOMIZE) build config/crd | $(KUBECTL) replace -f -
 
 .PHONY: uninstall
 uninstall-crd: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,9 @@ uninstall-crd: manifests kustomize ## Uninstall CRDs from the K8s cluster specif
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: helm manifests update-crd ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(HELM) install -f charts/spark-operator-chart/ci/ci-values.yaml spark-operator ./charts/spark-operator-chart/
+deploy: IMAGE_TAG=local
+deploy: helm manifests update-crd kind-load-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	$(HELM) upgrade --install -f charts/spark-operator-chart/ci/ci-values.yaml spark-operator ./charts/spark-operator-chart/
 
 .PHONY: undeploy
 undeploy: helm ## Uninstall spark-operator

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ LOCALBIN ?= $(shell pwd)/bin
 KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 KIND_VERSION ?= v0.23.0
-KIND_K8S_VERSION ?= v1.29.3
+KIND_K8S_VERSION ?= v1.29.12
 ENVTEST_VERSION ?= release-0.18
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.29.3
@@ -268,20 +268,19 @@ kind-delete-cluster: kind ## Delete the created kind cluster.
 
 .PHONY: install
 install-crd: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) replace -f -
 
 .PHONY: uninstall
 uninstall-crd: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+deploy: helm manifests update-crd ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	$(HELM) install -f charts/spark-operator-chart/ci/ci-values.yaml spark-operator ./charts/spark-operator-chart/
 
 .PHONY: undeploy
-undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+undeploy: helm ## Uninstall spark-operator
+	$(HELM) uninstall spark-operator
 
 ##@ Dependencies
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Currently `make deploy` and `make install-crd` are broken. This PR aims to fix it.

fixes: #2386 

**Proposed changes:**

- For `make deploy`, I followed the e2e-test logic where it deploys using the helm chart directory and the value file for CI.
- For `make install-crd`, I am using `kubectl replace` instead of apply to avoid overloading annotations.
- I've also updated the default kind node image to `v1.29.12` because `v1.29.3` [does not exist anymore](https://hub.docker.com/r/kindest/node/tags?name=1.29.3).

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

Example outputs.

```
$ make deploy
NAME: spark-operator
LAST DEPLOYED: Tue Jan 28 21:02:43 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
$ k get pods
NAME                                         READY   STATUS    RESTARTS   AGE
spark-operator-controller-86978864c7-nvdv5   1/1     Running   0          3m48s
spark-operator-webhook-6c477b69d6-gb8kj      1/1     Running   0          3m48s
```

```
$ make undeploy
release "spark-operator" uninstalled
```
