### PR TITLE
Enable the override of MemoryLimit through webhook

### DIFF
--- a/api/v1beta2/sparkapplication_types.go
+++ b/api/v1beta2/sparkapplication_types.go
@@ -427,6 +427,9 @@ type SparkPodSpec struct {
 	// Memory is the amount of memory to request for the pod.
 	// +optional
 	Memory *string `json:"memory,omitempty"`
+	// MemoryLimit overrides the memory limit of the pod.
+	// +optional
+	MemoryLimit *string `json:"memoryLimit,omitempty"`
 	// MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.
 	// +optional
 	MemoryOverhead *string `json:"memoryOverhead,omitempty"`

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -896,6 +896,11 @@ func (in *SparkPodSpec) DeepCopyInto(out *SparkPodSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MemoryLimit != nil {
+		in, out := &in.MemoryLimit, &out.MemoryLimit
+		*out = new(string)
+		**out = **in
+	}
 	if in.MemoryOverhead != nil {
 		in, out := &in.MemoryOverhead, &out.MemoryOverhead
 		*out = new(string)

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3118,6 +3118,9 @@ spec:
                         description: Memory is the amount of memory to request for
                           the pod.
                         type: string
+                      memoryLimit:
+                        description: MemoryLimit overrides the memory limit of the pod.
+                        type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory
                           to allocate in cluster mode, in MiB unless otherwise specified.
@@ -8241,6 +8244,9 @@ spec:
                       memory:
                         description: Memory is the amount of memory to request for
                           the pod.
+                        type: string
+                      memoryLimit:
+                        description: MemoryLimit overrides the memory limit of the pod.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3119,7 +3119,8 @@ spec:
                           the pod.
                         type: string
                       memoryLimit:
-                        description: MemoryLimit overrides the memory limit of the pod.
+                        description: MemoryLimit overrides the memory limit of the
+                          pod.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory
@@ -8246,7 +8247,8 @@ spec:
                           the pod.
                         type: string
                       memoryLimit:
-                        description: MemoryLimit overrides the memory limit of the pod.
+                        description: MemoryLimit overrides the memory limit of the
+                          pod.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3071,6 +3071,9 @@ spec:
                     description: Memory is the amount of memory to request for the
                       pod.
                     type: string
+                  memoryLimit:
+                    description: MemoryLimit overrides the memory limit of the pod.
+                    type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to
                       allocate in cluster mode, in MiB unless otherwise specified.
@@ -8171,6 +8174,9 @@ spec:
                   memory:
                     description: Memory is the amount of memory to request for the
                       pod.
+                    type: string
+                  memoryLimit:
+                    description: MemoryLimit overrides the memory limit of the pod.
                     type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3118,6 +3118,9 @@ spec:
                         description: Memory is the amount of memory to request for
                           the pod.
                         type: string
+                      memoryLimit:
+                        description: MemoryLimit overrides the memory limit of the pod.
+                        type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory
                           to allocate in cluster mode, in MiB unless otherwise specified.
@@ -8241,6 +8244,9 @@ spec:
                       memory:
                         description: Memory is the amount of memory to request for
                           the pod.
+                        type: string
+                      memoryLimit:
+                        description: MemoryLimit overrides the memory limit of the pod.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3119,7 +3119,8 @@ spec:
                           the pod.
                         type: string
                       memoryLimit:
-                        description: MemoryLimit overrides the memory limit of the pod.
+                        description: MemoryLimit overrides the memory limit of the
+                          pod.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory
@@ -8246,7 +8247,8 @@ spec:
                           the pod.
                         type: string
                       memoryLimit:
-                        description: MemoryLimit overrides the memory limit of the pod.
+                        description: MemoryLimit overrides the memory limit of the
+                          pod.
                         type: string
                       memoryOverhead:
                         description: MemoryOverhead is the amount of off-heap memory

--- a/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3071,6 +3071,9 @@ spec:
                     description: Memory is the amount of memory to request for the
                       pod.
                     type: string
+                  memoryLimit:
+                    description: MemoryLimit overrides the memory limit of the pod.
+                    type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to
                       allocate in cluster mode, in MiB unless otherwise specified.
@@ -8171,6 +8174,9 @@ spec:
                   memory:
                     description: Memory is the amount of memory to request for the
                       pod.
+                    type: string
+                  memoryLimit:
+                    description: MemoryLimit overrides the memory limit of the pod.
                     type: string
                   memoryOverhead:
                     description: MemoryOverhead is the amount of off-heap memory to

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -2880,6 +2880,18 @@ string
 </tr>
 <tr>
 <td>
+<code>memoryLimit</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MemoryLimit overrides the memory limit of the pod.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>memoryOverhead</code><br/>
 <em>
 string

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -97,6 +97,40 @@ func (d *SparkPodDefaulter) Default(ctx context.Context, obj runtime.Object) err
 	return nil
 }
 
+func addMemoryLimit(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
+	i := findContainer(pod)
+	if i < 0 {
+		return fmt.Errorf("failed to add memory limit as Spark container was not found in pod %s", pod.Name)
+	}
+
+	var memoryLimit *string
+	if util.IsDriverPod(pod) {
+		memoryLimit = app.Spec.Driver.MemoryLimit
+	} else if util.IsExecutorPod(pod) {
+		memoryLimit = app.Spec.Executor.MemoryLimit
+	}
+
+	if memoryLimit == nil {
+		return nil
+	}
+
+	// Convert memory limit to a Kubernetes-style unit
+	limitQuantity, err := resource.ParseQuantity(util.ConvertJavaMemoryStringToK8sMemoryString(*memoryLimit))
+	if err != nil {
+		return fmt.Errorf("failed to parse memory limit %s: %v", *memoryLimit, err)
+	}
+
+	if pod.Spec.Containers[i].Resources.Limits == nil {
+		pod.Spec.Containers[i].Resources.Limits = corev1.ResourceList{}
+	}
+
+	// Apply the memory limit to the container's resources
+	logger.Info(fmt.Sprintf("Adding memory limit %s to container in pod %s", *memoryLimit, pod.Name))
+	pod.Spec.Containers[i].Resources.Limits[corev1.ResourceMemory] = limitQuantity
+	logger.Info(fmt.Sprintf("Successfully added memory limit %s to container in pod %s", limitQuantity.String(), pod.Name))
+	return nil
+}
+
 func (d *SparkPodDefaulter) isSparkJobNamespace(ns string) bool {
 	return d.sparkJobNamespaces[metav1.NamespaceAll] || d.sparkJobNamespaces[ns]
 }
@@ -123,6 +157,7 @@ func mutateSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
 		addNodeSelectors,
 		addAffinity,
 		addTolerations,
+		addMemoryLimit,
 		addGPU,
 		addPrometheusConfig,
 		addContainerSecurityContext,

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -125,9 +125,8 @@ func addMemoryLimit(pod *corev1.Pod, app *v1beta2.SparkApplication) error {
 	}
 
 	// Apply the memory limit to the container's resources
-	logger.Info(fmt.Sprintf("Adding memory limit %s to container in pod %s", *memoryLimit, pod.Name))
 	pod.Spec.Containers[i].Resources.Limits[corev1.ResourceMemory] = limitQuantity
-	logger.Info(fmt.Sprintf("Successfully added memory limit %s to container in pod %s", limitQuantity.String(), pod.Name))
+	logger.V(1).Info("Added memory limit to Spark container in pod", "name", pod.Name, "namespace", pod.Namespace, "memoryLimit", limitQuantity.String())
 	return nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,6 +28,19 @@ import (
 	"github.com/kubeflow/spark-operator/pkg/common"
 )
 
+var unitMap = map[string]string{
+	"k":  "Ki",
+	"kb": "Ki",
+	"m":  "Mi",
+	"mb": "Mi",
+	"g":  "Gi",
+	"gb": "Gi",
+	"t":  "Ti",
+	"tb": "Ti",
+	"p":  "Pi",
+	"pb": "Pi",
+}
+
 func GetMasterURL() (string, error) {
 	kubernetesServiceHost := os.Getenv(common.EnvKubernetesServiceHost)
 	if kubernetesServiceHost == "" {
@@ -120,19 +133,6 @@ func WriteObjectToFile(obj interface{}, filePath string) error {
 }
 
 func ConvertJavaMemoryStringToK8sMemoryString(memory string) string {
-
-	unitMap := map[string]string{
-		"k":  "Ki",
-		"kb": "Ki",
-		"m":  "Mi",
-		"mb": "Mi",
-		"g":  "Gi",
-		"gb": "Gi",
-		"t":  "Ti",
-		"tb": "Ti",
-		"p":  "Pi",
-		"pb": "Pi",
-	}
 
 	for unit, k8sUnit := range unitMap {
 		if strings.HasSuffix(strings.ToLower(memory), unit) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -118,3 +118,28 @@ func WriteObjectToFile(obj interface{}, filePath string) error {
 
 	return nil
 }
+
+func ConvertJavaMemoryStringToK8sMemoryString(memory string) string {
+
+	unitMap := map[string]string{
+		"k":  "Ki",
+		"kb": "Ki",
+		"m":  "Mi",
+		"mb": "Mi",
+		"g":  "Gi",
+		"gb": "Gi",
+		"t":  "Ti",
+		"tb": "Ti",
+		"p":  "Pi",
+		"pb": "Pi",
+	}
+
+	for unit, k8sUnit := range unitMap {
+		if strings.HasSuffix(strings.ToLower(memory), unit) {
+			return strings.TrimSuffix(memory, unit) + k8sUnit
+		}
+	}
+
+	// return original memory value if no conversion is needed
+	return memory
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -201,3 +201,31 @@ spec:
 		Expect(os.Remove(file)).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("ConvertJavaMemoryStringToK8sMemoryString", func() {
+	It("Should return a memory converted in expected K8s unit", func() {
+
+		unitMap := map[string]string{
+			"k":  "Ki",
+			"kb": "Ki",
+			"m":  "Mi",
+			"mb": "Mi",
+			"g":  "Gi",
+			"gb": "Gi",
+			"t":  "Ti",
+			"tb": "Ti",
+			"p":  "Pi",
+			"pb": "Pi",
+			"Ki": "Ki",
+			"Mi": "Mi",
+			"Gi": "Gi",
+			"Ti": "Ti",
+			"Pi": "Pi",
+		}
+
+		for unit, response := range unitMap {
+			Expect(util.ConvertJavaMemoryStringToK8sMemoryString(unit)).To(Equal(response))
+		}
+
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

Add the ability to setup `memoryLimits` definition through webhook. 

The changes were originally part of the development of https://github.com/kubeflow/spark-operator/pull/2383 and https://github.com/kubeflow/spark-operator/pull/2389.
## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

This changes addresses the community most reacted issue https://github.com/kubeflow/spark-operator/issues/1489.

A few users have created their own custom version of either SparkOperator or Kubernetes Admission Controller to enable memoryLimits with a different value than memory requested.

It was first raised here https://github.com/kubeflow/spark-operator/pull/1990. The pull request 1990 contained two features: memoryLimits and queue boost. Since the second part was covered in another PR, the 1990 was closed and the memoryLimits was not merged in.



## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
