### PR TITLE
Add ShuffleTrackingEnabled to DynamicAllocation struct to allow disabling shuffle tracking

### DIFF
--- a/api/v1beta2/sparkapplication_types.go
+++ b/api/v1beta2/sparkapplication_types.go
@@ -703,6 +703,12 @@ type DynamicAllocation struct {
 	// MaxExecutors is the upper bound for the number of executors if dynamic allocation is enabled.
 	// +optional
 	MaxExecutors *int32 `json:"maxExecutors,omitempty"`
+	// ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without
+	// the need for an external shuffle service. This option will try to keep alive executors that are storing
+	// shuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.
+	// ShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.
+	// +optional
+	ShuffleTrackingEnabled *bool `json:"shuffleTrackingEnabled,omitempty"`
 	// ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding
 	// shuffle data if shuffle tracking is enabled (true by default if dynamic allocation is enabled).
 	// +optional

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -279,6 +279,11 @@ func (in *DynamicAllocation) DeepCopyInto(out *DynamicAllocation) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ShuffleTrackingEnabled != nil {
+		in, out := &in.ShuffleTrackingEnabled, &out.ShuffleTrackingEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ShuffleTrackingTimeout != nil {
 		in, out := &in.ShuffleTrackingTimeout, &out.ShuffleTrackingTimeout
 		*out = new(int64)

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -5296,6 +5296,13 @@ spec:
                           of executors if dynamic allocation is enabled.
                         format: int32
                         type: integer
+                      shuffleTrackingEnabled:
+                        description: |-
+                          ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without
+                          the need for an external shuffle service. This option will try to keep alive executors that are storing
+                          shuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.
+                          ShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.
+                        type: boolean
                       shuffleTrackingTimeout:
                         description: |-
                           ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -5238,6 +5238,13 @@ spec:
                       executors if dynamic allocation is enabled.
                     format: int32
                     type: integer
+                  shuffleTrackingEnabled:
+                    description: |-
+                      ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without
+                      the need for an external shuffle service. This option will try to keep alive executors that are storing
+                      shuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.
+                      ShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.
+                    type: boolean
                   shuffleTrackingTimeout:
                     description: |-
                       ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding

--- a/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -5296,6 +5296,13 @@ spec:
                           of executors if dynamic allocation is enabled.
                         format: int32
                         type: integer
+                      shuffleTrackingEnabled:
+                        description: |-
+                          ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without
+                          the need for an external shuffle service. This option will try to keep alive executors that are storing
+                          shuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.
+                          ShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.
+                        type: boolean
                       shuffleTrackingTimeout:
                         description: |-
                           ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding

--- a/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
@@ -5238,6 +5238,13 @@ spec:
                       executors if dynamic allocation is enabled.
                     format: int32
                     type: integer
+                  shuffleTrackingEnabled:
+                    description: |-
+                      ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without
+                      the need for an external shuffle service. This option will try to keep alive executors that are storing
+                      shuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.
+                      ShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.
+                    type: boolean
                   shuffleTrackingTimeout:
                     description: |-
                       ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -741,6 +741,21 @@ int32
 </tr>
 <tr>
 <td>
+<code>shuffleTrackingEnabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without
+the need for an external shuffle service. This option will try to keep alive executors that are storing
+shuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.
+ShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>shuffleTrackingTimeout</code><br/>
 <em>
 int64

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -1005,8 +1005,8 @@ func dynamicAllocationOption(app *v1beta2.SparkApplication) ([]string, error) {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%t", common.SparkDynamicAllocationShuffleTrackingEnabled, *dynamicAllocation.ShuffleTrackingEnabled))
 	} else {
-	  	args = append(args, "--conf",
-		    fmt.Sprintf("%s=true", common.SparkDynamicAllocationShuffleTrackingEnabled))
+		args = append(args, "--conf",
+			fmt.Sprintf("%s=true", common.SparkDynamicAllocationShuffleTrackingEnabled))
 	}
 	if dynamicAllocation.ShuffleTrackingTimeout != nil {
 		args = append(args, "--conf",

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -1001,13 +1001,12 @@ func dynamicAllocationOption(app *v1beta2.SparkApplication) ([]string, error) {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%d", common.SparkDynamicAllocationMaxExecutors, *dynamicAllocation.MaxExecutors))
 	}
+	shuffleTrackingEnabled := true
 	if dynamicAllocation.ShuffleTrackingEnabled != nil {
-		args = append(args, "--conf",
-			fmt.Sprintf("%s=%t", common.SparkDynamicAllocationShuffleTrackingEnabled, *dynamicAllocation.ShuffleTrackingEnabled))
-	} else {
-		args = append(args, "--conf",
-			fmt.Sprintf("%s=true", common.SparkDynamicAllocationShuffleTrackingEnabled))
+		shuffleTrackingEnabled = *dynamicAllocation.ShuffleTrackingEnabled
 	}
+	args = append(args, "--conf",
+		fmt.Sprintf("%s=%t", common.SparkDynamicAllocationShuffleTrackingEnabled, shuffleTrackingEnabled))
 	if dynamicAllocation.ShuffleTrackingTimeout != nil {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%d", common.SparkDynamicAllocationShuffleTrackingTimeout, *dynamicAllocation.ShuffleTrackingTimeout))

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -989,10 +989,6 @@ func dynamicAllocationOption(app *v1beta2.SparkApplication) ([]string, error) {
 	args = append(args, "--conf",
 		fmt.Sprintf("%s=true", common.SparkDynamicAllocationEnabled))
 
-	// Turn on shuffle tracking if dynamic allocation is enabled.
-	args = append(args, "--conf",
-		fmt.Sprintf("%s=true", common.SparkDynamicAllocationShuffleTrackingEnabled))
-
 	if dynamicAllocation.InitialExecutors != nil {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%d", common.SparkDynamicAllocationInitialExecutors, *dynamicAllocation.InitialExecutors))
@@ -1004,6 +1000,10 @@ func dynamicAllocationOption(app *v1beta2.SparkApplication) ([]string, error) {
 	if dynamicAllocation.MaxExecutors != nil {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%d", common.SparkDynamicAllocationMaxExecutors, *dynamicAllocation.MaxExecutors))
+	}
+	if dynamicAllocation.ShuffleTrackingEnabled != nil {
+		args = append(args, "--conf",
+			fmt.Sprintf("%s=%t", common.SparkDynamicAllocationShuffleTrackingEnabled, *dynamicAllocation.ShuffleTrackingEnabled))
 	}
 	if dynamicAllocation.ShuffleTrackingTimeout != nil {
 		args = append(args, "--conf",

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -1004,6 +1004,9 @@ func dynamicAllocationOption(app *v1beta2.SparkApplication) ([]string, error) {
 	if dynamicAllocation.ShuffleTrackingEnabled != nil {
 		args = append(args, "--conf",
 			fmt.Sprintf("%s=%t", common.SparkDynamicAllocationShuffleTrackingEnabled, *dynamicAllocation.ShuffleTrackingEnabled))
+	} else {
+	  	args = append(args, "--conf",
+		    fmt.Sprintf("%s=true", common.SparkDynamicAllocationShuffleTrackingEnabled))
 	}
 	if dynamicAllocation.ShuffleTrackingTimeout != nil {
 		args = append(args, "--conf",

--- a/internal/webhook/sparkapplication_defaulter.go
+++ b/internal/webhook/sparkapplication_defaulter.go
@@ -98,5 +98,9 @@ func defaultExecutorSpec(app *v1beta2.SparkApplication) {
 				app.Spec.Executor.Instances = util.Int32Ptr(1)
 			}
 		}
+		// Set default for ShuffleTrackingEnabled to true if dynamicAllocation.enabled is true.
+		if enableDynamicAllocation && app.Spec.DynamicAllocation.ShuffleTrackingEnabled == nil {
+			app.Spec.DynamicAllocation.ShuffleTrackingEnabled = util.BoolPtr(true)
+		}
 	}
 }

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -494,4 +495,14 @@ func GetInitialExecutorNumber(app *v1beta2.SparkApplication) int32 {
 	}
 
 	return initialNumExecutors
+}
+
+// IsDynamicAllocationEnabled determines if Spark Dynamic Allocation is enabled in app.Spec.DynamicAllocation or in
+// app.Spec.SparkConf. app.Spec.DynamicAllocation configs will take precedence over app.Spec.SparkConf configs.
+func IsDynamicAllocationEnabled(app *v1beta2.SparkApplication) bool {
+	if app.Spec.DynamicAllocation != nil {
+		return app.Spec.DynamicAllocation.Enabled
+	}
+	dynamicAllocationConfVal, _ := strconv.ParseBool(app.Spec.SparkConf[common.SparkDynamicAllocationEnabled])
+	return dynamicAllocationConfVal
 }

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -356,3 +356,69 @@ var _ = Describe("DriverStateToApplicationState", func() {
 		Expect(util.DriverStateToApplicationState(v1beta2.DriverStateUnknown)).To(Equal(v1beta2.ApplicationStateUnknown))
 	})
 })
+
+var _ = Describe("Check if IsDynamicAllocationEnabled", func() {
+	Context("when app.Spec.DynamicAllocation is True", func() {
+		app := &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "test-namespace",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				DynamicAllocation: &v1beta2.DynamicAllocation{
+					Enabled: true,
+				},
+			},
+		}
+		It("Should return true", func() {
+			Expect(util.IsDynamicAllocationEnabled(app)).To(BeTrue())
+		})
+	})
+	Context("when app.Spec.DynamicAllocation is nil but True in app.Spec.SparkConf", func() {
+		app := &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "test-namespace",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				SparkConf: map[string]string{
+					"spark.dynamicAllocation.enabled": "true",
+				},
+			},
+		}
+		It("Should return true", func() {
+			Expect(util.IsDynamicAllocationEnabled(app)).To(BeTrue())
+		})
+	})
+	Context("when app.Spec.DynamicAllocation is nil and not set in app.Spec.SparkConf", func() {
+		app := &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "test-namespace",
+			},
+		}
+		It("Should return false", func() {
+			Expect(util.IsDynamicAllocationEnabled(app)).To(BeFalse())
+		})
+	})
+	Context("when app.Spec.DynamicAllocation is True but false in app.Spec.SparkConf", func() {
+		app := &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "test-namespace",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				DynamicAllocation: &v1beta2.DynamicAllocation{
+					Enabled: true,
+				},
+				SparkConf: map[string]string{
+					"spark.dynamicAllocation.enabled": "false",
+				},
+			},
+		}
+		It("Should return true because app.Spec.DynamicAllocation configs will take precedence over "+
+			"app.Spec.SparkConf configs", func() {
+			Expect(util.IsDynamicAllocationEnabled(app)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Add ShuffleTrackingEnabled *bool to DynamicAllocation so that shuffle tracking can be disabled when using an external shuffle service. Set default for ShuffleTrackingEnabled to true if dynamicAllocation.enabled is true so that it's not a breaking change.

**Proposed changes:**

- Add ShuffleTrackingEnabled *bool to DynamicAllocation struct
- Set default for ShuffleTrackingEnabled to true if dynamicAllocation.enabled is true
- Set `spark.dynamicAllocation.shuffleTracking.enabled` spark conf based on ShuffleTrackingEnabled value

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Currently if dynamicAllocation is enabled, shuffle tracking is enabled by default. When using an external shuffle service,
we want dynamicAllocation to be enabled and want shuffle tracking to be disabled. So adding a variable to allow users to 
disable shuffle tracking is helpful when dynamicAllocation is enabled. By default shuffle tracking will be enabled so that 
it doesn't break existing use cases and its not a breaking change.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
