### PR TITLE
Add timeZone to ScheduledSparkApplication

### DIFF
--- a/api/v1beta2/scheduledsparkapplication_types.go
+++ b/api/v1beta2/scheduledsparkapplication_types.go
@@ -34,6 +34,12 @@ type ScheduledSparkApplicationSpec struct {
 
 	// Schedule is a cron schedule on which the application should run.
 	Schedule string `json:"schedule"`
+	// TimeZone is the time zone in which the cron schedule will be interpreted in.
+	// This value is passed to time.LoadLocation, so it must be either "Local", "UTC",
+	// or a valid IANA location name e.g. "America/New_York".
+	// +optional
+	// Defaults to "Local".
+	TimeZone string `json:"timeZone"`
 	// Template is a template from which SparkApplication instances can be created.
 	Template SparkApplicationSpec `json:"template"`
 	// Suspend is a flag telling the controller to suspend subsequent runs of the application if set to true.
@@ -80,6 +86,7 @@ type ScheduledSparkApplicationStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=scheduledsparkapp,singular=scheduledsparkapplication
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=.spec.schedule,name=Schedule,type=string
+// +kubebuilder:printcolumn:JSONPath=.spec.timeZone,name=TimeZone,type=string
 // +kubebuilder:printcolumn:JSONPath=.spec.suspend,name=Suspend,type=string
 // +kubebuilder:printcolumn:JSONPath=.status.lastRun,name=Last Run,type=date
 // +kubebuilder:printcolumn:JSONPath=.status.lastRunName,name=Last Run Name,type=string

--- a/api/v1beta2/scheduledsparkapplication_types.go
+++ b/api/v1beta2/scheduledsparkapplication_types.go
@@ -39,7 +39,7 @@ type ScheduledSparkApplicationSpec struct {
 	// or a valid IANA location name e.g. "America/New_York".
 	// +optional
 	// Defaults to "Local".
-	TimeZone string `json:"timeZone"`
+	TimeZone string `json:"timeZone,omitempty"`
 	// Template is a template from which SparkApplication instances can be created.
 	Template SparkApplicationSpec `json:"template"`
 	// Suspend is a flag telling the controller to suspend subsequent runs of the application if set to true.

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .spec.schedule
       name: Schedule
       type: string
+    - jsonPath: .spec.timeZone
+      name: TimeZone
+      type: string
     - jsonPath: .spec.suspend
       name: Suspend
       type: string
@@ -12384,6 +12387,13 @@ spec:
                 - sparkVersion
                 - type
                 type: object
+              timeZone:
+                description: |-
+                  TimeZone is the time zone in which the cron schedule will be interpreted in.
+                  This value is passed to time.LoadLocation, so it must be either "Local", "UTC",
+                  or a valid IANA location name e.g. "America/New_York".
+                  Defaults to "Local".
+                type: string
             required:
             - schedule
             - template

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .spec.schedule
       name: Schedule
       type: string
+    - jsonPath: .spec.timeZone
+      name: TimeZone
+      type: string
     - jsonPath: .spec.suspend
       name: Suspend
       type: string
@@ -12384,6 +12387,13 @@ spec:
                 - sparkVersion
                 - type
                 type: object
+              timeZone:
+                description: |-
+                  TimeZone is the time zone in which the cron schedule will be interpreted in.
+                  This value is passed to time.LoadLocation, so it must be either "Local", "UTC",
+                  or a valid IANA location name e.g. "America/New_York".
+                  Defaults to "Local".
+                type: string
             required:
             - schedule
             - template

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1412,6 +1412,21 @@ string
 </tr>
 <tr>
 <td>
+<code>timeZone</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TimeZone is the time zone in which the cron schedule will be interpreted in.
+This value is passed to time.LoadLocation, so it must be either &ldquo;Local&rdquo;, &ldquo;UTC&rdquo;,
+or a valid IANA location name e.g. &ldquo;America/New_York&rdquo;.
+Defaults to &ldquo;Local&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>template</code><br/>
 <em>
 <a href="#sparkoperator.k8s.io/v1beta2.SparkApplicationSpec">
@@ -1517,6 +1532,21 @@ string
 </td>
 <td>
 <p>Schedule is a cron schedule on which the application should run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeZone</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TimeZone is the time zone in which the cron schedule will be interpreted in.
+This value is passed to time.LoadLocation, so it must be either &ldquo;Local&rdquo;, &ldquo;UTC&rdquo;,
+or a valid IANA location name e.g. &ldquo;America/New_York&rdquo;.
+Defaults to &ldquo;Local&rdquo;.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Purpose of this PR

* Allow a timezone to be specified in a `ScheduledSparkApplication`
* Explicitly validate the timezone for better user feedback
* Ensure backwards compatibility if any users are relying on `CRON_TZ=` or `TZ=` prefixes in the schedule field being parsed by `robfig/cron`

Close https://github.com/kubeflow/spark-operator/issues/1712 
Close https://github.com/kubeflow/spark-operator/issues/2328

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X] I have conducted a self-review of my own code.
- [X] I have updated documentation accordingly.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] Existing unit tests pass locally with my changes.