### PR TITLE
fix: requeue pending rerun while resources exist

### DIFF
--- a/api/v1beta2/defaults.go
+++ b/api/v1beta2/defaults.go
@@ -65,6 +65,11 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 		}
 	}
 
+	// Default RetryInterval to 5 sec for retry/poll intervals.
+	if app.Spec.RetryInterval == nil {
+		app.Spec.RetryInterval = ptr.To[int64](5)
+	}
+
 	setDriverSpecDefaults(&app.Spec.Driver, app.Spec.SparkConf)
 	setExecutorSpecDefaults(&app.Spec.Executor, app.Spec.SparkConf, app.Spec.DynamicAllocation)
 }

--- a/api/v1beta2/defaults_test.go
+++ b/api/v1beta2/defaults_test.go
@@ -120,6 +120,31 @@ func TestSetSparkApplicationDefaultsOnFailureRestartPolicyShouldSetDefaultValueF
 	assert.Equal(t, int64(5), *app.Spec.RestartPolicy.OnSubmissionFailureRetryInterval)
 }
 
+func TestSetSparkApplicationDefaultsShouldSetDefaultRetryInterval(t *testing.T) {
+	app := &SparkApplication{
+		Spec: SparkApplicationSpec{},
+	}
+
+	SetSparkApplicationDefaults(app)
+
+	assert.NotNil(t, app.Spec.RetryInterval)
+	assert.Equal(t, int64(5), *app.Spec.RetryInterval)
+}
+
+func TestSetSparkApplicationDefaultsShouldNotOverrideRetryInterval(t *testing.T) {
+	expectedRetryInterval := int64(12)
+	app := &SparkApplication{
+		Spec: SparkApplicationSpec{
+			RetryInterval: &expectedRetryInterval,
+		},
+	}
+
+	SetSparkApplicationDefaults(app)
+
+	assert.NotNil(t, app.Spec.RetryInterval)
+	assert.Equal(t, expectedRetryInterval, *app.Spec.RetryInterval)
+}
+
 func TestSetSparkApplicationDefaultsDriverSpecDefaults(t *testing.T) {
 	//Case1: Driver config not set.
 	app := &SparkApplication{

--- a/api/v1beta2/sparkapplication_types.go
+++ b/api/v1beta2/sparkapplication_types.go
@@ -107,7 +107,8 @@ type SparkApplicationSpec struct {
 	// This is best effort and actual retry attempts can be >= the value specified.
 	// +optional
 	FailureRetries *int32 `json:"failureRetries,omitempty"`
-	// RetryInterval is the unit of intervals in seconds between submission retries.
+	// RetryInterval is the unit of intervals in seconds between retry/poll attempts
+	// in controller-managed loops (for example submission retries and pending rerun cleanup polling).
 	// +optional
 	RetryInterval *int64 `json:"retryInterval,omitempty"`
 	// This sets the major Python version of the docker

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -52,6 +52,8 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
+const pendingRerunRequeueDelay = 5 * time.Second
+
 // Options defines the options of the controller.
 type Options struct {
 	Namespaces            []string
@@ -500,6 +502,7 @@ func (r *Reconciler) reconcileRunningSparkApplication(ctx context.Context, req c
 func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	key := req.NamespacedName
+	var result ctrl.Result
 	retryErr := retry.RetryOnConflict(
 		retry.DefaultRetry,
 		func() error {
@@ -518,7 +521,13 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 				r.recordSparkApplicationEvent(app)
 				r.submitSparkApplication(ctx, app)
 			} else {
-				logger.Info("Resources associated with SparkApplication still exist")
+				// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
+				// but the UI Service is still terminating.
+				logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
+				if err := r.deleteSparkResources(ctx, app); err != nil {
+					logger.Error(err, "failed to delete spark resources")
+				}
+				result.RequeueAfter = pendingRerunRequeueDelay
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
 				return err
@@ -528,9 +537,9 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 	)
 	if retryErr != nil {
 		logger.Error(retryErr, "Failed to reconcile SparkApplication")
-		return ctrl.Result{}, retryErr
+		return result, retryErr
 	}
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 func (r *Reconciler) reconcileInvalidatingSparkApplication(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -523,31 +523,22 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 				if app.Status.TerminationTime.IsZero() {
 					app.Status.TerminationTime = metav1.Now()
 				}
-				if util.PendingRerunCleanupRetryBudgetExceeded(app) {
-					app.Status.TerminationTime = metav1.Now()
-					app.Status.AppState.State = v1beta2.ApplicationStateFailed
-					app.Status.AppState.ErrorMessage = "failed to delete resources before rerun after exhausting cleanup retries"
-					r.recordSparkApplicationEvent(app)
-				} else {
-					timeUntilNextRetryDue, err := util.TimeUntilNextRetryDue(app)
-					if err != nil {
-						app.Status.TerminationTime = metav1.Now()
-						app.Status.AppState.State = v1beta2.ApplicationStateFailed
-						app.Status.AppState.ErrorMessage = fmt.Sprintf("failed to determine pending rerun cleanup retry: %v", err)
-						r.recordSparkApplicationEvent(app)
-					} else if timeUntilNextRetryDue <= 0 {
-						// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
-						// but the UI Service/executors are still terminating.
-						logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
-						if err := r.deleteSparkResources(ctx, app); err != nil {
-							logger.Error(err, "failed to delete spark resources")
-						}
-						result.Requeue = true
-					} else {
-						// Keep polling until Kubernetes GC has finished removing all resources associated with the app.
-						logger.Info("Resources associated with SparkApplication still exist, waiting for GC to complete")
-						result.RequeueAfter = timeUntilNextRetryDue
+				timeUntilNextRetryDue, err := util.TimeUntilNextRetryDue(app)
+				if err != nil {
+					// If no retry interval can be computed for this state, requeue with default rate limiter backoff.
+					result.Requeue = true
+				} else if timeUntilNextRetryDue <= 0 {
+					// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
+					// but the UI Service/executors are still terminating.
+					logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
+					if err := r.deleteSparkResources(ctx, app); err != nil {
+						logger.Error(err, "failed to delete spark resources")
 					}
+					result.Requeue = true
+				} else {
+					// Keep polling until Kubernetes GC has finished removing all resources associated with the app.
+					logger.Info("Resources associated with SparkApplication still exist, waiting for GC to complete")
+					result.RequeueAfter = timeUntilNextRetryDue
 				}
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -52,7 +52,11 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
-const pendingRerunRequeueDelay = 5 * time.Second
+const (
+	pendingRerunRequeueDelay = 5 * time.Second
+	// Keep PendingRerun cleanup retry budget aligned with the default Pod termination grace period (30s).
+	pendingRerunCleanupRetryWindow = 30 * time.Second
+)
 
 // Options defines the options of the controller.
 type Options struct {
@@ -518,16 +522,31 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 			logger.Info("Pending rerun SparkApplication", "state", app.Status.AppState.State)
 			if r.validateSparkResourceDeletion(ctx, app) {
 				logger.Info("Successfully deleted resources associated with SparkApplication", "state", app.Status.AppState.State)
+				// This timestamp is used only for bounding PendingRerun cleanup retries.
+				app.Status.TerminationTime = metav1.Time{}
 				r.recordSparkApplicationEvent(app)
 				r.submitSparkApplication(ctx, app)
 			} else {
-				// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
-				// but the UI Service is still terminating.
-				logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
-				if err := r.deleteSparkResources(ctx, app); err != nil {
-					logger.Error(err, "failed to delete spark resources")
+				if app.Status.TerminationTime.IsZero() {
+					app.Status.TerminationTime = metav1.Now()
 				}
-				result.RequeueAfter = pendingRerunRequeueDelay
+
+				if time.Since(app.Status.TerminationTime.Time) >= pendingRerunCleanupRetryWindow {
+					app.Status.AppState.State = v1beta2.ApplicationStateFailed
+					app.Status.AppState.ErrorMessage = fmt.Sprintf(
+						"failed to delete resources before rerun within %s",
+						pendingRerunCleanupRetryWindow,
+					)
+					logger.Info("Pending rerun cleanup timed out, transitioning to failed state")
+				} else {
+					// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
+					// but the UI Service is still terminating.
+					logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
+					if err := r.deleteSparkResources(ctx, app); err != nil {
+						logger.Error(err, "failed to delete spark resources")
+					}
+					result.RequeueAfter = pendingRerunRequeueDelay
+				}
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
 				return err

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -52,12 +52,6 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
-const (
-	pendingRerunRequeueDelay = 5 * time.Second
-	// Keep PendingRerun cleanup retry budget aligned with the default Pod termination grace period (30s).
-	pendingRerunCleanupRetryWindow = 30 * time.Second
-)
-
 // Options defines the options of the controller.
 type Options struct {
 	Namespaces            []string
@@ -522,7 +516,6 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 			logger.Info("Pending rerun SparkApplication", "state", app.Status.AppState.State)
 			if r.validateSparkResourceDeletion(ctx, app) {
 				logger.Info("Successfully deleted resources associated with SparkApplication", "state", app.Status.AppState.State)
-				// This timestamp is used only for bounding PendingRerun cleanup retries.
 				app.Status.TerminationTime = metav1.Time{}
 				r.recordSparkApplicationEvent(app)
 				r.submitSparkApplication(ctx, app)
@@ -530,22 +523,31 @@ func (r *Reconciler) reconcilePendingRerunSparkApplication(ctx context.Context, 
 				if app.Status.TerminationTime.IsZero() {
 					app.Status.TerminationTime = metav1.Now()
 				}
-
-				if time.Since(app.Status.TerminationTime.Time) >= pendingRerunCleanupRetryWindow {
+				if util.PendingRerunCleanupRetryBudgetExceeded(app) {
+					app.Status.TerminationTime = metav1.Now()
 					app.Status.AppState.State = v1beta2.ApplicationStateFailed
-					app.Status.AppState.ErrorMessage = fmt.Sprintf(
-						"failed to delete resources before rerun within %s",
-						pendingRerunCleanupRetryWindow,
-					)
-					logger.Info("Pending rerun cleanup timed out, transitioning to failed state")
+					app.Status.AppState.ErrorMessage = "failed to delete resources before rerun after exhausting cleanup retries"
+					r.recordSparkApplicationEvent(app)
 				} else {
-					// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
-					// but the UI Service is still terminating.
-					logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
-					if err := r.deleteSparkResources(ctx, app); err != nil {
-						logger.Error(err, "failed to delete spark resources")
+					timeUntilNextRetryDue, err := util.TimeUntilNextRetryDue(app)
+					if err != nil {
+						app.Status.TerminationTime = metav1.Now()
+						app.Status.AppState.State = v1beta2.ApplicationStateFailed
+						app.Status.AppState.ErrorMessage = fmt.Sprintf("failed to determine pending rerun cleanup retry: %v", err)
+						r.recordSparkApplicationEvent(app)
+					} else if timeUntilNextRetryDue <= 0 {
+						// Retry cleanup in case deletion is only partially complete, for example if the driver pod is gone
+						// but the UI Service/executors are still terminating.
+						logger.Info("Resources associated with SparkApplication still exist, retrying deletion")
+						if err := r.deleteSparkResources(ctx, app); err != nil {
+							logger.Error(err, "failed to delete spark resources")
+						}
+						result.Requeue = true
+					} else {
+						// Keep polling until Kubernetes GC has finished removing all resources associated with the app.
+						logger.Info("Resources associated with SparkApplication still exist, waiting for GC to complete")
+						result.RequeueAfter = timeUntilNextRetryDue
 					}
-					result.RequeueAfter = pendingRerunRequeueDelay
 				}
 			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -1127,40 +1127,13 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStatePendingRerun))
 		})
 
-		It("Should transition to Failed after cleanup retries are exhausted", func() {
-			By("Setting the cleanup retry start time older than the retry budget")
-			app := &v1beta2.SparkApplication{}
-			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
-			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-35 * time.Second))
-			Expect(k8sClient.Status().Update(ctx, app)).Should(Succeed())
-
-			By("Reconciling the pending rerun SparkApplication")
-			reconciler := sparkapplication.NewReconciler(
-				nil,
-				k8sClient.Scheme(),
-				k8sClient,
-				record.NewFakeRecorder(3),
-				nil,
-				&sparkapplication.SparkSubmitter{},
-				sparkapplication.Options{Namespaces: []string{appNamespace}},
-			)
-			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(BeZero())
-
-			By("Checking SparkApplication transitions to Failed")
-			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
-			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
-			Expect(app.Status.TerminationTime).NotTo(BeZero())
-			Expect(app.Status.AppState.ErrorMessage).To(ContainSubstring("cleanup retries"))
-		})
-
-		It("Should transition to Failed when retry interval cannot be determined", func() {
-			By("Updating restart policy to Never so no failure retry interval is configured")
+		It("Should use spec retry interval for cleanup polling", func() {
+			By("Updating restart policy to Never and setting RetryInterval to 3 seconds")
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
 			app.Spec.RestartPolicy = v1beta2.RestartPolicy{Type: v1beta2.RestartPolicyNever}
-			Expect(k8sClient.Update(ctx, app)).Should(Succeed())
+			app.Spec.RetryInterval = ptr.To[int64](3)
+			Expect(k8sClient.Update(ctx, app)).To(Succeed())
 
 			By("Reconciling the pending rerun SparkApplication")
 			reconciler := sparkapplication.NewReconciler(
@@ -1174,13 +1147,12 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(BeZero())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).Should(BeNumerically(">", 0))
+			Expect(result.RequeueAfter).Should(BeNumerically("<=", 3*time.Second))
 
-			By("Checking SparkApplication transitions to Failed with retry interval error")
+			By("Checking SparkApplication remains PendingRerun")
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
-			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
-			Expect(app.Status.AppState.ErrorMessage).To(ContainSubstring("failed to determine pending rerun cleanup retry"))
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStatePendingRerun))
 		})
 	})
 

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -1121,6 +1121,33 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
 			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStatePendingRerun))
 		})
+
+		It("Should transition to Failed after pending rerun cleanup timeout", func() {
+			By("Setting pending rerun cleanup start time older than retry window")
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-31 * time.Second))
+			Expect(k8sClient.Status().Update(ctx, app)).Should(Succeed())
+
+			By("Reconciling the pending rerun SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			By("Checking SparkApplication transitions to Failed with cleanup timeout error")
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
+			Expect(app.Status.AppState.ErrorMessage).To(ContainSubstring("failed to delete resources before rerun"))
+		})
 	})
 
 	Context("Suspend and Resume", func() {

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -1030,6 +1030,99 @@ var _ = Describe("SparkApplication Controller", func() {
 		})
 	})
 
+	Context("When reconciling a pending rerun SparkApplication whose resources still exist", func() {
+		ctx := context.Background()
+		appName := "test-pending-rerun"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		BeforeEach(func() {
+			By("Creating a SparkApplication already marked PendingRerun")
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName,
+					Namespace: appNamespace,
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					MainApplicationFile: ptr.To("local:///dummy.jar"),
+				},
+			}
+			v1beta2.SetSparkApplicationDefaults(app)
+			Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+
+			By("Creating the driver pod and web UI service that still need cleanup")
+			driver := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driver)).To(Succeed())
+
+			uiService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.GetDefaultUIServiceName(app),
+					Namespace: appNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, uiService)).To(Succeed())
+
+			app.Status.AppState.State = v1beta2.ApplicationStatePendingRerun
+			app.Status.DriverInfo.PodName = driver.Name
+			app.Status.DriverInfo.WebUIServiceName = uiService.Name
+			Expect(k8sClient.Status().Update(ctx, app)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Deleting the test SparkApplication")
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName,
+					Namespace: appNamespace,
+				},
+			}
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, app))).Should(Succeed())
+
+			By("Deleting the driver pod")
+			driverKey := getDriverNamespacedName(appName, appNamespace)
+			driver := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      driverKey.Name,
+					Namespace: driverKey.Namespace,
+				},
+			}
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, driver))).Should(Succeed())
+
+			By("Deleting the web UI service")
+			uiService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.GetDefaultUIServiceName(app),
+					Namespace: appNamespace,
+				},
+			}
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, uiService))).Should(Succeed())
+		})
+
+		It("Should requeue while resources are still being deleted", func() {
+			By("Reconciling the pending rerun SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+			By("Checking SparkApplication remains PendingRerun")
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStatePendingRerun))
+		})
+	})
+
 	Context("Suspend and Resume", func() {
 		ctx := context.Background()
 		appName := "test"

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -1048,6 +1048,10 @@ var _ = Describe("SparkApplication Controller", func() {
 				},
 				Spec: v1beta2.SparkApplicationSpec{
 					MainApplicationFile: ptr.To("local:///dummy.jar"),
+					RestartPolicy: v1beta2.RestartPolicy{
+						Type:             v1beta2.RestartPolicyOnFailure,
+						OnFailureRetries: ptr.To[int32](3),
+					},
 				},
 			}
 			v1beta2.SetSparkApplicationDefaults(app)
@@ -1114,7 +1118,8 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+			Expect(result.RequeueAfter).Should(BeNumerically(">", 0))
+			Expect(result.RequeueAfter).Should(BeNumerically("<=", 5*time.Second))
 
 			By("Checking SparkApplication remains PendingRerun")
 			app := &v1beta2.SparkApplication{}
@@ -1122,11 +1127,11 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStatePendingRerun))
 		})
 
-		It("Should transition to Failed after pending rerun cleanup timeout", func() {
-			By("Setting pending rerun cleanup start time older than retry window")
+		It("Should transition to Failed after cleanup retries are exhausted", func() {
+			By("Setting the cleanup retry start time older than the retry budget")
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
-			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-31 * time.Second))
+			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-35 * time.Second))
 			Expect(k8sClient.Status().Update(ctx, app)).Should(Succeed())
 
 			By("Reconciling the pending rerun SparkApplication")
@@ -1143,10 +1148,39 @@ var _ = Describe("SparkApplication Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
 
-			By("Checking SparkApplication transitions to Failed with cleanup timeout error")
+			By("Checking SparkApplication transitions to Failed")
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
 			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
-			Expect(app.Status.AppState.ErrorMessage).To(ContainSubstring("failed to delete resources before rerun"))
+			Expect(app.Status.TerminationTime).NotTo(BeZero())
+			Expect(app.Status.AppState.ErrorMessage).To(ContainSubstring("cleanup retries"))
+		})
+
+		It("Should transition to Failed when retry interval cannot be determined", func() {
+			By("Updating restart policy to Never so no failure retry interval is configured")
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			app.Spec.RestartPolicy = v1beta2.RestartPolicy{Type: v1beta2.RestartPolicyNever}
+			Expect(k8sClient.Update(ctx, app)).Should(Succeed())
+
+			By("Reconciling the pending rerun SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(result.Requeue).To(BeFalse())
+
+			By("Checking SparkApplication transitions to Failed with retry interval error")
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
+			Expect(app.Status.AppState.ErrorMessage).To(ContainSubstring("failed to determine pending rerun cleanup retry"))
 		})
 	})
 

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -109,52 +109,6 @@ func ShouldRetry(app *v1beta2.SparkApplication) bool {
 	return false
 }
 
-func pendingRerunCleanupAttemptsDone(app *v1beta2.SparkApplication) (int32, bool) {
-	retryInterval := app.Spec.RestartPolicy.OnFailureRetryInterval
-	if retryInterval == nil || app.Status.TerminationTime.IsZero() {
-		return 0, false
-	}
-
-	baseInterval := time.Duration(*retryInterval) * time.Second
-	if baseInterval <= 0 {
-		return 0, false
-	}
-
-	elapsed := time.Since(app.Status.TerminationTime.Time)
-	if elapsed < 0 {
-		elapsed = 0
-	}
-
-	return int32(elapsed/baseInterval) + 1, true
-}
-
-// PendingRerunCleanupRetryBudgetExceeded returns whether cleanup retries for a PendingRerun app are exhausted.
-// This is intentionally separate from ShouldRetry because event filtering also uses ShouldRetry and
-// we do not want PendingRerun cleanup semantics to change queue behavior outside the controller.
-func PendingRerunCleanupRetryBudgetExceeded(app *v1beta2.SparkApplication) bool {
-	if app == nil || app.Status.AppState.State != v1beta2.ApplicationStatePendingRerun {
-		return false
-	}
-
-	if app.Spec.RestartPolicy.Type == v1beta2.RestartPolicyAlways {
-		return false
-	}
-	if app.Spec.RestartPolicy.Type != v1beta2.RestartPolicyOnFailure {
-		// PendingRerun can be reached from non-retry flows (e.g. INVALIDATING on spec update).
-		// Do not treat non-OnFailure policies as exhausted cleanup budget.
-		return false
-	}
-	if app.Spec.RestartPolicy.OnFailureRetries == nil {
-		return true
-	}
-
-	attemptsDone, ok := pendingRerunCleanupAttemptsDone(app)
-	if !ok {
-		return true
-	}
-	return attemptsDone > *app.Spec.RestartPolicy.OnFailureRetries
-}
-
 func TimeUntilNextRetryDue(app *v1beta2.SparkApplication) (time.Duration, error) {
 	var retryInterval *int64
 	lastAttemptTime := app.Status.LastSubmissionAttemptTime
@@ -165,11 +119,18 @@ func TimeUntilNextRetryDue(app *v1beta2.SparkApplication) (time.Duration, error)
 	case v1beta2.ApplicationStateFailing:
 		retryInterval = app.Spec.RestartPolicy.OnFailureRetryInterval
 	case v1beta2.ApplicationStatePendingRerun:
-		retryInterval = app.Spec.RestartPolicy.OnFailureRetryInterval
-		// PendingRerun cleanup retries are measured from the first cleanup attempt timestamp.
+		retryInterval = app.Spec.RetryInterval
+		// PendingRerun cleanup polling starts from the first cleanup attempt timestamp.
 		lastAttemptTime = app.Status.TerminationTime
-		if attempts, ok := pendingRerunCleanupAttemptsDone(app); ok {
-			attemptsDone = attempts
+		if retryInterval != nil && !lastAttemptTime.IsZero() {
+			baseInterval := time.Duration(*retryInterval) * time.Second
+			if baseInterval > 0 {
+				elapsed := time.Since(lastAttemptTime.Time)
+				if elapsed < 0 {
+					elapsed = 0
+				}
+				attemptsDone = int32(elapsed/baseInterval) + 1
+			}
 		}
 	}
 

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -109,17 +109,70 @@ func ShouldRetry(app *v1beta2.SparkApplication) bool {
 	return false
 }
 
+func pendingRerunCleanupAttemptsDone(app *v1beta2.SparkApplication) (int32, bool) {
+	retryInterval := app.Spec.RestartPolicy.OnFailureRetryInterval
+	if retryInterval == nil || app.Status.TerminationTime.IsZero() {
+		return 0, false
+	}
+
+	baseInterval := time.Duration(*retryInterval) * time.Second
+	if baseInterval <= 0 {
+		return 0, false
+	}
+
+	elapsed := time.Since(app.Status.TerminationTime.Time)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+
+	return int32(elapsed/baseInterval) + 1, true
+}
+
+// PendingRerunCleanupRetryBudgetExceeded returns whether cleanup retries for a PendingRerun app are exhausted.
+// This is intentionally separate from ShouldRetry because event filtering also uses ShouldRetry and
+// we do not want PendingRerun cleanup semantics to change queue behavior outside the controller.
+func PendingRerunCleanupRetryBudgetExceeded(app *v1beta2.SparkApplication) bool {
+	if app == nil || app.Status.AppState.State != v1beta2.ApplicationStatePendingRerun {
+		return false
+	}
+
+	if app.Spec.RestartPolicy.Type == v1beta2.RestartPolicyAlways {
+		return false
+	}
+	if app.Spec.RestartPolicy.Type != v1beta2.RestartPolicyOnFailure {
+		// PendingRerun can be reached from non-retry flows (e.g. INVALIDATING on spec update).
+		// Do not treat non-OnFailure policies as exhausted cleanup budget.
+		return false
+	}
+	if app.Spec.RestartPolicy.OnFailureRetries == nil {
+		return true
+	}
+
+	attemptsDone, ok := pendingRerunCleanupAttemptsDone(app)
+	if !ok {
+		return true
+	}
+	return attemptsDone > *app.Spec.RestartPolicy.OnFailureRetries
+}
+
 func TimeUntilNextRetryDue(app *v1beta2.SparkApplication) (time.Duration, error) {
 	var retryInterval *int64
+	lastAttemptTime := app.Status.LastSubmissionAttemptTime
+	attemptsDone := app.Status.SubmissionAttempts
 	switch app.Status.AppState.State {
 	case v1beta2.ApplicationStateFailedSubmission:
 		retryInterval = app.Spec.RestartPolicy.OnSubmissionFailureRetryInterval
 	case v1beta2.ApplicationStateFailing:
 		retryInterval = app.Spec.RestartPolicy.OnFailureRetryInterval
+	case v1beta2.ApplicationStatePendingRerun:
+		retryInterval = app.Spec.RestartPolicy.OnFailureRetryInterval
+		// PendingRerun cleanup retries are measured from the first cleanup attempt timestamp.
+		lastAttemptTime = app.Status.TerminationTime
+		if attempts, ok := pendingRerunCleanupAttemptsDone(app); ok {
+			attemptsDone = attempts
+		}
 	}
 
-	attemptsDone := app.Status.SubmissionAttempts
-	lastAttemptTime := app.Status.LastSubmissionAttemptTime
 	if retryInterval == nil || lastAttemptTime.IsZero() || attemptsDone <= 0 {
 		return -1, fmt.Errorf("invalid retry interval (%v), last attempt time (%v) or attemptsDone (%v)", retryInterval, lastAttemptTime, attemptsDone)
 	}

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -224,6 +224,123 @@ var _ = Describe("IsDriverRunning", func() {
 	})
 })
 
+var _ = Describe("ShouldRetry", func() {
+	Context("when PendingRerun cleanup retries remain", func() {
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				TerminationTime: metav1.NewTime(time.Now()),
+				AppState: v1beta2.ApplicationState{
+					State: v1beta2.ApplicationStatePendingRerun,
+				},
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				RestartPolicy: v1beta2.RestartPolicy{
+					Type:                   v1beta2.RestartPolicyOnFailure,
+					OnFailureRetries:       ptr.To[int32](3),
+					OnFailureRetryInterval: ptr.To[int64](10),
+				},
+			},
+		}
+
+		It("Should return false", func() {
+			Expect(util.ShouldRetry(app)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("PendingRerunCleanupRetryBudgetExceeded", func() {
+	Context("when restart policy is Never", func() {
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				TerminationTime: metav1.NewTime(time.Now().Add(-60 * time.Second)),
+				AppState: v1beta2.ApplicationState{
+					State: v1beta2.ApplicationStatePendingRerun,
+				},
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				RestartPolicy: v1beta2.RestartPolicy{
+					Type: v1beta2.RestartPolicyNever,
+				},
+			},
+		}
+
+		It("Should return false", func() {
+			Expect(util.PendingRerunCleanupRetryBudgetExceeded(app)).To(BeFalse())
+		})
+	})
+
+	Context("when PendingRerun cleanup retries remain", func() {
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				TerminationTime: metav1.NewTime(time.Now()),
+				AppState: v1beta2.ApplicationState{
+					State: v1beta2.ApplicationStatePendingRerun,
+				},
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				RestartPolicy: v1beta2.RestartPolicy{
+					Type:                   v1beta2.RestartPolicyOnFailure,
+					OnFailureRetries:       ptr.To[int32](3),
+					OnFailureRetryInterval: ptr.To[int64](10),
+				},
+			},
+		}
+
+		It("Should return false", func() {
+			Expect(util.PendingRerunCleanupRetryBudgetExceeded(app)).To(BeFalse())
+		})
+	})
+
+	Context("when PendingRerun cleanup retries are exhausted", func() {
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				TerminationTime: metav1.NewTime(time.Now().Add(-35 * time.Second)),
+				AppState: v1beta2.ApplicationState{
+					State: v1beta2.ApplicationStatePendingRerun,
+				},
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				RestartPolicy: v1beta2.RestartPolicy{
+					Type:                   v1beta2.RestartPolicyOnFailure,
+					OnFailureRetries:       ptr.To[int32](3),
+					OnFailureRetryInterval: ptr.To[int64](10),
+				},
+			},
+		}
+
+		It("Should return true", func() {
+			Expect(util.PendingRerunCleanupRetryBudgetExceeded(app)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("TimeUntilNextRetryDue", func() {
+	Context("when PendingRerun cleanup is on the second retry interval", func() {
+		app := &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				TerminationTime: metav1.NewTime(time.Now().Add(-15 * time.Second)),
+				AppState: v1beta2.ApplicationState{
+					State: v1beta2.ApplicationStatePendingRerun,
+				},
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				RestartPolicy: v1beta2.RestartPolicy{
+					Type:                   v1beta2.RestartPolicyOnFailure,
+					OnFailureRetries:       ptr.To[int32](3),
+					OnFailureRetryInterval: ptr.To[int64](10),
+				},
+			},
+		}
+
+		It("Should return the remaining time in the current linear backoff window", func() {
+			due, err := util.TimeUntilNextRetryDue(app)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(due).To(BeNumerically(">", 0))
+			Expect(due).To(BeNumerically("<=", 20*time.Second))
+		})
+	})
+})
+
 var _ = Describe("GetLocalVolumes", func() {
 	Context("SparkApplication with local volumes", func() {
 		volume1 := corev1.Volume{

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -248,95 +248,25 @@ var _ = Describe("ShouldRetry", func() {
 	})
 })
 
-var _ = Describe("PendingRerunCleanupRetryBudgetExceeded", func() {
-	Context("when restart policy is Never", func() {
-		app := &v1beta2.SparkApplication{
-			Status: v1beta2.SparkApplicationStatus{
-				TerminationTime: metav1.NewTime(time.Now().Add(-60 * time.Second)),
-				AppState: v1beta2.ApplicationState{
-					State: v1beta2.ApplicationStatePendingRerun,
-				},
-			},
-			Spec: v1beta2.SparkApplicationSpec{
-				RestartPolicy: v1beta2.RestartPolicy{
-					Type: v1beta2.RestartPolicyNever,
-				},
-			},
-		}
-
-		It("Should return false", func() {
-			Expect(util.PendingRerunCleanupRetryBudgetExceeded(app)).To(BeFalse())
-		})
-	})
-
-	Context("when PendingRerun cleanup retries remain", func() {
-		app := &v1beta2.SparkApplication{
-			Status: v1beta2.SparkApplicationStatus{
-				TerminationTime: metav1.NewTime(time.Now()),
-				AppState: v1beta2.ApplicationState{
-					State: v1beta2.ApplicationStatePendingRerun,
-				},
-			},
-			Spec: v1beta2.SparkApplicationSpec{
-				RestartPolicy: v1beta2.RestartPolicy{
-					Type:                   v1beta2.RestartPolicyOnFailure,
-					OnFailureRetries:       ptr.To[int32](3),
-					OnFailureRetryInterval: ptr.To[int64](10),
-				},
-			},
-		}
-
-		It("Should return false", func() {
-			Expect(util.PendingRerunCleanupRetryBudgetExceeded(app)).To(BeFalse())
-		})
-	})
-
-	Context("when PendingRerun cleanup retries are exhausted", func() {
-		app := &v1beta2.SparkApplication{
-			Status: v1beta2.SparkApplicationStatus{
-				TerminationTime: metav1.NewTime(time.Now().Add(-35 * time.Second)),
-				AppState: v1beta2.ApplicationState{
-					State: v1beta2.ApplicationStatePendingRerun,
-				},
-			},
-			Spec: v1beta2.SparkApplicationSpec{
-				RestartPolicy: v1beta2.RestartPolicy{
-					Type:                   v1beta2.RestartPolicyOnFailure,
-					OnFailureRetries:       ptr.To[int32](3),
-					OnFailureRetryInterval: ptr.To[int64](10),
-				},
-			},
-		}
-
-		It("Should return true", func() {
-			Expect(util.PendingRerunCleanupRetryBudgetExceeded(app)).To(BeTrue())
-		})
-	})
-})
-
 var _ = Describe("TimeUntilNextRetryDue", func() {
-	Context("when PendingRerun cleanup is on the second retry interval", func() {
+	Context("when PendingRerun cleanup is in the second retry interval", func() {
 		app := &v1beta2.SparkApplication{
 			Status: v1beta2.SparkApplicationStatus{
-				TerminationTime: metav1.NewTime(time.Now().Add(-15 * time.Second)),
+				TerminationTime: metav1.NewTime(time.Now().Add(-7 * time.Second)),
 				AppState: v1beta2.ApplicationState{
 					State: v1beta2.ApplicationStatePendingRerun,
 				},
 			},
 			Spec: v1beta2.SparkApplicationSpec{
-				RestartPolicy: v1beta2.RestartPolicy{
-					Type:                   v1beta2.RestartPolicyOnFailure,
-					OnFailureRetries:       ptr.To[int32](3),
-					OnFailureRetryInterval: ptr.To[int64](10),
-				},
+				RetryInterval: ptr.To[int64](5),
 			},
 		}
 
-		It("Should return the remaining time in the current linear backoff window", func() {
+		It("Should return remaining time in the current linear backoff window", func() {
 			due, err := util.TimeUntilNextRetryDue(app)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(due).To(BeNumerically(">", 0))
-			Expect(due).To(BeNumerically("<=", 20*time.Second))
+			Expect(due).To(BeNumerically("<=", 10*time.Second))
 		})
 	})
 })


### PR DESCRIPTION
Please refer https://github.com/kubeflow/spark-operator/issues/2905 for more details
## Summary
- avoid prematurely finalizing `PENDING_RERUN` when the previous application resources still exist
- keep reconciliation in `PENDING_RERUN` by returning a requeue result until old resources are cleaned up
- add controller tests to verify the requeue behavior and guard against regressions

## Test plan
- [x] unit tests for pending rerun path added/updated
- [x] validate controller behavior in `PENDING_RERUN` when resources exist

