### PR TITLE
Splat recordExecutorEvent args for cleaner event messages

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -1156,18 +1156,18 @@ func (r *Reconciler) recordDriverEvent(app *v1beta2.SparkApplication, state v1be
 	}
 }
 
-func (r *Reconciler) recordExecutorEvent(app *v1beta2.SparkApplication, state v1beta2.ExecutorState, args ...interface{}) {
+func (r *Reconciler) recordExecutorEvent(app *v1beta2.SparkApplication, state v1beta2.ExecutorState, args ...any) {
 	switch state {
 	case v1beta2.ExecutorStatePending:
-		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorPending, "Executor %s is pending", args)
+		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorPending, "Executor %s is pending", args...)
 	case v1beta2.ExecutorStateRunning:
-		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorRunning, "Executor %s is running", args)
+		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorRunning, "Executor %s is running", args...)
 	case v1beta2.ExecutorStateCompleted:
-		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorCompleted, "Executor %s completed", args)
+		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorCompleted, "Executor %s completed", args...)
 	case v1beta2.ExecutorStateFailed:
-		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorFailed, "Executor %s failed with ExitCode: %d, Reason: %s", args)
+		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorFailed, "Executor %s failed with ExitCode: %d, Reason: %s", args...)
 	case v1beta2.ExecutorStateUnknown:
-		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorUnknown, "Executor %s in unknown state", args)
+		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorUnknown, "Executor %s in unknown state", args...)
 	}
 }
 


### PR DESCRIPTION
PR loosely related to https://github.com/kubeflow/spark-operator/issues/1263

## Purpose of this PR

Splats args provided to `recordExecutorEvent` to avoid missing interpolation in event messages.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Without this change you'll get messages that look like this:

```
Executor [spark-pi-python-oomer-9ee50397e27f13ad-exec-3 %!s(int32=137) OOMKilled] failed with ExitCode: %!d(MISSING), Reason: %!s(MISSING)
```

With this change they look like this instead:

```
Executor spark-pi-python-oomer-8cfd2197e269b2ec-exec-1 failed with ExitCode: 137, Reason: OOMKilled
```

## Checklist

- [x] I have conducted a self-review of my own code.
- ~I have updated documentation accordingly.~ no documentation found on event formatting
- ~I have added tests that prove my changes are effective or that my feature works.~ see Additional Notes
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

It looks like the `args` slice was introduced back in [#1280](https://github.com/kubeflow/spark-operator/pull/1280/files#diff-915090b1cf1857dc448319dbbbc11699ba40e674744723a5772a4624a1c79282R980) and has been un-splatted ever since.

There doesn't appear to be any specific testing for these event recorders, but I confirmed via panic insertion that it does get exercised by ["SparkApplication Controller When reconciling a running SparkApplication [It] Should add the executors to the SparkApplication"](https://github.com/kubeflow/spark-operator/blob/191ac52820444bbca2d4cc8700b8367f7fb07833/internal/controller/sparkapplication/controller_test.go#L716)