### PR TITLE
Make default ingress tls and annotations congurable in the helm config

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -93,8 +93,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.uiIngress.enable | bool | `false` | Specifies whether to create ingress for Spark web UI. `controller.uiService.enable` must be `true` to enable ingress. |
 | controller.uiIngress.urlFormat | string | `""` | Ingress URL format. Required if `controller.uiIngress.enable` is true. |
 | controller.uiIngress.ingressClassName | string | `""` | Optionally set the ingressClassName. |
-| controller.uiIngress.defaultIngressTLS | list | `[]` | Optionally set default TLS configuration for the Spark UI's ingress. `ingressTLS` in the SparkApplication spec overrides this. |
-| controller.uiIngress.defaultIngressAnnotations | object | `{}` | Optionally set default ingress annotations for the Spark UI's ingress. `ingressAnnotations` in the SparkApplication spec overrides this. |
+| controller.uiIngress.tls | list | `[]` | Optionally set default TLS configuration for the Spark UI's ingress. `ingressTLS` in the SparkApplication spec overrides this. |
+| controller.uiIngress.annotations | object | `{}` | Optionally set default ingress annotations for the Spark UI's ingress. `ingressAnnotations` in the SparkApplication spec overrides this. |
 | controller.batchScheduler.enable | bool | `false` | Specifies whether to enable batch scheduler for spark jobs scheduling. If enabled, users can specify batch scheduler name in spark application. |
 | controller.batchScheduler.kubeSchedulerNames | list | `[]` | Specifies a list of kube-scheduler names for scheduling Spark pods. |
 | controller.batchScheduler.default | string | `""` | Default batch scheduler to be used if not specified by the user. If specified, this value must be either "volcano" or "yunikorn". Specifying any other value will cause the controller to error on startup. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -93,6 +93,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.uiIngress.enable | bool | `false` | Specifies whether to create ingress for Spark web UI. `controller.uiService.enable` must be `true` to enable ingress. |
 | controller.uiIngress.urlFormat | string | `""` | Ingress URL format. Required if `controller.uiIngress.enable` is true. |
 | controller.uiIngress.ingressClassName | string | `""` | Optionally set the ingressClassName. |
+| controller.uiIngress.defaultIngressTLS | list | `[]` | Optionally set default TLS configuration for the Spark UI's ingress. `ingressTLS` in the SparkApplication spec overrides this. |
+| controller.uiIngress.defaultIngressAnnotations | object | `{}` | Optionally set default ingress annotations for the Spark UI's ingress. `ingressAnnotations` in the SparkApplication spec overrides this. |
 | controller.batchScheduler.enable | bool | `false` | Specifies whether to enable batch scheduler for spark jobs scheduling. If enabled, users can specify batch scheduler name in spark application. |
 | controller.batchScheduler.kubeSchedulerNames | list | `[]` | Specifies a list of kube-scheduler names for scheduling Spark pods. |
 | controller.batchScheduler.default | string | `""` | Default batch scheduler to be used if not specified by the user. If specified, this value must be either "volcano" or "yunikorn". Specifying any other value will cause the controller to error on startup. |

--- a/charts/spark-operator-chart/ci/ci-values.yaml
+++ b/charts/spark-operator-chart/ci/ci-values.yaml
@@ -1,11 +1,2 @@
 image:
   tag: local
-
-controller:
-  uiIngress:
-    enable: true
-    urlFormat: app.fake.com
-    ingressTLS:
-    - hosts:
-      - "*.fake.com"
-      secretName: test-secret

--- a/charts/spark-operator-chart/ci/ci-values.yaml
+++ b/charts/spark-operator-chart/ci/ci-values.yaml
@@ -1,2 +1,11 @@
 image:
   tag: local
+
+controller:
+  uiIngress:
+    enable: true
+    urlFormat: app.fake.com
+    ingressTLS:
+    - hosts:
+      - "*.fake.com"
+      secretName: test-secret

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -73,10 +73,10 @@ spec:
         - --ingress-class-name={{ . }}
         {{- end }}
         {{- with .Values.controller.uiIngress.tls }}
-        - --ingress-tls={{ . | toJson | quote }}
+        - --ingress-tls={{ . | toJson }}
         {{- end }}
         {{- with .Values.controller.uiIngress.annotations }}
-        - --ingress-annotations={{ . | toJson | quote }}
+        - --ingress-annotations={{ . | toJson }}
         {{- end }}
         {{- end }}
         {{- if .Values.controller.batchScheduler.enable }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -72,6 +72,9 @@ spec:
         {{- with .Values.controller.uiIngress.ingressClassName }}
         - --ingress-class-name={{ . }}
         {{- end }}
+        {{- with .Values.controller.uiIngress.ingressTLS }}
+        - --ingress-tls={{ . | toJson }}
+        {{- end }}
         {{- end }}
         {{- if .Values.controller.batchScheduler.enable }}
         - --enable-batch-scheduler=true

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -72,8 +72,11 @@ spec:
         {{- with .Values.controller.uiIngress.ingressClassName }}
         - --ingress-class-name={{ . }}
         {{- end }}
-        {{- with .Values.controller.uiIngress.ingressTLS }}
-        - --ingress-tls={{ . | toJson }}
+        {{- with .Values.controller.uiIngress.defaultIngressTLS }}
+        - --default-ingress-tls={{ . | toJson }}
+        {{- end }}
+        {{- with .Values.controller.uiIngress.defaultIngressAnnotations }}
+        - --default-ingress-annotations={{ . | toJson }}
         {{- end }}
         {{- end }}
         {{- if .Values.controller.batchScheduler.enable }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -72,11 +72,11 @@ spec:
         {{- with .Values.controller.uiIngress.ingressClassName }}
         - --ingress-class-name={{ . }}
         {{- end }}
-        {{- with .Values.controller.uiIngress.defaultIngressTLS }}
-        - --default-ingress-tls={{ . | toJson }}
+        {{- with .Values.controller.uiIngress.tls }}
+        - --ingress-tls={{ . | toJson | quote }}
         {{- end }}
-        {{- with .Values.controller.uiIngress.defaultIngressAnnotations }}
-        - --default-ingress-annotations={{ . | toJson }}
+        {{- with .Values.controller.uiIngress.annotations }}
+        - --ingress-annotations={{ . | toJson | quote }}
         {{- end }}
         {{- end }}
         {{- if .Values.controller.batchScheduler.enable }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -184,36 +184,36 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --ingress-class-name=nginx
 
-  - it: Should contain `--default-ingress-tls` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.defaultIngressTLS` is set
+  - it: Should contain `--ingress-tls` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.tls` is set
     set:
       controller:
         uiService:
           enable: true
         uiIngress:
           enable: true
-          defaultIngressTLS:
-          - hosts:
-            - "*.test.com"
-            secretName: test-secret
+          tls:
+            - hosts:
+                - "*.test.com"
+              secretName: test-secret
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
-          content: '--default-ingress-tls=[{"hosts":["*.test.com"],"secretName":"test-secret"}]'
+          content: '--ingress-tls="[{\"hosts\":[\"*.test.com\"],\"secretName\":\"test-secret\"}]"'
 
-  - it: Should contain `--default-ingress-annotations` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.defaultIngressAnnotations` is set
+  - it: Should contain `--ingress-annotations` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.annotations` is set
     set:
       controller:
         uiService:
           enable: true
         uiIngress:
           enable: true
-          defaultIngressAnnotations:
+          annotations:
             cert-manager.io/cluster-issuer: "letsencrypt"
             kubernetes.io/ingress.class: nginx
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
-          content: '--default-ingress-annotations={"cert-manager.io/cluster-issuer":"letsencrypt","kubernetes.io/ingress.class":"nginx"}'
+          content: '--ingress-annotations="{\"cert-manager.io/cluster-issuer\":\"letsencrypt\",\"kubernetes.io/ingress.class\":\"nginx\"}"'
 
   - it: Should contain `--enable-batch-scheduler` arg if `controller.batchScheduler.enable` is `true`
     set:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -184,6 +184,37 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --ingress-class-name=nginx
 
+  - it: Should contain `--default-ingress-tls` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.defaultIngressTLS` is set
+    set:
+      controller:
+        uiService:
+          enable: true
+        uiIngress:
+          enable: true
+          defaultIngressTLS:
+          - hosts:
+            - "*.test.com"
+            secretName: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: '--default-ingress-tls=[{"hosts":["*.test.com"],"secretName":"test-secret"}]'
+
+  - it: Should contain `--default-ingress-annotations` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.defaultIngressAnnotations` is set
+    set:
+      controller:
+        uiService:
+          enable: true
+        uiIngress:
+          enable: true
+          defaultIngressAnnotations:
+            cert-manager.io/cluster-issuer: "letsencrypt"
+            kubernetes.io/ingress.class: nginx
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: '--default-ingress-annotations={"cert-manager.io/cluster-issuer":"letsencrypt","kubernetes.io/ingress.class":"nginx"}'
+
   - it: Should contain `--enable-batch-scheduler` arg if `controller.batchScheduler.enable` is `true`
     set:
       controller:
@@ -246,7 +277,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --leader-election-lock-namespace=spark-operator
-  
+
   - it: Should disable leader election if `controller.leaderElection.enable` is set to `false`
     set:
       controller:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -198,7 +198,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
-          content: '--ingress-tls="[{\"hosts\":[\"*.test.com\"],\"secretName\":\"test-secret\"}]"'
+          content: '--ingress-tls=[{"hosts":["*.test.com"],"secretName":"test-secret"}]'
 
   - it: Should contain `--ingress-annotations` arg if `controller.uiIngress.enable` is set to `true` and `controller.uiIngress.annotations` is set
     set:
@@ -213,7 +213,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
-          content: '--ingress-annotations="{\"cert-manager.io/cluster-issuer\":\"letsencrypt\",\"kubernetes.io/ingress.class\":\"nginx\"}"'
+          content: '--ingress-annotations={"cert-manager.io/cluster-issuer":"letsencrypt","kubernetes.io/ingress.class":"nginx"}'
 
   - it: Should contain `--enable-batch-scheduler` arg if `controller.batchScheduler.enable` is `true`
     set:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -74,10 +74,12 @@ controller:
     urlFormat: ""
     # -- Optionally set the ingressClassName.
     ingressClassName: ""
+    # -- Optionally set default TLS configuration for the Spark UI's ingress. `ingressTLS` in the SparkApplication spec overrides this.
     defaultIngressTLS: []
     # - hosts:
     #   - "*.example.com"
     #   secretName: "example-secret"
+    # -- Optionally set default ingress annotations for the Spark UI's ingress. `ingressAnnotations` in the SparkApplication spec overrides this.
     defaultIngressAnnotations: {}
       # key1: value1
       # key2: value2

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -75,12 +75,12 @@ controller:
     # -- Optionally set the ingressClassName.
     ingressClassName: ""
     # -- Optionally set default TLS configuration for the Spark UI's ingress. `ingressTLS` in the SparkApplication spec overrides this.
-    defaultIngressTLS: []
+    tls: []
     # - hosts:
     #   - "*.example.com"
     #   secretName: "example-secret"
     # -- Optionally set default ingress annotations for the Spark UI's ingress. `ingressAnnotations` in the SparkApplication spec overrides this.
-    defaultIngressAnnotations: {}
+    annotations: {}
       # key1: value1
       # key2: value2
 

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -74,6 +74,7 @@ controller:
     urlFormat: ""
     # -- Optionally set the ingressClassName.
     ingressClassName: ""
+    ingressTLS: []
 
   batchScheduler:
     # -- Specifies whether to enable batch scheduler for spark jobs scheduling.

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -74,7 +74,13 @@ controller:
     urlFormat: ""
     # -- Optionally set the ingressClassName.
     ingressClassName: ""
-    ingressTLS: []
+    defaultIngressTLS: []
+    # - hosts:
+    #   - "*.example.com"
+    #   secretName: "example-secret"
+    defaultIngressAnnotations: {}
+      # key1: value1
+      # key2: value2
 
   batchScheduler:
     # -- Specifies whether to enable batch scheduler for spark jobs scheduling.

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -138,7 +138,10 @@ func NewStartCommand() *cobra.Command {
 		},
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			if ingressTLSstring != "" {
-				return json.Unmarshal([]byte(ingressTLSstring), &ingressTLS)
+				err := json.Unmarshal([]byte(ingressTLSstring), &ingressTLS)
+				if err != nil {
+					return err
+				}
 			}
 			return nil
 		},

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -419,7 +419,7 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		EnableUIService:              enableUIService,
 		IngressClassName:             ingressClassName,
 		IngressURLFormat:             ingressURLFormat,
-		IngressTLS:                   ingressTLS,
+		DefaultIngressTLS:            ingressTLS,
 		DefaultBatchScheduler:        defaultBatchScheduler,
 		DriverPodCreationGracePeriod: driverPodCreationGracePeriod,
 		SparkApplicationMetrics:      sparkApplicationMetrics,

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"slices"
 	"time"
+
 	networkingv1 "k8s.io/api/networking/v1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -418,6 +419,7 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		EnableUIService:              enableUIService,
 		IngressClassName:             ingressClassName,
 		IngressURLFormat:             ingressURLFormat,
+		IngressTLS:                   ingressTLS,
 		DefaultBatchScheduler:        defaultBatchScheduler,
 		DriverPodCreationGracePeriod: driverPodCreationGracePeriod,
 		SparkApplicationMetrics:      sparkApplicationMetrics,

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -25,8 +25,6 @@ import (
 	"slices"
 	"time"
 
-	networkingv1 "k8s.io/api/networking/v1"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -37,6 +35,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"slices"
 	"time"
@@ -136,18 +137,18 @@ func NewStartCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "Start controller and webhook",
-		PreRun: func(_ *cobra.Command, args []string) {
-			development = viper.GetBool("development")
-		},
 		PreRunE: func(_ *cobra.Command, args []string) error {
+			development = viper.GetBool("development")
+
 			if defaultIngressTLSstring != "" {
-				err := json.Unmarshal([]byte(defaultIngressTLSstring), &defaultIngressTLS)
-				if err != nil {
-					return err
+				if err := json.Unmarshal([]byte(defaultIngressTLSstring), &defaultIngressTLS); err != nil {
+					return fmt.Errorf("failed parsing default-ingress-tls JSON string from CLI: %v", err)
 				}
 			}
 			if defaultIngressAnnotationsString != "" {
-				return json.Unmarshal([]byte(defaultIngressAnnotationsString), &defaultIngressAnnotations)
+				if err := json.Unmarshal([]byte(defaultIngressAnnotationsString), &defaultIngressAnnotations); err != nil {
+					return fmt.Errorf("failed parsing default-ingress-annotations JSON string from CLI: %v", err)
+				}
 			}
 			return nil
 		},

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -137,7 +137,10 @@ func NewStartCommand() *cobra.Command {
 			development = viper.GetBool("development")
 		},
 		PreRunE: func(_ *cobra.Command, args []string) error {
-			return json.Unmarshal([]byte(ingressTLSstring), &ingressTLS)
+			if ingressTLSstring != "" {
+				return json.Unmarshal([]byte(ingressTLSstring), &ingressTLS)
+			}
+			return nil
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			sparkoperator.PrintVersion(false)
@@ -406,6 +409,7 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		sparkExecutorMetrics = metrics.NewSparkExecutorMetrics(metricsPrefix, metricsLabels)
 		sparkExecutorMetrics.Register()
 	}
+	logger.Info("Ingress TLS configuration", "ingressTLS", ingressTLS)
 	options := sparkapplication.Options{
 		Namespaces:                   namespaces,
 		EnableUIService:              enableUIService,

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -86,16 +86,16 @@ var (
 	workqueueRateLimiterMaxDelay   time.Duration
 
 	// Batch scheduler
-	enableBatchScheduler      bool
-	kubeSchedulerNames        []string
-	defaultBatchScheduler     string
-	defaultIngressTLS         []networkingv1.IngressTLS
-	defaultIngressAnnotations map[string]string
+	enableBatchScheduler  bool
+	kubeSchedulerNames    []string
+	defaultBatchScheduler string
 
 	// Spark web UI service and ingress
-	enableUIService  bool
-	ingressClassName string
-	ingressURLFormat string
+	enableUIService    bool
+	ingressClassName   string
+	ingressURLFormat   string
+	ingressTLS         []networkingv1.IngressTLS
+	ingressAnnotations map[string]string
 
 	// Leader election
 	enableLeaderElection        bool
@@ -132,22 +132,22 @@ func init() {
 }
 
 func NewStartCommand() *cobra.Command {
-	var defaultIngressTLSstring string
-	var defaultIngressAnnotationsString string
+	var ingressTLSstring string
+	var ingressAnnotationsString string
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "Start controller and webhook",
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			development = viper.GetBool("development")
 
-			if defaultIngressTLSstring != "" {
-				if err := json.Unmarshal([]byte(defaultIngressTLSstring), &defaultIngressTLS); err != nil {
-					return fmt.Errorf("failed parsing default-ingress-tls JSON string from CLI: %v", err)
+			if ingressTLSstring != "" {
+				if err := json.Unmarshal([]byte(ingressTLSstring), &ingressTLS); err != nil {
+					return fmt.Errorf("failed parsing ingress-tls JSON string from CLI: %v", err)
 				}
 			}
-			if defaultIngressAnnotationsString != "" {
-				if err := json.Unmarshal([]byte(defaultIngressAnnotationsString), &defaultIngressAnnotations); err != nil {
-					return fmt.Errorf("failed parsing default-ingress-annotations JSON string from CLI: %v", err)
+			if ingressAnnotationsString != "" {
+				if err := json.Unmarshal([]byte(ingressAnnotationsString), &ingressAnnotations); err != nil {
+					return fmt.Errorf("failed parsing ingress-annotations JSON string from CLI: %v", err)
 				}
 			}
 			return nil
@@ -174,8 +174,8 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().BoolVar(&enableUIService, "enable-ui-service", true, "Enable Spark Web UI service.")
 	command.Flags().StringVar(&ingressClassName, "ingress-class-name", "", "Set ingressClassName for ingress resources created.")
 	command.Flags().StringVar(&ingressURLFormat, "ingress-url-format", "", "Ingress URL format.")
-	command.Flags().StringVar(&defaultIngressTLSstring, "default-ingress-tls", "", "JSON format string for the default TLS config on the Spark UI ingresses. e.g. '[{\"hosts\":[\"*.example.com\"],\"secretName\":\"example-secret\"}]'. `ingressTLS` in the SparkApplication spec will override this value.")
-	command.Flags().StringVar(&defaultIngressAnnotationsString, "default-ingress-annotations", "", "JSON format string for the default ingress annotations for the Spark UI ingresses. e.g. '[{\"cert-manager.io/cluster-issuer\": \"letsencrypt\"}]'. `ingressAnnotations` in the SparkApplication spec will override this value.")
+	command.Flags().StringVar(&ingressTLSstring, "ingress-tls", "", "JSON format string for the default TLS config on the Spark UI ingresses. e.g. '[{\"hosts\":[\"*.example.com\"],\"secretName\":\"example-secret\"}]'. `ingressTLS` in the SparkApplication spec will override this value.")
+	command.Flags().StringVar(&ingressAnnotationsString, "ingress-annotations", "", "JSON format string for the default ingress annotations for the Spark UI ingresses. e.g. '[{\"cert-manager.io/cluster-issuer\": \"letsencrypt\"}]'. `ingressAnnotations` in the SparkApplication spec will override this value.")
 
 	command.Flags().BoolVar(&enableLeaderElection, "leader-election", false, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
@@ -425,8 +425,8 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		EnableUIService:              enableUIService,
 		IngressClassName:             ingressClassName,
 		IngressURLFormat:             ingressURLFormat,
-		DefaultIngressTLS:            defaultIngressTLS,
-		DefaultIngressAnnotations:    defaultIngressAnnotations,
+		IngressTLS:                   ingressTLS,
+		IngressAnnotations:           ingressAnnotations,
 		DefaultBatchScheduler:        defaultBatchScheduler,
 		DriverPodCreationGracePeriod: driverPodCreationGracePeriod,
 		SparkApplicationMetrics:      sparkApplicationMetrics,

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -62,6 +62,7 @@ type Options struct {
 	IngressClassName      string
 	IngressURLFormat      string
 	IngressTLS            []networkingv1.IngressTLS
+	IngressAnnotations	map[string]string
 	DefaultBatchScheduler string
 
 	DriverPodCreationGracePeriod time.Duration

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -61,6 +61,7 @@ type Options struct {
 	EnableUIService       bool
 	IngressClassName      string
 	IngressURLFormat      string
+	IngressTLS            []networkingv1.IngressTLS
 	DefaultBatchScheduler string
 
 	DriverPodCreationGracePeriod time.Duration
@@ -323,7 +324,7 @@ func (r *Reconciler) reconcileSubmittedSparkApplication(ctx context.Context, req
 						app.Spec.SparkConf[common.SparkUIProxyBase] = ingressURL.Path
 						app.Spec.SparkConf[common.SparkUIProxyRedirectURI] = "/"
 					}
-					ingress, err := r.createWebUIIngress(app, *service, ingressURL, r.options.IngressClassName)
+					ingress, err := r.createWebUIIngress(app, *service, ingressURL, r.options.IngressClassName, r.options.IngressTLS, r.options.IngressAnnotations)
 					if err != nil {
 						return fmt.Errorf("failed to create web UI ingress: %v", err)
 					}

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -57,13 +57,13 @@ var (
 
 // Options defines the options of the controller.
 type Options struct {
-	Namespaces            []string
-	EnableUIService       bool
-	IngressClassName      string
-	IngressURLFormat      string
-	IngressTLS            []networkingv1.IngressTLS
-	IngressAnnotations	map[string]string
-	DefaultBatchScheduler string
+	Namespaces                []string
+	EnableUIService           bool
+	IngressClassName          string
+	IngressURLFormat          string
+	DefaultIngressTLS         []networkingv1.IngressTLS
+	DefaultIngressAnnotations map[string]string
+	DefaultBatchScheduler     string
 
 	DriverPodCreationGracePeriod time.Duration
 

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -57,13 +57,13 @@ var (
 
 // Options defines the options of the controller.
 type Options struct {
-	Namespaces                []string
-	EnableUIService           bool
-	IngressClassName          string
-	IngressURLFormat          string
-	DefaultIngressTLS         []networkingv1.IngressTLS
-	DefaultIngressAnnotations map[string]string
-	DefaultBatchScheduler     string
+	Namespaces            []string
+	EnableUIService       bool
+	IngressClassName      string
+	IngressURLFormat      string
+	IngressTLS            []networkingv1.IngressTLS
+	IngressAnnotations    map[string]string
+	DefaultBatchScheduler string
 
 	DriverPodCreationGracePeriod time.Duration
 

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 var _ = Describe("SparkApplication Controller", func() {
-	Context("When reconciling a new SparkApplication", func() {
+	Context("When reconciling a submitted SparkApplication", func() {
 		ctx := context.Background()
 		appName := "test"
 		appNamespace := "default"
@@ -68,6 +68,13 @@ var _ = Describe("SparkApplication Controller", func() {
 				util.IngressCapabilities = util.Capabilities{"networking.k8s.io/v1": true}
 				v1beta2.SetSparkApplicationDefaults(app)
 				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+				driverPod := createDriverPod(appName, appNamespace)
+				Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+
+				app.Status.DriverInfo.PodName = driverPod.Name
+				app.Status.AppState.State = v1beta2.ApplicationStateSubmitted
+				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
 			}
 		})
 
@@ -81,6 +88,11 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(k8sClient.Get(ctx, ingressKey, ingress)).To(Succeed())
 			By("Deleting the created test ingress")
 			Expect(k8sClient.Delete(ctx, ingress)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			By("Deleting the driver pod")
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
 		})
 
 		It("Should create an ingress for the Spark UI with no TLS or annotations", func() {
@@ -138,7 +150,7 @@ var _ = Describe("SparkApplication Controller", func() {
 		})
 	})
 
-	Context("When reconciling a new SparkApplication with spark UI ingress TLS and annotations", func() {
+	Context("When reconciling a submitted SparkApplication with spark UI ingress TLS and annotations", func() {
 		ctx := context.Background()
 		appName := "test"
 		appNamespace := "default"
@@ -179,6 +191,13 @@ var _ = Describe("SparkApplication Controller", func() {
 
 				v1beta2.SetSparkApplicationDefaults(app)
 				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+				driverPod := createDriverPod(appName, appNamespace)
+				Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+
+				app.Status.DriverInfo.PodName = driverPod.Name
+				app.Status.AppState.State = v1beta2.ApplicationStateSubmitted
+				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
 			}
 		})
 
@@ -192,6 +211,11 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(k8sClient.Get(ctx, ingressKey, ingress)).To(Succeed())
 			By("Deleting the created test ingress")
 			Expect(k8sClient.Delete(ctx, ingress)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			By("Deleting the driver pod")
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
 		})
 
 		It("Should create an ingress for the Spark UI with TLS and annotations", func() {

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -77,7 +77,7 @@ var _ = Describe("SparkApplication Controller", func() {
 
 		It("Should create an ingress for the Spark UI with TLS and annotations", func() {
 			By("Reconciling the new test SparkApplication")
-			ingressTLS := []networkingv1.IngressTLS{
+			defaultIngressTLS := []networkingv1.IngressTLS{
 				{
 					Hosts:      []string{"example.com", "www.example.com"},
 					SecretName: "example-tls-secret",
@@ -87,7 +87,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					SecretName: "another-tls-secret",
 				},
 			}
-			ingressAnnotations := map[string]string{
+			defaultIngressAnnotations := map[string]string{
 				"cert-manager.io/cluster-issuer": "letsencrypt",
 				"kubernetes.io/ingress.class":    "nginx",
 			}
@@ -97,16 +97,17 @@ var _ = Describe("SparkApplication Controller", func() {
 				k8sClient,
 				record.NewFakeRecorder(3),
 				nil,
-				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", IngressTLS: ingressTLS, IngressAnnotations: ingressAnnotations, Namespaces: []string{appNamespace}},
+				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", DefaultIngressTLS: defaultIngressTLS, DefaultIngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
 
 			ingress := &networkingv1.Ingress{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: appName + "-ui-ingress", Namespace: appNamespace}, ingress)).To(Succeed())
-			Expect(ingress.Spec.TLS).To(Equal(ingressTLS))
-			Expect(ingress.ObjectMeta.Annotations).To(Equal(ingressAnnotations))
+			Expect(ingress.Spec.TLS).To(Equal(defaultIngressTLS))
+			Expect(ingress.ObjectMeta.Annotations).To(Equal(defaultIngressAnnotations))
 		})
+		// TODO(tomnewton):
 		// Test with no TLS options
 		// Test with SparkApplication TLS options overriding.
 	})

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -91,6 +91,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				k8sClient,
 				record.NewFakeRecorder(3),
 				nil,
+				&sparkapplication.SparkSubmitter{},
 				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
@@ -124,6 +125,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				k8sClient,
 				record.NewFakeRecorder(3),
 				nil,
+				&sparkapplication.SparkSubmitter{},
 				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", DefaultIngressTLS: defaultIngressTLS, DefaultIngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
@@ -199,6 +201,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				k8sClient,
 				record.NewFakeRecorder(3),
 				nil,
+				&sparkapplication.SparkSubmitter{},
 				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
@@ -227,6 +230,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				k8sClient,
 				record.NewFakeRecorder(3),
 				nil,
+				&sparkapplication.SparkSubmitter{},
 				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", DefaultIngressTLS: defaultIngressTLS, DefaultIngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -106,12 +106,12 @@ var _ = Describe("SparkApplication Controller", func() {
 			By("Reconciling the new test SparkApplication")
 			defaultIngressTLS := []networkingv1.IngressTLS{
 				{
-					Hosts:      []string{"example.com", "www.example.com"},
+					Hosts:      []string{"*.test.com", "*.test2.com"},
 					SecretName: "example-tls-secret",
 				},
 				{
-					Hosts:      []string{"another-example.com"},
-					SecretName: "another-tls-secret",
+					Hosts:      []string{"another-test.com"},
+					SecretName: "test-tls-secret",
 				},
 			}
 			defaultIngressAnnotations := map[string]string{
@@ -150,8 +150,8 @@ var _ = Describe("SparkApplication Controller", func() {
 		}
 		ingressTLS := []networkingv1.IngressTLS{
 			{
-				Hosts:      []string{"example.com"},
-				SecretName: "example-tls-secret",
+				Hosts:      []string{"*.test.com"},
+				SecretName: "test-tls-secret",
 			},
 		}
 		ingressAnnotations := map[string]string{"cert-manager.io/cluster-issuer": "letsencrypt"}
@@ -214,7 +214,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			By("Reconciling the new test SparkApplication")
 			defaultIngressTLS := []networkingv1.IngressTLS{
 				{
-					Hosts:      []string{"default.com"},
+					Hosts:      []string{"*.default.com"},
 					SecretName: "default-tls-secret",
 				},
 			}

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -126,7 +126,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				record.NewFakeRecorder(3),
 				nil,
 				&sparkapplication.SparkSubmitter{},
-				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", DefaultIngressTLS: defaultIngressTLS, DefaultIngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
+				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", IngressTLS: defaultIngressTLS, IngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
@@ -232,7 +232,7 @@ var _ = Describe("SparkApplication Controller", func() {
 				record.NewFakeRecorder(3),
 				nil,
 				&sparkapplication.SparkSubmitter{},
-				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", DefaultIngressTLS: defaultIngressTLS, DefaultIngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
+				sparkapplication.Options{EnableUIService: true, IngressURLFormat: "{{$appName}}.spark.test.com", IngressTLS: defaultIngressTLS, IngressAnnotations: defaultIngressAnnotations, Namespaces: []string{appNamespace}},
 			)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -89,19 +89,19 @@ func (r *Reconciler) createDriverIngress(app *v1beta2.SparkApplication, driverIn
 	}
 	ingressName := fmt.Sprintf("%s-ing-%d", app.Name, *driverIngressConfiguration.ServicePort)
 	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
-		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, nil, nil)
+		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, []networkingv1.IngressTLS{}, map[string]string{})
 	}
 	return r.createDriverIngressLegacy(app, service, ingressName, ingressURL)
 }
 
-func (r *Reconciler) createDriverIngressV1(app *v1beta2.SparkApplication, service SparkService, ingressName string, ingressURL *url.URL, ingressClassName string, defaultIngressTLS *[]networkingv1.IngressTLS, defaultIngressAnnotations *map[string]string) (*SparkIngress, error) {
+func (r *Reconciler) createDriverIngressV1(app *v1beta2.SparkApplication, service SparkService, ingressName string, ingressURL *url.URL, ingressClassName string, defaultIngressTLS []networkingv1.IngressTLS, defaultIngressAnnotations map[string]string) (*SparkIngress, error) {
 	ingressResourceAnnotations := util.GetWebUIIngressAnnotations(app)
-	if len(ingressResourceAnnotations) == 0 && defaultIngressAnnotations != nil && len(*defaultIngressAnnotations) != 0 {
-		ingressResourceAnnotations = *defaultIngressAnnotations
+	if len(ingressResourceAnnotations) == 0 && len(defaultIngressAnnotations) != 0 {
+		ingressResourceAnnotations = defaultIngressAnnotations
 	}
 	ingressTLSHosts := util.GetWebUIIngressTLS(app)
-	if len(ingressTLSHosts) == 0 && defaultIngressTLS != nil && len(*defaultIngressTLS) != 0 {
-		ingressTLSHosts = *defaultIngressTLS
+	if len(ingressTLSHosts) == 0 && len(defaultIngressTLS) != 0 {
+		ingressTLSHosts = defaultIngressTLS
 	}
 
 	ingressURLPath := ingressURL.Path

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -147,10 +147,11 @@ func (r *Reconciler) createDriverIngressV1(app *v1beta2.SparkApplication, servic
 		}
 		ingress.ObjectMeta.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$2"
 	}
+	if len(ingressTLSHosts) == 0 && defaultIngressTLS != nil && len(*defaultIngressTLS) != 0 {
+		ingressTLSHosts = *defaultIngressTLS
+	}
 	if len(ingressTLSHosts) != 0 {
 		ingress.Spec.TLS = ingressTLSHosts
-	} else if defaultIngressTLS != nil && len(*defaultIngressTLS) != 0 {
-		ingress.Spec.TLS = *defaultIngressTLS
 	}
 	if len(ingressClassName) != 0 {
 		ingress.Spec.IngressClassName = &ingressClassName

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -89,12 +89,12 @@ func (r *Reconciler) createDriverIngress(app *v1beta2.SparkApplication, driverIn
 	}
 	ingressName := fmt.Sprintf("%s-ing-%d", app.Name, *driverIngressConfiguration.ServicePort)
 	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
-		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName)
+		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, nil)
 	}
 	return r.createDriverIngressLegacy(app, service, ingressName, ingressURL)
 }
 
-func (r *Reconciler) createDriverIngressV1(app *v1beta2.SparkApplication, service SparkService, ingressName string, ingressURL *url.URL, ingressClassName string) (*SparkIngress, error) {
+func (r *Reconciler) createDriverIngressV1(app *v1beta2.SparkApplication, service SparkService, ingressName string, ingressURL *url.URL, ingressClassName string, defaultIngressTLS *[]networkingv1.IngressTLS) (*SparkIngress, error) {
 	ingressResourceAnnotations := util.GetWebUIIngressAnnotations(app)
 	ingressTLSHosts := util.GetWebUIIngressTLS(app)
 
@@ -149,6 +149,8 @@ func (r *Reconciler) createDriverIngressV1(app *v1beta2.SparkApplication, servic
 	}
 	if len(ingressTLSHosts) != 0 {
 		ingress.Spec.TLS = ingressTLSHosts
+	} else if defaultIngressTLS != nil && len(*defaultIngressTLS) != 0 {
+		ingress.Spec.TLS = *defaultIngressTLS
 	}
 	if len(ingressClassName) != 0 {
 		ingress.Spec.IngressClassName = &ingressClassName

--- a/internal/controller/sparkapplication/web_ui.go
+++ b/internal/controller/sparkapplication/web_ui.go
@@ -50,7 +50,7 @@ func (r *Reconciler) createWebUIService(app *v1beta2.SparkApplication) (*SparkSe
 func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string, defaultIngressTLS []networkingv1.IngressTLS, defaultIngressAnnotations map[string]string) (*SparkIngress, error) {
 	ingressName := util.GetDefaultUIIngressName(app)
 	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
-		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, &defaultIngressTLS, &defaultIngressAnnotations)
+		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, defaultIngressTLS, defaultIngressAnnotations)
 	}
 	return r.createDriverIngressLegacy(app, service, ingressName, ingressURL)
 }

--- a/internal/controller/sparkapplication/web_ui.go
+++ b/internal/controller/sparkapplication/web_ui.go
@@ -47,10 +47,10 @@ func (r *Reconciler) createWebUIService(app *v1beta2.SparkApplication) (*SparkSe
 	return r.createDriverIngressService(app, portName, port, targetPort, serviceName, serviceType, serviceAnnotations, serviceLabels)
 }
 
-func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string, ingressTLS []networkingv1.IngressTLS, ingressAnnotations map[string]string) (*SparkIngress, error) {
+func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string, defaultIngressTLS []networkingv1.IngressTLS, defaultIngressAnnotations map[string]string) (*SparkIngress, error) {
 	ingressName := util.GetDefaultUIIngressName(app)
 	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
-		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, &ingressTLS, &ingressAnnotations)
+		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, &defaultIngressTLS, &defaultIngressAnnotations)
 	}
 	return r.createDriverIngressLegacy(app, service, ingressName, ingressURL)
 }

--- a/internal/controller/sparkapplication/web_ui.go
+++ b/internal/controller/sparkapplication/web_ui.go
@@ -21,10 +21,11 @@ import (
 	"net/url"
 	"strconv"
 
+	networkingv1 "k8s.io/api/networking/v1"
+
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
-	networkingv1 "k8s.io/api/networking/v1"
 )
 
 func (r *Reconciler) createWebUIService(app *v1beta2.SparkApplication) (*SparkService, error) {

--- a/internal/controller/sparkapplication/web_ui.go
+++ b/internal/controller/sparkapplication/web_ui.go
@@ -47,10 +47,10 @@ func (r *Reconciler) createWebUIService(app *v1beta2.SparkApplication) (*SparkSe
 	return r.createDriverIngressService(app, portName, port, targetPort, serviceName, serviceType, serviceAnnotations, serviceLabels)
 }
 
-func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string, ingressTLS []networkingv1.IngressTLS) (*SparkIngress, error) {
+func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string, ingressTLS []networkingv1.IngressTLS, ingressAnnotations map[string]string) (*SparkIngress, error) {
 	ingressName := util.GetDefaultUIIngressName(app)
 	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
-		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, &ingressTLS)
+		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, &ingressTLS, &ingressAnnotations)
 	}
 	return r.createDriverIngressLegacy(app, service, ingressName, ingressURL)
 }

--- a/internal/controller/sparkapplication/web_ui.go
+++ b/internal/controller/sparkapplication/web_ui.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 func (r *Reconciler) createWebUIService(app *v1beta2.SparkApplication) (*SparkService, error) {
@@ -46,10 +47,10 @@ func (r *Reconciler) createWebUIService(app *v1beta2.SparkApplication) (*SparkSe
 	return r.createDriverIngressService(app, portName, port, targetPort, serviceName, serviceType, serviceAnnotations, serviceLabels)
 }
 
-func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string) (*SparkIngress, error) {
+func (r *Reconciler) createWebUIIngress(app *v1beta2.SparkApplication, service SparkService, ingressURL *url.URL, ingressClassName string, ingressTLS []networkingv1.IngressTLS) (*SparkIngress, error) {
 	ingressName := util.GetDefaultUIIngressName(app)
 	if util.IngressCapabilities.Has("networking.k8s.io/v1") {
-		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName)
+		return r.createDriverIngressV1(app, service, ingressName, ingressURL, ingressClassName, &ingressTLS)
 	}
 	return r.createDriverIngressLegacy(app, service, ingressName, ingressURL)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR
Support helm chart level defaults for ingress TLS and annotations, so they don't need to be configured on every SparkApplication. 
Closes: https://github.com/kubeflow/spark-operator/issues/2460

**Proposed changes:**

- Add CLI arguments `--ingress-tls` and `--ingress-annotations` and use them when TLS/annotations are not provided in the SparkApplication's spec. These are provided as JSON strings in the CLI. 
- Expose these via the helm config. The user configures them as normal in the helm yaml and they get serialised to JSON, so they can be read by the controller. 
- Wrote unit tests. 

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes
I considered adding an e2e test to cover the helm and CLI configuration. However, I couldn't see a way to run the e2e tests with multiple helm configs. I could have changed all the e2e tests to use these new configs, but then we loose test coverage for when the new configs are not used. 

I'm a golang noob. 
