### PR TITLE
Deprecating sparkctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ build-operator: ## Build Spark operator.
 
 .PHONY: build-sparkctl
 build-sparkctl: ## Build sparkctl binary.
-	echo "⚠️ Warning: sparkctl is deprecated and no longer maintained. It will be removed in a future release."
+	echo "⚠️ Warning: sparkctl is deprecated and no longer maintained. It will be removed in a future release. Please use kubectl instead."
 	echo "Building sparkctl binary..."
 	CGO_ENABLED=0 go build -o $(SPARKCTL) -buildvcs=false cmd/sparkctl/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ build-operator: ## Build Spark operator.
 
 .PHONY: build-sparkctl
 build-sparkctl: ## Build sparkctl binary.
+	echo "⚠️ Warning: sparkctl is deprecated and no longer maintained. It will be removed in a future release."
 	echo "Building sparkctl binary..."
 	CGO_ENABLED=0 go build -o $(SPARKCTL) -buildvcs=false cmd/sparkctl/main.go
 

--- a/cmd/sparkctl/README.md
+++ b/cmd/sparkctl/README.md
@@ -1,4 +1,6 @@
 # sparkctl
+> ⚠️ **Deprecated:** `sparkctl` is no longer actively maintained and may be removed in a future release.  
+> We recommend using `kubectl` or other Kubernetes-native tools to manage `SparkApplication` resources.
 
 `sparkctl` is a command-line tool of the Spark Operator for creating, listing, checking status of, getting logs of, and deleting `SparkApplication`s. It can also do port forwarding from a local port to the Spark web UI port for accessing the Spark web UI on the driver. Each function is implemented as a sub-command of `sparkctl`.
 

--- a/cmd/sparkctl/main.go
+++ b/cmd/sparkctl/main.go
@@ -17,11 +17,15 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"os"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/kubeflow/spark-operator/cmd/sparkctl/app"
 )
 
 func main() {
+	fmt.Fprintln(os.Stderr, "⚠️ Warning: sparkctl is deprecated and no longer maintained. Use kubectl instead.")
 	app.Execute()
 }

--- a/cmd/sparkctl/main.go
+++ b/cmd/sparkctl/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubeflow/spark-operator/cmd/sparkctl/app"
 )
 
+// Deprecated: sparkctl is no longer maintained. Use kubectl or other tools instead.
 func main() {
 	fmt.Fprintln(os.Stderr, "⚠️ Warning: sparkctl is deprecated and no longer maintained. Use kubectl instead.")
 	app.Execute()


### PR DESCRIPTION
## Purpose of this PR

This  PR is to mark sparkCtl deprecated in preparation for #2465 



- mark sparkctl deprecated
- advice users to move to another alternative e.g. kubectl

## Change Category


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update



## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

