### PR TITLE
Support non-standard Spark container names

### DIFF
--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -714,6 +714,7 @@ func findContainer(pod *corev1.Pod) int {
 		candidateContainerNames = append(candidateContainerNames, common.SparkExecutorContainerName, common.Spark3DefaultExecutorContainerName)
 	}
 
+	// return -1 if the pod is not a Driver or an Executor pod
 	if len(candidateContainerNames) == 0 {
 		return -1
 	}
@@ -725,7 +726,8 @@ func findContainer(pod *corev1.Pod) int {
 			}
 		}
 	}
-	return -1
+	// if no containers match the candidateContainerNames, assume the first container is the spark container.
+	return 0
 }
 
 func hasContainer(pod *corev1.Pod, container *corev1.Container) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**
- If using a non-standard container name for Spark driver or executor container, assume that the first container in the list is the Spark container, which is what [Spark assumes](https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template). See **Rationale** section for further explanation.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->
Current implementation only supports standard Spark container names. Driver container name must be `spark-kubernetes-driver` and executor container name must be `spark-kubernetes-executor` or `executor`. However, Pod template files can define multiple containers, and you can use the spark properties spark.kubernetes.driver.podTemplateContainerName and spark.kubernetes.executor.podTemplateContainerName to indicate which container should be used as a basis for the driver or executor. If not specified, or if the container name is not valid, Spark will assume that the first container in the list will be the driver or executor container [[Source](https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template)].

`podTemplateContainerName` config could be specified via `Spec.SparkConf` or in `spark-defaults.conf`, and in the webhook it's hard to determine if `podTemplateContainerName` is set via any one of the possible Spark configuration methods, so in the Webhook it is better to assume that if standard Spark container name is not found, the first container in the list is the driver or executor container.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
