### PR TITLE
fix: add webhook cert validity checking

### DIFF
--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -18,6 +18,10 @@ package certificate_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -124,14 +128,16 @@ var _ = Describe("Certificate Provider", func() {
 			Name:      secretName,
 			Namespace: secretNamespace,
 		}
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: secretNamespace,
-			},
-		}
+		var secret *corev1.Secret
 
 		BeforeEach(func() {
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: secretNamespace,
+				},
+			}
+
 			By("Creating a new webhook secret with data populated")
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
@@ -170,6 +176,36 @@ var _ = Describe("Certificate Provider", func() {
 			serverCert, err := cp.ServerCert()
 			Expect(err).To(BeNil())
 			Expect(serverCert).To(Equal(secret.Data[common.ServerCertPem]))
+		})
+
+		It("Should generate a new certificate when validation fails", func() {
+			By("Creating a certificate with an expired NotAfter field")
+			Expect(k8sClient.Get(ctx, key, secret)).To(Succeed())
+			caKeyPem, _ := pem.Decode(secret.Data[common.CAKeyPem])
+			caCertPem, _ := pem.Decode(secret.Data[common.CACertPem])
+			serverKeyPem, _ := pem.Decode(secret.Data[common.ServerKeyPem])
+			serverCertPem, _ := pem.Decode(secret.Data[common.ServerCertPem])
+			caKey, _ := x509.ParsePKCS1PrivateKey(caKeyPem.Bytes)
+			caCert, _ := x509.ParseCertificate(caCertPem.Bytes)
+			serverKey, _ := x509.ParsePKCS1PrivateKey(serverKeyPem.Bytes)
+			serverCert, _ := x509.ParseCertificate(serverCertPem.Bytes)
+
+			serverCert.NotAfter = time.Now().AddDate(0, 0, -1)
+			certBytes, err := x509.CreateCertificate(rand.Reader, serverCert, caCert, serverKey.Public(), caKey)
+			Expect(err).To(BeNil())
+			expiredPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+
+			secret.Data[common.ServerCertPem] = expiredPEM
+			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+			By("Creating a new cert provider and synchronize should generate new certificates")
+			cp := certificate.NewProvider(k8sClient, secretName, secretNamespace)
+			Expect(cp.SyncSecret(context.TODO(), secretName, secretNamespace)).To(Succeed())
+
+			By("Checking out whether the webhook certificate changed after syncronize")
+			serverPEM, err := cp.ServerCert()
+			Expect(err).To(BeNil())
+			Expect(serverPEM).ShouldNot(Equal(expiredPEM))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Invalid certificates stored in the webhook secret are used without validation.  This can lead to certificate expired or name validation errors during a webhook call.

Fixes https://github.com/kubeflow/spark-operator/issues/2482

**Proposed changes:**

- use the x509.Certificate.Verify method to check if the certificate is valid and regenerate it if not.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
