### PR TITLE
Make app.Spec.Driver.Image and app.Spec.Image optional

### DIFF
--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -320,8 +320,6 @@ func driverConfOption(app *v1beta2.SparkApplication) ([]string, error) {
 	} else if app.Spec.Image != nil && *app.Spec.Image != "" {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%s", common.SparkKubernetesDriverContainerImage, *app.Spec.Image))
-	} else {
-		return nil, fmt.Errorf("driver container image is not specified")
 	}
 
 	if app.Spec.Driver.Cores != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**
- Make `app.Spec.Driver.Image` and `app.Spec.Image` optional as defined in the api-docs. This is the behavior in Spark Operator V1.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
