### PR TITLE
Bugfix/lifecycle on executor spark3

### DIFF
--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -1742,77 +1742,90 @@ func TestPatchSparkPod_GracePeriodSeconds(t *testing.T) {
 }
 
 func TestPatchSparkPod_Lifecycle(t *testing.T) {
-	preStopTest := &corev1.ExecAction{
-		Command: []string{"/bin/sh", "-c", "echo Hello from the pre stop handler > /usr/share/message"},
-	}
-	postStartTest := &corev1.ExecAction{
-		Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
-	}
-	app := &v1beta2.SparkApplication{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "spark-test",
-			UID:  "spark-test-1",
+	testcases := []struct{
+		ExecutorContainerName string
+	}{
+		{
+			ExecutorContainerName: common.SparkExecutorContainerName,
 		},
-		Spec: v1beta2.SparkApplicationSpec{
-			Driver: v1beta2.DriverSpec{
-				Lifecycle: &corev1.Lifecycle{
-					PreStop: &corev1.LifecycleHandler{Exec: preStopTest},
-				},
-			},
-			Executor: v1beta2.ExecutorSpec{
-				Lifecycle: &corev1.Lifecycle{
-					PostStart: &corev1.LifecycleHandler{Exec: postStartTest},
-				},
-			},
+		{
+			ExecutorContainerName: common.Spark3DefaultExecutorContainerName,
 		},
 	}
 
-	driverPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "spark-driver",
-			Labels: map[string]string{
-				common.LabelSparkRole:               common.SparkRoleDriver,
-				common.LabelLaunchedBySparkOperator: "true",
+	for _, testCase := range testcases {
+		preStopTest := &corev1.ExecAction{
+			Command: []string{"/bin/sh", "-c", "echo Hello from the pre stop handler > /usr/share/message"},
+		}
+		postStartTest := &corev1.ExecAction{
+			Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
+		}
+		app := &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "spark-test",
+				UID:  "spark-test-1",
 			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  common.SparkDriverContainerName,
-					Image: "spark-driver:latest",
+			Spec: v1beta2.SparkApplicationSpec{
+				Driver: v1beta2.DriverSpec{
+					Lifecycle: &corev1.Lifecycle{
+						PreStop: &corev1.LifecycleHandler{Exec: preStopTest},
+					},
+				},
+				Executor: v1beta2.ExecutorSpec{
+					Lifecycle: &corev1.Lifecycle{
+						PostStart: &corev1.LifecycleHandler{Exec: postStartTest},
+					},
 				},
 			},
-		},
-	}
-
-	executorPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "spark-executor",
-			Labels: map[string]string{
-				common.LabelSparkRole:               common.SparkRoleExecutor,
-				common.LabelLaunchedBySparkOperator: "true",
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  common.SparkExecutorContainerName,
-					Image: "spark-executor:latest",
+		}
+	
+		driverPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "spark-driver",
+				Labels: map[string]string{
+					common.LabelSparkRole:               common.SparkRoleDriver,
+					common.LabelLaunchedBySparkOperator: "true",
 				},
 			},
-		},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  common.SparkDriverContainerName,
+						Image: "spark-driver:latest",
+					},
+				},
+			},
+		}
+	
+		executorPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "spark-executor",
+				Labels: map[string]string{
+					common.LabelSparkRole:               common.SparkRoleExecutor,
+					common.LabelLaunchedBySparkOperator: "true",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  testCase.ExecutorContainerName,
+						Image: "spark-executor:latest",
+					},
+				},
+			},
+		}
+	
+		modifiedDriverPod, err := getModifiedPod(driverPod, app)
+		if err != nil {
+			t.Fatal(err)
+		}
+		modifiedExecutorPod, err := getModifiedPod(executorPod, app)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, preStopTest, modifiedDriverPod.Spec.Containers[0].Lifecycle.PreStop.Exec)
+		assert.Equal(t, postStartTest, modifiedExecutorPod.Spec.Containers[0].Lifecycle.PostStart.Exec)
 	}
-
-	modifiedDriverPod, err := getModifiedPod(driverPod, app)
-	if err != nil {
-		t.Fatal(err)
-	}
-	modifiedExecutorPod, err := getModifiedPod(executorPod, app)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, preStopTest, modifiedDriverPod.Spec.Containers[0].Lifecycle.PreStop.Exec)
-	assert.Equal(t, postStartTest, modifiedExecutorPod.Spec.Containers[0].Lifecycle.PostStart.Exec)
 }
 
 func getModifiedPod(old *corev1.Pod, app *v1beta2.SparkApplication) (*corev1.Pod, error) {


### PR DESCRIPTION
Before this fix if you have  a Spark 3.x spec where the executor has a lifecycle then the webhook will fail to identify the correct container. As described in issue [2457](https://github.com/kubeflow/spark-operator/issues/2457)

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Solve the bug as detailed in https://github.com/kubeflow/spark-operator/issues/2457 where spark3 executors are blocked if they have a lifecycle 

**Proposed changes:**

- re-use code to identify the container in the pod

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly => Not applicable ?
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
