### PR TITLE
Add enterprise-gateway as sub chart to spark-operator

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -30,6 +30,13 @@ keywords:
 
 home: https://github.com/kubeflow/spark-operator
 
+dependencies:
+  - name: enterprise-gateway
+    version: 3.3.0-dev.0
+    repository: https://lresende.github.io/helm-chart/
+    alias: jupyter-gateway
+    condition: jupyter-gateway.enable
+
 maintainers:
 - name: yuchaoran2011
   email: yuchaoran2011@gmail.com

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -435,3 +435,10 @@ certManager:
   # See [cert-manager.io/v1.Certificate](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Certificate).
   # @default -- 1/3 of issued certificate’s lifetime.
   renewBefore: ""
+
+  jupyter-gateway:
+    # -- Specifies whether to enable Jupyter Gateway.
+    enable: true
+    namespace: enterprise-gateway
+    kip:
+      enabled: false


### PR DESCRIPTION
## Purpose of this PR

Adds an optional dependency for the Enterprise Gateway as a subchart to the Spark Operator Helm chart to enable Jupyter notebooks to launch kernels in Spark Operator. The chart will only install the gateway if `jupyter-gateway.enable` is set to true.

Still waiting on the dependency [#1408](https://github.com/jupyter-server/enterprise_gateway/pull/1408)  before we can continue.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [X ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.