### PR TITLE
Include pod.Status.Message in recordExecutorEvent

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -842,11 +842,11 @@ func (r *Reconciler) updateExecutorState(ctx context.Context, app *v1beta2.Spark
 				if newState == v1beta2.ExecutorStateFailed {
 					execContainerState := util.GetExecutorContainerTerminatedState(&pod)
 					if execContainerState != nil {
-						r.recordExecutorEvent(app, newState, pod.Name, execContainerState.ExitCode, execContainerState.Reason)
+						r.recordExecutorEvent(app, newState, pod.Name, execContainerState.ExitCode, execContainerState.Reason, pod.Status.Message)
 					} else {
 						// If we can't find the container state,
 						// we need to set the exitCode and the Reason to unambiguous values.
-						r.recordExecutorEvent(app, newState, pod.Name, -1, "Unknown (Container not Found)")
+						r.recordExecutorEvent(app, newState, pod.Name, -1, "Unknown (Container not Found)", pod.Status.Message)
 					}
 				} else {
 					r.recordExecutorEvent(app, newState, pod.Name)
@@ -1165,7 +1165,7 @@ func (r *Reconciler) recordExecutorEvent(app *v1beta2.SparkApplication, state v1
 	case v1beta2.ExecutorStateCompleted:
 		r.recorder.Eventf(app, corev1.EventTypeNormal, common.EventSparkExecutorCompleted, "Executor %s completed", args...)
 	case v1beta2.ExecutorStateFailed:
-		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorFailed, "Executor %s failed with ExitCode: %d, Reason: %s", args...)
+		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorFailed, "Executor %s failed with ExitCode: %d, Reason: %s, Pod Message: %s", args...)
 	case v1beta2.ExecutorStateUnknown:
 		r.recorder.Eventf(app, corev1.EventTypeWarning, common.EventSparkExecutorUnknown, "Executor %s in unknown state", args...)
 	}


### PR DESCRIPTION
PR loosely related to https://github.com/kubeflow/spark-operator/issues/1263

## Purpose of this PR

This adds `pod.Status.Message` to the event message produced by `recordExecutorEvent`

**Proposed changes:**

- Append `pod.Status.Message` content to the message produced by recordExecutorEvent, if available in the pod data

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

This is especially useful for ephemeral-storage exhaustion. In this case you don't get a container termination reason since the storage is pod-level. The yaml ends up looking like this:

```yaml
  containerStatuses:
  - name: spark-kubernetes-executor 
    # [snip...]
    ready: false
    restartCount: 0
    started: false
    state:
      terminated:
        containerID: containerd://0f83df84ff6f209c16fc98833eb904f4976bdd054f18ec81e328bf96622ae282
        exitCode: 143
        finishedAt: "2025-07-09T20:10:38Z"
        reason: Error
        startedAt: "2025-07-09T20:07:47Z"
    volumeMounts:
    - [snip...]
  hostIP: [redacted]
  hostIPs:
  - ip: [redacted]
  message: 'Pod ephemeral local storage usage exceeds the total limit of containers
    10Gi. '
  phase: Failed
```

The resulting message will look like this:

```
0s                      Warning   SparkExecutorFailed                SparkApplication/spark-python-misfit              Executor spark-python-misfit-7db59b97f110ed3f-exec-1 failed with ExitCode: 143, Reason: Error, Pod Message: Pod ephemeral local storage usage exceeds the total limit of containers 200Mi.
```

## Checklist

- [x] I have conducted a self-review of my own code.
- ~I have updated documentation accordingly.~ no documentation found on event formatting
- ~I have added tests that prove my changes are effective or that my feature works.~ see Additional notes
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

As with https://github.com/kubeflow/spark-operator/pull/2582 this function doesn't have any direct testing, but it does get exercised by ["SparkApplication Controller When reconciling a running SparkApplication [It] Should add the executors to the SparkApplication"](https://github.com/kubeflow/spark-operator/blob/191ac52820444bbca2d4cc8700b8367f7fb07833/internal/controller/sparkapplication/controller_test.go#L716)