### PR TITLE
specify branch name in chart testing

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -208,7 +208,7 @@ jobs:
         run: |
           docker build -t docker.io/kubeflow/spark-operator:local .
           minikube image load docker.io/kubeflow/spark-operator:local
-          ct install
+          ct install --target-branch ${{ steps.get_branch.outputs.BRANCH }}
 
   e2e-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Integration tests for helm chart are failing after chart-testitng-action was bumped to 2.7.0: https://github.com/kubeflow/spark-operator/pull/2391

This introduced a breaking change from chart-testing: 
- https://github.com/helm/chart-testing-action/releases/tag/v2.7.0
- https://github.com/helm/chart-testing/releases/tag/v3.11.0

Tests fail with `targetBranch 'origin/main' does not exist`.
See: https://github.com/kubeflow/spark-operator/actions/runs/13597275163/job/38016877250

Tested the change introduced here in my own repository. They do work: 
- https://github.com/nabuskey/spark-operator/commit/942d590d86962f2df29a0e859a9fb891ff8fa105
- https://github.com/nabuskey/spark-operator/pull/1

**Proposed changes:**

- Specify the branch name explicitly in the `ct install` command.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

See above.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
