### PR TITLE
Changing image repo from docker.io to  ghcr.io

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -206,8 +206,8 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          docker build -t ghcr.io/kubeflow/spark-operator:local .
-          minikube image load ghcr.io/kubeflow/spark-operator:local
+          docker build -t ghcr.io/kubeflow/spark-operator/controller:local .
+          minikube image load ghcr.io/kubeflow/spark-operator/controller:local
           ct install --target-branch ${{ steps.get_branch.outputs.BRANCH }}
 
   e2e-test:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -206,8 +206,8 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          docker build -t docker.io/kubeflow/spark-operator:local .
-          minikube image load docker.io/kubeflow/spark-operator:local
+          docker build -t ghcr.io/kubeflow/spark-operator:local .
+          minikube image load ghcr.io/kubeflow/spark-operator:local
           ct install --target-branch ${{ steps.get_branch.outputs.BRANCH }}
 
   e2e-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   SEMVER_PATTERN: '^v([0-9]+)\.([0-9]+)\.([0-9]+)(-rc\.([0-9]+))?$'
   IMAGE_REGISTRY: ghcr.io
-  IMAGE_REPOSITORY: kubeflow/spark-operator
+  IMAGE_REPOSITORY: kubeflow/spark-operator/controller
 
 jobs:
   check-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -214,8 +214,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Login to container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.IMAGE_REGISTRY }} 
+          registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   SEMVER_PATTERN: '^v([0-9]+)\.([0-9]+)\.([0-9]+)(-rc\.([0-9]+))?$'
-  IMAGE_REGISTRY: docker.io
+  IMAGE_REGISTRY: ghcr.io
   IMAGE_REPOSITORY: kubeflow/spark-operator
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,9 +151,9 @@ jobs:
       - name: Login to container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.IMAGE_REGISTRY }} 
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ UNAME := `uname | tr '[:upper:]' '[:lower:]'`
 CONTAINER_TOOL ?= docker
 
 # Image URL to use all building/pushing image targets
-IMAGE_REGISTRY ?= docker.io
+IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPOSITORY ?= kubeflow/spark-operator
 IMAGE_TAG ?= $(VERSION)
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY):$(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CONTAINER_TOOL ?= docker
 
 # Image URL to use all building/pushing image targets
 IMAGE_REGISTRY ?= ghcr.io
-IMAGE_REPOSITORY ?= kubeflow/spark-operator
+IMAGE_REPOSITORY ?= kubeflow/spark-operator/controller
 IMAGE_TAG ?= $(VERSION)
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY):$(IMAGE_TAG)
 

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -79,7 +79,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | fullnameOverride | string | `""` | String to fully override release name. |
 | commonLabels | object | `{}` | Common labels to add to the resources. |
 | image.registry | string | `"ghcr.io"` | Image registry. |
-| image.repository | string | `"kubeflow/spark-operator"` | Image repository. |
+| image.repository | string | `"kubeflow/spark-operator/controller"` | Image repository. |
 | image.tag | string | If not set, the chart appVersion will be used. | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | image.pullSecrets | list | `[]` | Image pull secrets for private image registry. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -78,7 +78,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | nameOverride | string | `""` | String to partially override release name. |
 | fullnameOverride | string | `""` | String to fully override release name. |
 | commonLabels | object | `{}` | Common labels to add to the resources. |
-| image.registry | string | `"docker.io"` | Image registry. |
+| image.registry | string | `"ghcr.io"` | Image registry. |
 | image.repository | string | `"kubeflow/spark-operator"` | Image repository. |
 | image.tag | string | If not set, the chart appVersion will be used. | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Image registry.
   registry: ghcr.io
   # -- Image repository.
-  repository: kubeflow/spark-operator
+  repository: kubeflow/spark-operator/controller
   # -- Image tag.
   # @default -- If not set, the chart appVersion will be used.
   tag: ""

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -29,7 +29,7 @@ commonLabels: {}
 
 image:
   # -- Image registry.
-  registry: docker.io
+  registry: ghcr.io
   # -- Image repository.
   repository: kubeflow/spark-operator
   # -- Image tag.


### PR DESCRIPTION
## Purpose of this PR

As per the kubeflow wide initiative to migrate all images from docker.io to ghcr.io kubeflow/maniifests#3010 , I am am making the change to do the same. the sparkoperator repo specific issue is #2480 

**Proposed changes:**

- change  image registry to ghcr.io

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

This change is a part of Kubeflow wide initiative  kubeflow/maniifests#3010

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

Additional comments 
/closes #2480 