### PR TITLE
fix(controller): adopt existing driver pod when status update is lost after submit

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -315,7 +316,20 @@ func (r *Reconciler) reconcileNewSparkApplication(ctx context.Context, req ctrl.
 			}
 			app := old.DeepCopy()
 
-			r.submitSparkApplication(ctx, app)
+			// Guard against duplicated submission: if the operator restarted after spark-submit
+			// succeeded but before the status update was persisted, the driver pod already
+			// exists while the application status is still New. Re-running spark-submit in
+			// that case would fail with "driver pod already exists". When the driver pod is
+			// ours, adopt it (submission id, attempts, etc.) and skip submit; further
+			// reconcile passes fill remaining status from the pod.
+			// See https://github.com/kubeflow/spark-operator/issues/2788.
+			adopted, err := r.tryAdoptExistingDriverPod(ctx, app)
+			if err != nil {
+				return err
+			}
+			if !adopted {
+				r.submitSparkApplication(ctx, app)
+			}
 			if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
 				return err
 			}
@@ -957,6 +971,45 @@ func (r *Reconciler) submitSparkApplication(ctx context.Context, app *v1beta2.Sp
 		submitErr = fmt.Errorf("failed to submit spark application: %v", err)
 		return
 	}
+}
+
+// tryAdoptExistingDriverPod recovers status from a driver pod already created by a
+// prior successful spark-submit when the SparkApplication is still New because the
+// status write was lost (for example after a controller restart). It returns true when
+// the pod exists, looks like an operator driver for this app, and is owned by this
+// SparkApplication UID. Matching via owner reference avoids adopting a same-named pod
+// from an unrelated or recycled SparkApplication. Restores SubmissionID from the pod
+// label so pod event fan-out stays consistent with event_handler.
+func (r *Reconciler) tryAdoptExistingDriverPod(ctx context.Context, app *v1beta2.SparkApplication) (bool, error) {
+	driverPodName := util.GetDriverPodName(app)
+	pod := &corev1.Pod{}
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: app.Namespace, Name: driverPodName}, pod); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check for existing driver pod %s: %v", driverPodName, err)
+	}
+	if !util.IsLaunchedBySparkOperator(pod) || !util.IsDriverPod(pod) {
+		return false, nil
+	}
+	if !slices.ContainsFunc(pod.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.UID == app.UID
+	}) {
+		return false, nil
+	}
+	app.Status.DriverInfo.PodName = driverPodName
+	if id := pod.Labels[common.LabelSubmissionID]; id != "" {
+		app.Status.SubmissionID = id
+	}
+	app.Status.LastSubmissionAttemptTime = metav1.Now()
+	if app.Status.SubmissionAttempts == 0 {
+		app.Status.SubmissionAttempts = 1
+	}
+	if app.Status.ExecutionAttempts == 0 {
+		app.Status.ExecutionAttempts = 1
+	}
+	app.Status.AppState.State = v1beta2.ApplicationStateSubmitted
+	return true, nil
 }
 
 // updateDriverState finds the driver pod of the application

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -417,6 +417,153 @@ var _ = Describe("SparkApplication Controller", func() {
 		})
 	})
 
+	Context("When reconciling a New SparkApplication whose driver pod already exists", func() {
+		// This simulates the scenario described in
+		// https://github.com/kubeflow/spark-operator/issues/2788, where the operator was
+		// restarted after spark-submit succeeded (creating the driver pod) but before the
+		// SparkApplication status was persisted. The driver pod exists while the application
+		// is still in the New state. Reconciliation should skip resubmission and transition
+		// to Submitted; the Submitted-state reconcile then fills in the rest of the status.
+		ctx := context.Background()
+		appName := "test"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		BeforeEach(func() {
+			By("Creating a test SparkApplication in the New state")
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      appName,
+						Namespace: appNamespace,
+					},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: ptr.To("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+
+			By("Creating a driver pod owned by the SparkApplication, simulating a prior submission")
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			driverPod := createDriverPod(appName, appNamespace)
+			driverPod.Labels[common.LabelSubmissionID] = "recovered-submission-id"
+			driverPod.OwnerReferences = []metav1.OwnerReference{util.GetOwnerReference(app)}
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			By("Deleting the created test SparkApplication")
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			By("Deleting the driver pod")
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+		})
+
+		It("Should transition to Submitted without resubmitting when the driver pod already exists", func() {
+			By("Reconciling the New SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			By("Verifying that the application transitioned to Submitted")
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(app.Status.AppState.State).To(Equal(v1beta2.ApplicationStateSubmitted))
+			Expect(app.Status.DriverInfo.PodName).To(Equal(util.GetDriverPodName(app)))
+			Expect(app.Status.SubmissionID).To(Equal("recovered-submission-id"))
+			Expect(app.Status.SubmissionAttempts).To(Equal(int32(1)))
+			Expect(app.Status.ExecutionAttempts).To(Equal(int32(1)))
+		})
+	})
+
+	Context("When reconciling a New SparkApplication whose driver pod is owned by a different SparkApplication", func() {
+		// Sanity check that pod adoption only kicks in for pods owned by the current
+		// SparkApplication (matched by UID via owner references).
+		ctx := context.Background()
+		appName := "test"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		BeforeEach(func() {
+			By("Creating a test SparkApplication in the New state")
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      appName,
+						Namespace: appNamespace,
+					},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: ptr.To("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+
+			By("Creating a driver pod with no owner reference matching this SparkApplication")
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+
+			By("Deleting the created test SparkApplication")
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			By("Deleting the driver pod")
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+		})
+
+		It("Should not adopt the unrelated driver pod", func() {
+			By("Reconciling the New SparkApplication")
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			// We expect spark-submit to be attempted (and to fail since SPARK_HOME is unset
+			// in the test environment); critically the application must not be adopted into
+			// the Submitted state based on the unrelated pod.
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(app.Status.AppState.State).NotTo(Equal(v1beta2.ApplicationStateSubmitted))
+		})
+	})
+
 	Context("When reconciling a completed SparkApplication", func() {
 		ctx := context.Background()
 		appName := "test"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Make `SparkApplication` submission idempotent when the controller loses the post-submit status write (for example after a leader restart). If the driver pod for this application already exists and is owned by this `SparkApplication` (matched by `OwnerReference` UID), reconciliation skips `spark-submit` and recovers enough status to continue the normal lifecycle.

This addresses duplicate submission and the failure mode where `spark-submit` returns `driver pod already exist` while `.status` never left `New`. Requiring an owner reference in addition to operator driver labels avoids adopting an unrelated or recycled same-named pod.

**Proposed changes:**

- Add `tryAdoptExistingDriverPod` and call it from `reconcileNewSparkApplication` before `submitSparkApplication`.
- Adoption sets `driverInfo.podName`, `submissionID` from the driver pod label when present (keeps pod event enqueue behavior in `event_handler` aligned), `lastSubmissionAttemptTime`, submission and execution attempts when they were zero, and `appState` to `Submitted`.
- Add envtest coverage for adoption when the pod is owned by the app, and for non-adoption when the pod is unrelated.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Fixes https://github.com/kubeflow/spark-operator/issues/2788.

Downstream reconcile (`reconcileSubmittedSparkApplication`, driver and executor state updates) fills in `sparkApplicationID`, terminal state, and related fields from the driver pod, consistent with the path where status was never lost.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

Tested with `go test ./internal/controller/sparkapplication/... -timeout 120s`.
