### PR TITLE
Add print columns for Spark Connect

### DIFF
--- a/api/v1alpha1/sparkconnect_types.go
+++ b/api/v1alpha1/sparkconnect_types.go
@@ -30,6 +30,8 @@ func init() {
 // +kubebuilder:resource:scope=Namespaced,shortName=sparkconn,singular=sparkconnect
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=.metadata.creationTimestamp,name=Age,type=date
+// +kubebuilder:printcolumn:JSONPath=.status.state,name="Status",type=string
+// +kubebuilder:printcolumn:JSONPath=.status.server.podName,name="PodName",type=string
 
 // SparkConnect is the Schema for the sparkconnections API.
 type SparkConnect struct {

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkconnects.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkconnects.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.server.podName
+      name: PodName
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/sparkoperator.k8s.io_sparkconnects.yaml
+++ b/config/crd/bases/sparkoperator.k8s.io_sparkconnects.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.server.podName
+      name: PodName
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This adds two additional print columns: `state` and `podname`. Adding them should make it easier for end users to figure out what is happening to the spark connect server.

```
k get sparkconn
NAME            AGE   STATUS     PODNAME
spark-connect   59s   NotReady   spark-connect-server
```

**Proposed changes:**

- adds two additional print columns: `state` and `podname`
- <Change 2>
- <Change 3>

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
