### PR TITLE
fix: Patch memory resources being duplicated

### DIFF
--- a/internal/webhook/resourcequota.go
+++ b/internal/webhook/resourcequota.go
@@ -153,13 +153,16 @@ func getSparkPodCoresLimits(podSpec *v1beta2.SparkPodSpec, replicas int64) (core
 	return resourceList, nil
 }
 
-func getMemoryRequests(app *v1beta2.SparkApplication) (corev1.ResourceList, error) {
+func getMemory(
+	app *v1beta2.SparkApplication,
+	parseLimit bool,
+) (int64, error) {
 	// If memory overhead factor is set, use it. Otherwise, use the default value.
 	var memoryOverheadFactor float64
 	if app.Spec.MemoryOverheadFactor != nil {
 		parsed, err := strconv.ParseFloat(*app.Spec.MemoryOverheadFactor, 64)
 		if err != nil {
-			return nil, err
+			return -1, err
 		}
 		memoryOverheadFactor = parsed
 	} else if app.Spec.Type == v1beta2.SparkApplicationTypeJava {
@@ -169,9 +172,14 @@ func getMemoryRequests(app *v1beta2.SparkApplication) (corev1.ResourceList, erro
 	}
 
 	// Calculate driver pod memory requests.
-	driverResourceList, err := getSparkPodMemoryRequests(&app.Spec.Driver.SparkPodSpec, memoryOverheadFactor, 1)
+	driverMemory, err := getSparkPodMemory(
+		&app.Spec.Driver.SparkPodSpec,
+		memoryOverheadFactor,
+		1,
+		parseLimit,
+	)
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
 	// Calculate executor pod memory requests.
@@ -179,44 +187,71 @@ func getMemoryRequests(app *v1beta2.SparkApplication) (corev1.ResourceList, erro
 	if app.Spec.Executor.Instances != nil {
 		replicas = int64(*app.Spec.Executor.Instances)
 	}
-	executorResourceList, err := getSparkPodMemoryRequests(&app.Spec.Executor.SparkPodSpec, memoryOverheadFactor, replicas)
+	executorMemory, err := getSparkPodMemory(
+		&app.Spec.Executor.SparkPodSpec,
+		memoryOverheadFactor,
+		replicas,
+		parseLimit,
+	)
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
-	return util.SumResourceList([]corev1.ResourceList{driverResourceList, executorResourceList}), nil
+	return driverMemory + executorMemory, nil
 }
 
-func getSparkPodMemoryRequests(podSpec *v1beta2.SparkPodSpec, memoryOverheadFactor float64, replicas int64) (corev1.ResourceList, error) {
+func getSparkPodMemory(
+	podSpec *v1beta2.SparkPodSpec,
+	memoryOverheadFactor float64,
+	replicas int64,
+	parseLimit bool,
+) (int64, error) {
 	var memoryBytes, memoryOverheadBytes int64
-	if podSpec.Memory != nil {
-		parsed, err := parseJavaMemoryString(*podSpec.Memory)
-		if err != nil {
-			return nil, err
-		}
-		memoryBytes = parsed
+	var err error
+	if parseLimit && podSpec.MemoryLimit != nil {
+		memoryBytes, err = parseJavaMemoryString(*podSpec.MemoryLimit)
+	} else if podSpec.Memory != nil {
+		// Either in the case of parsing requests or if parsing limits but no limit is supplied
+		memoryBytes, err = parseJavaMemoryString(*podSpec.Memory)
+	} else {
+		memoryBytes = common.DefaultMemoryBytes
+	}
+	if err != nil {
+		return -1, err
 	}
 
 	if podSpec.MemoryOverhead != nil {
 		parsed, err := parseJavaMemoryString(*podSpec.MemoryOverhead)
 		if err != nil {
-			return nil, err
+			return -1, err
 		}
 		memoryOverheadBytes = parsed
 	} else {
 		memoryOverheadBytes = int64(math.Max(float64(memoryBytes)*memoryOverheadFactor, common.MinMemoryOverhead))
 	}
 
-	resourceList := corev1.ResourceList{
-		corev1.ResourceMemory:         *resource.NewQuantity((memoryBytes+memoryOverheadBytes)*replicas, resource.BinarySI),
-		corev1.ResourceRequestsMemory: *resource.NewQuantity((memoryBytes+memoryOverheadBytes)*replicas, resource.BinarySI),
-	}
-	return resourceList, nil
+	return (memoryBytes + memoryOverheadBytes) * replicas, nil
 }
 
-// For Spark pod, memory requests and limits are the same.
+func getMemoryRequests(app *v1beta2.SparkApplication) (corev1.ResourceList, error) {
+	memoryBytes, err := getMemory(app, false)
+	if err != nil {
+		return nil, err
+	}
+	return corev1.ResourceList{
+		corev1.ResourceMemory:         *resource.NewQuantity(memoryBytes, resource.BinarySI),
+		corev1.ResourceRequestsMemory: *resource.NewQuantity(memoryBytes, resource.BinarySI),
+	}, nil
+}
+
 func getMemoryLimits(app *v1beta2.SparkApplication) (corev1.ResourceList, error) {
-	return getMemoryRequests(app)
+	memoryBytes, err := getMemory(app, true)
+	if err != nil {
+		return nil, err
+	}
+	return corev1.ResourceList{
+		corev1.ResourceLimitsMemory: *resource.NewQuantity(memoryBytes, resource.BinarySI),
+	}, nil
 }
 
 // Logic copied from https://github.com/apache/spark/blob/5264164a67df498b73facae207eda12ee133be7d/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java#L276
@@ -245,15 +280,28 @@ func parseJavaMemoryString(s string) (int64, error) {
 }
 
 // Check whether the resource list will satisfy the resource quota.
-func validateResourceQuota(resourceList corev1.ResourceList, resourceQuota corev1.ResourceQuota) bool {
-	for key, quantity := range resourceList {
+func validateResourceQuota(resourceList corev1.ResourceList, resourceQuota corev1.ResourceQuota) error {
+	for key, requested := range resourceList {
 		if _, ok := resourceQuota.Status.Hard[key]; !ok {
 			continue
 		}
-		quantity.Add(resourceQuota.Status.Used[key])
-		if quantity.Cmp(resourceQuota.Spec.Hard[key]) > 0 {
-			return false
+
+		// These are to make formatting easier
+		total := requested.DeepCopy()
+		used := resourceQuota.Status.Used[key]
+		hard := resourceQuota.Status.Hard[key]
+
+		total.Add(used)
+		if total.Cmp(hard) > 0 {
+			return fmt.Errorf(
+				"Exceeded '%s' quota: requested=%s, used=%s, limit=%s (new total would be: %s)",
+				key,
+				requested.String(),
+				used.String(),
+				hard.String(),
+				total.String(),
+			)
 		}
 	}
-	return true
+	return nil
 }

--- a/internal/webhook/resourcequota.go
+++ b/internal/webhook/resourcequota.go
@@ -294,7 +294,7 @@ func validateResourceQuota(resourceList corev1.ResourceList, resourceQuota corev
 		total.Add(used)
 		if total.Cmp(hard) > 0 {
 			return fmt.Errorf(
-				"Exceeded '%s' quota: requested=%s, used=%s, limit=%s (new total would be: %s)",
+				"exceeded '%s' quota: requested=%s, used=%s, limit=%s (new total would be: %s)",
 				key,
 				requested.String(),
 				used.String(),

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -112,6 +112,7 @@ func (v *SparkApplicationValidator) ValidateUpdate(ctx context.Context, oldObj r
 	// Validate SparkApplication resource usage when resource quota enforcement is enabled.
 	if v.enableResourceQuotaEnforcement {
 		if err := v.validateResourceUsage(ctx, newApp); err != nil {
+			logger.Info("Resource request validation failed: %s", err)
 			return nil, err
 		}
 	}
@@ -185,7 +186,7 @@ func (v *SparkApplicationValidator) validateSparkVersion(app *v1beta2.SparkAppli
 func (v *SparkApplicationValidator) validateResourceUsage(ctx context.Context, app *v1beta2.SparkApplication) error {
 	requests, err := getResourceList(app)
 	if err != nil {
-		return fmt.Errorf("failed to calculate resource quests: %v", err)
+		return fmt.Errorf("failed to calculate resource requests: %v", err)
 	}
 
 	resourceQuotaList := &corev1.ResourceQuotaList{}
@@ -200,8 +201,8 @@ func (v *SparkApplicationValidator) validateResourceUsage(ctx context.Context, a
 			continue
 		}
 
-		if !validateResourceQuota(requests, resourceQuota) {
-			return fmt.Errorf("failed to validate resource quota \"%s/%s\"", resourceQuota.Namespace, resourceQuota.Name)
+		if err := validateResourceQuota(requests, resourceQuota); err != nil {
+			return fmt.Errorf("failed to validate resource quota \"%s/%s\" with error \"%s\"", resourceQuota.Namespace, resourceQuota.Name, err)
 		}
 	}
 

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -73,6 +73,7 @@ func (v *SparkApplicationValidator) ValidateCreate(ctx context.Context, obj runt
 
 	if v.enableResourceQuotaEnforcement {
 		if err := v.validateResourceUsage(ctx, app); err != nil {
+			logger.Error(err, "Resource request validation failed")
 			return nil, err
 		}
 	}
@@ -112,7 +113,7 @@ func (v *SparkApplicationValidator) ValidateUpdate(ctx context.Context, oldObj r
 	// Validate SparkApplication resource usage when resource quota enforcement is enabled.
 	if v.enableResourceQuotaEnforcement {
 		if err := v.validateResourceUsage(ctx, newApp); err != nil {
-			logger.Info("Resource request validation failed: %s", err)
+			logger.Error(err, "Resource request validation failed")
 			return nil, err
 		}
 	}

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -202,7 +202,7 @@ func (v *SparkApplicationValidator) validateResourceUsage(ctx context.Context, a
 		}
 
 		if err := validateResourceQuota(requests, resourceQuota); err != nil {
-			return fmt.Errorf("failed to validate resource quota \"%s/%s\" with error \"%s\"", resourceQuota.Namespace, resourceQuota.Name, err)
+			return fmt.Errorf("failed to validate resource quota \"%s/%s\" with error \"%v\"", resourceQuota.Namespace, resourceQuota.Name, err)
 		}
 	}
 

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -18,6 +18,8 @@ package webhook
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -209,6 +211,58 @@ func TestSparkApplicationValidatorValidateCreate_ResourceQuotaExceeded(t *testin
 
 	if _, err := validator.ValidateCreate(context.Background(), newSparkApplication()); err == nil || !strings.Contains(err.Error(), "failed to validate resource quota") {
 		t.Fatalf("expected resource quota validation error, got %v", err)
+	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_ResourceQuota_Mem(t *testing.T) {
+	cases := []struct {
+		hard, used   string
+		expect_error bool
+		err_pattern  string
+	}{
+		{"3Gi", "0", false, ""},
+		{"2Gi", "0", true, `failed to validate resource quota "default/strict" with error "exceeded '.*' quota: requested=3006477106, used=0, limit=2Gi \(new total would be: 3006477106\)"`},
+		{"1Gi", "0", true, `failed to validate resource quota "default/strict" with error "exceeded '.*' quota: requested=3006477106, used=0, limit=1Gi \(new total would be: 3006477106\)"`},
+		{"512Mi", "0", true, `failed to validate resource quota "default/strict" with error "exceeded '.*' quota: requested=3006477106, used=0, limit=512Mi \(new total would be: 3006477106\)"`},
+	}
+
+	for _, tc := range cases {
+		for _, kind := range []corev1.ResourceName{corev1.ResourceLimitsMemory, corev1.ResourceMemory, corev1.ResourceRequestsMemory} {
+			t.Run(fmt.Sprintf("%v-%v", kind, tc.hard), func(t *testing.T) {
+				quota := &corev1.ResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "strict",
+						Namespace: "default",
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: corev1.ResourceList{
+							kind: resource.MustParse(tc.hard),
+						},
+					},
+					Status: corev1.ResourceQuotaStatus{
+						Hard: corev1.ResourceList{
+							kind: resource.MustParse(tc.hard),
+						},
+						Used: corev1.ResourceList{
+							kind: resource.MustParse(tc.used),
+						},
+					},
+				}
+
+				validator := newTestValidator(t, true, quota)
+
+				_, err := validator.ValidateCreate(context.Background(), newSparkApplication())
+				if err != nil && !tc.expect_error {
+					t.Errorf("Unexpected error:\n\texpected=<nil>\n\treturned=%v", err)
+				} else if err == nil && tc.expect_error {
+					t.Errorf("Unexpected error:\n\t pattern=%v\n\treturned=%v", tc.err_pattern, err)
+				} else if tc.expect_error {
+					if matched, _ := regexp.MatchString(tc.err_pattern, err.Error()); !matched {
+						t.Errorf("Unexpected error:\n\t pattern=%v\n\treturned=%v", tc.err_pattern, err)
+					}
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

This PR is to fix an error where memory requests are doubled for spark applications when quota enforcement is enabled. The changes added are in two main categories listed below.

**IMPORTANT NOTE:** Before merge, I will add some additional tests to validate this logic. Putting up the PR now for some early feedback.

**Proposed changes:**

1. Fix the memory resource validation
2. Add more information when resources are rejected
3. Other misc things
    - Add a default for when no memory is set [here](https://github.com/CarterFendley/spark-operator/blob/8755dc43b01052ed56e93928e8125b85e382c04a/internal/webhook/resourcequota.go#L217)

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

For the changes respectively:
1. Resource quotas for memory do not seem to be evaluated correctly.
2. Add more informative information so a user can know which resource they are exceeding.

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

#### Change 2 - Add more information when resources are rejected.

First I will explain the new error message because that is simple. With a change to [validateResourceQuota](https://github.com/CarterFendley/spark-operator/blob/8755dc43b01052ed56e93928e8125b85e382c04a/internal/webhook/resourcequota.go#L283) and [validateResourceUsage](https://github.com/CarterFendley/spark-operator/blob/8755dc43b01052ed56e93928e8125b85e382c04a/internal/webhook/sparkapplication_validator.go#L186) the new error message looks like:
```
Error from server (Forbidden): error when creating "examples/spark-pi.yaml": admission webhook "validate-sparkoperator-k8s-io-v1beta2-sparkapplication.sparkoperator.k8s.io" denied the request: failed to validate resource quota "default/compute-quota" with error "Exceeded 'memory' quota: requested=3584Mi, used=0, limit=2Gi (new total would be: 3584Mi)
```
This matches the native Spark K8 integration more closely and removes guess work.

#### Change 1 - Fix the memory resource validation.

At a high level, because
- `getSparkPodMemoryRequests` was setting `memory` and `requests.memory` [here](https://github.com/CarterFendley/spark-operator/blob/610ec74d9df46b0aeee71bec53100768c8c06cb7/internal/webhook/resourcequota.go#L210-L213)
- `getMemoryLimits` reused this function [here](https://github.com/CarterFendley/spark-operator/blob/610ec74d9df46b0aeee71bec53100768c8c06cb7/internal/webhook/resourcequota.go#L219)

Then [this SumResourceList](https://github.com/CarterFendley/spark-operator/blob/610ec74d9df46b0aeee71bec53100768c8c06cb7/internal/webhook/resourcequota.go#L73-L78) will double `memory` and `requests.memory`.

This can be seen while running the `examples/spark-pi.yaml` after enabling `--enable-resource-quota-enforcement=true` and with the following resource quota:
```yaml
apiVersion: v1
kind: ResourceQuota
metadata:
  name: compute-quota
spec:
  hard:
    pods: "10"
    cpu: "2"
    memory: 2Gi
```
This is what produced the error message shown above.
```
Error from server (Forbidden): error when creating "examples/spark-pi.yaml": admission webhook "validate-sparkoperator-k8s-io-v1beta2-sparkapplication.sparkoperator.k8s.io" denied the request: failed to validate resource quota "default/compute-quota" with error "Exceeded 'memory' quota: requested=3584Mi, used=0, limit=2Gi (new total would be: 3584Mi)
```
As this error message states, the calculated requested memory is `3584Mi`. However this spark job only requests `512m` for the driver and a single executor (see [here](https://github.com/CarterFendley/spark-operator/blob/610ec74d9df46b0aeee71bec53100768c8c06cb7/examples/spark-pi.yaml#L35)). This plus the default overhead should give us a total application request of:
```
(512 + 384) * 2 = 1792
```
However due to the reasons shown above we are getting:
```
((512 + 384) * 2) * 2 = 3584
```

This PR changes `getSparkPodMemoryRequests` (renamed `getSparkPodMemory`) and `getMemoryRequests` (renamed `getMemory`) to return a simple `int64`. Then `getMemoryRequests` and `getMemoryLimits` set the specific resource name [here](https://github.com/CarterFendley/spark-operator/blob/8755dc43b01052ed56e93928e8125b85e382c04a/internal/webhook/resourcequota.go#L236-L255).

Because this will now produce `memory`, `requests.memory` *and* `limits.memory` without any key duplicated, then the doubling is removed.

*Another note:* This is my first commit to the spark-operator side of kubeflow so if there is any convention which I should be following and I have neglected, please let me know and I will make changes :+1: 
