### PR TITLE
fix(controller): bound executor state with size-based eviction

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
+	"sort"
 	"strings"
 	"time"
 
@@ -1044,10 +1044,6 @@ func (r *Reconciler) updateExecutorState(ctx context.Context, app *v1beta2.Spark
 	var executorApplicationID string
 	for _, pod := range pods {
 		if util.IsExecutorPod(&pod) {
-			// If the executor number is higher than the `MaxTrackedExecutorPerApp` we want to stop persisting executors
-			if executorID, _ := strconv.Atoi(util.GetSparkExecutorID(&pod)); executorID > r.options.MaxTrackedExecutorPerApp {
-				continue
-			}
 			newState := util.GetExecutorState(&pod)
 			oldState, exists := app.Status.ExecutorState[pod.Name]
 			// Only record an executor event if the executor state is new or it has changed.
@@ -1106,7 +1102,80 @@ func (r *Reconciler) updateExecutorState(ctx context.Context, app *v1beta2.Spark
 		}
 	}
 
+	r.enforceExecutorStateCap(ctx, app)
+
 	return nil
+}
+
+// enforceExecutorStateCap bounds the size of app.Status.ExecutorState to
+// MaxTrackedExecutorPerApp. Terminated entries are evicted oldest-first by
+// executor ID; if the cap is still exceeded (all remaining entries are live),
+// the newest live entries are dropped and a warning is logged.
+//
+// Ordering relies on Spark assigning executor IDs as a monotonically
+// increasing per-application counter, so a larger ID means a more recently
+// created executor. Names without a parseable trailing ID resolve to 0 and
+// are thus treated as oldest; ID ties are broken by name for determinism.
+func (r *Reconciler) enforceExecutorStateCap(ctx context.Context, app *v1beta2.SparkApplication) {
+	logger := log.FromContext(ctx)
+	capacity := r.options.MaxTrackedExecutorPerApp
+	if capacity <= 0 || len(app.Status.ExecutorState) <= capacity {
+		return
+	}
+
+	type entry struct {
+		name string
+		id   int
+	}
+	var terminated, live []entry
+	for name, state := range app.Status.ExecutorState {
+		e := entry{name: name, id: util.ParseExecutorIDFromPodName(name)}
+		// UNKNOWN is set above when the pod is gone but the driver is still
+		// running, so treat it as evictable alongside terminal states.
+		if util.IsExecutorTerminated(state) || state == v1beta2.ExecutorStateUnknown {
+			terminated = append(terminated, e)
+		} else {
+			live = append(live, e)
+		}
+	}
+
+	// Terminated eviction: drop oldest-ID first until at cap or none left.
+	sort.Slice(terminated, func(i, j int) bool {
+		if terminated[i].id != terminated[j].id {
+			return terminated[i].id < terminated[j].id
+		}
+		return terminated[i].name < terminated[j].name
+	})
+	for _, e := range terminated {
+		if len(app.Status.ExecutorState) <= capacity {
+			return
+		}
+		delete(app.Status.ExecutorState, e.name)
+	}
+
+	if len(app.Status.ExecutorState) <= capacity {
+		return
+	}
+
+	// Live eviction: all remaining entries are live; drop newest-ID first.
+	sort.Slice(live, func(i, j int) bool {
+		if live[i].id != live[j].id {
+			return live[i].id > live[j].id
+		}
+		return live[i].name < live[j].name
+	})
+	dropped := 0
+	for _, e := range live {
+		if len(app.Status.ExecutorState) <= capacity {
+			break
+		}
+		delete(app.Status.ExecutorState, e.name)
+		dropped++
+	}
+	if dropped > 0 {
+		logger.Info("Dropped live executors from status; tracked-executor cap fully occupied by live entries",
+			"name", app.Name, "namespace", app.Namespace, "dropped", dropped, "cap", capacity)
+	}
 }
 
 func (r *Reconciler) getExecutorPods(ctx context.Context, app *v1beta2.SparkApplication) (*corev1.PodList, error) {

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -757,6 +757,559 @@ var _ = Describe("SparkApplication Controller", func() {
 		})
 	})
 
+	Context("When the live executor count is below the cap but executor IDs exceed it", func() {
+		ctx := context.Background()
+		appName := "test-high-id"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+		lowID := 1
+		highID := 5
+
+		BeforeEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec:       v1beta2.SparkApplicationSpec{MainApplicationFile: ptr.To("local:///dummy.jar")},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+			driverPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+			app.Status.DriverInfo.PodName = driverPod.Name
+			app.Status.AppState.State = v1beta2.ApplicationStateRunning
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+			for _, id := range []int{lowID, highID} {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+
+			for _, id := range []int{lowID, highID} {
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, getExecutorNamespacedName(appName, appNamespace, id), pod)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+			}
+		})
+
+		It("Should track every live executor", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: 3},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			Expect(app.Status.ExecutorState).To(HaveLen(2))
+			Expect(app.Status.ExecutorState).To(HaveKey(getExecutorNamespacedName(appName, appNamespace, highID).Name))
+			Expect(app.Status.ExecutorState[getExecutorNamespacedName(appName, appNamespace, highID).Name]).To(Equal(v1beta2.ExecutorStateRunning))
+		})
+	})
+
+	Context("When executors churn and are replaced with higher IDs", func() {
+		ctx := context.Background()
+		appName := "test-churn"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+		initialIDs := []int{1, 2, 3, 4}
+		replacementIDs := []int{5, 6, 7, 8}
+
+		BeforeEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec:       v1beta2.SparkApplicationSpec{MainApplicationFile: ptr.To("local:///dummy.jar")},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+			driverPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+			app.Status.DriverInfo.PodName = driverPod.Name
+			app.Status.AppState.State = v1beta2.ApplicationStateRunning
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+
+			podList := &corev1.PodList{}
+			Expect(k8sClient.List(ctx, podList, &client.ListOptions{Namespace: appNamespace})).To(Succeed())
+			for i := range podList.Items {
+				pod := &podList.Items[i]
+				if util.IsExecutorPod(pod) && pod.Labels[common.LabelSparkAppName] == appName {
+					Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+				}
+			}
+		})
+
+		It("Should report replacement executors as Running after the original executors are deleted", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(10),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: 10},
+			)
+
+			By("Spawning the initial executor pods")
+			for _, id := range initialIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the initial executor pods")
+			for _, id := range initialIDs {
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, getExecutorNamespacedName(appName, appNamespace, id), pod)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+			}
+
+			By("Spawning replacement executor pods with higher IDs")
+			for _, id := range replacementIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+
+			runningCount := 0
+			for _, state := range app.Status.ExecutorState {
+				if state == v1beta2.ExecutorStateRunning {
+					runningCount++
+				}
+			}
+			Expect(runningCount).To(Equal(len(replacementIDs)))
+
+			for _, id := range replacementIDs {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).To(HaveKeyWithValue(name, v1beta2.ExecutorStateRunning))
+			}
+		})
+
+		It("Should evict stale entries and track replacements up to the cap when churn exceeds it", func() {
+			capacity := 3
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(20),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: capacity},
+			)
+
+			By("Spawning the initial executor pods")
+			for _, id := range initialIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the initial executor pods")
+			for _, id := range initialIDs {
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, getExecutorNamespacedName(appName, appNamespace, id), pod)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+			}
+
+			By("Spawning replacement executor pods with higher IDs")
+			for _, id := range replacementIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+
+			// Cap is exceeded by stale entries plus 4 live replacements. The
+			// terminated pass evicts the 3 stale UNKNOWN entries (IDs 1, 2, 3)
+			// first, freeing space for 3 of the 4 replacements. The drop-newest
+			// live policy then drops the highest-ID live entry (ID 8), keeping
+			// IDs 5, 6, 7.
+			Expect(app.Status.ExecutorState).To(HaveLen(capacity))
+			for _, id := range initialIDs {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).NotTo(HaveKey(name))
+			}
+			for _, id := range replacementIDs[:capacity] {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).To(HaveKeyWithValue(name, v1beta2.ExecutorStateRunning))
+			}
+			for _, id := range replacementIDs[capacity:] {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).NotTo(HaveKey(name))
+			}
+		})
+	})
+
+	Context("When the live executor count exceeds the cap", func() {
+		ctx := context.Background()
+		appName := "test-all-live"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+		liveIDs := []int{1, 2, 3, 4, 5}
+		capacity := 3
+
+		BeforeEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec:       v1beta2.SparkApplicationSpec{MainApplicationFile: ptr.To("local:///dummy.jar")},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+			driverPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+			app.Status.DriverInfo.PodName = driverPod.Name
+			app.Status.AppState.State = v1beta2.ApplicationStateRunning
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+			for _, id := range liveIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+
+			for _, id := range liveIDs {
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, getExecutorNamespacedName(appName, appNamespace, id), pod)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+			}
+		})
+
+		It("Should drop the newest live executors and keep the oldest within the cap", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(10),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: capacity},
+			)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+
+			Expect(app.Status.ExecutorState).To(HaveLen(capacity))
+			for _, id := range liveIDs[:capacity] {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).To(HaveKeyWithValue(name, v1beta2.ExecutorStateRunning))
+			}
+			for _, id := range liveIDs[capacity:] {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).NotTo(HaveKey(name))
+			}
+		})
+	})
+
+	Context("When MaxTrackedExecutorPerApp is zero (no cap)", func() {
+		ctx := context.Background()
+		appName := "test-no-cap"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+		liveIDs := []int{1, 2, 3, 4, 5}
+
+		BeforeEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec:       v1beta2.SparkApplicationSpec{MainApplicationFile: ptr.To("local:///dummy.jar")},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+			driverPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+			app.Status.DriverInfo.PodName = driverPod.Name
+			app.Status.AppState.State = v1beta2.ApplicationStateRunning
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+			for _, id := range liveIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+
+			for _, id := range liveIDs {
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, getExecutorNamespacedName(appName, appNamespace, id), pod)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+			}
+		})
+
+		It("Should not evict any executor when the cap is non-positive", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(10),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: 0},
+			)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+			Expect(app.Status.ExecutorState).To(HaveLen(len(liveIDs)))
+			for _, id := range liveIDs {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).To(HaveKeyWithValue(name, v1beta2.ExecutorStateRunning))
+			}
+		})
+	})
+
+	Context("When the executor state map mixes COMPLETED, FAILED, UNKNOWN, and live entries", func() {
+		ctx := context.Background()
+		appName := "test-mixed"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+		seededStates := map[int]v1beta2.ExecutorState{
+			1: v1beta2.ExecutorStateCompleted,
+			2: v1beta2.ExecutorStateFailed,
+			3: v1beta2.ExecutorStateUnknown,
+			4: v1beta2.ExecutorStateCompleted,
+		}
+		liveIDs := []int{100, 101, 102}
+		capacity := 5
+
+		BeforeEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec:       v1beta2.SparkApplicationSpec{MainApplicationFile: ptr.To("local:///dummy.jar")},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+			driverPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+			app.Status.DriverInfo.PodName = driverPod.Name
+			app.Status.AppState.State = v1beta2.ApplicationStateRunning
+			app.Status.ExecutorState = map[string]v1beta2.ExecutorState{}
+			for id, state := range seededStates {
+				app.Status.ExecutorState[getExecutorNamespacedName(appName, appNamespace, id).Name] = state
+			}
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+
+			for _, id := range liveIDs {
+				pod := createExecutorPod(appName, appNamespace, id)
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				pod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+
+			for _, id := range liveIDs {
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, getExecutorNamespacedName(appName, appNamespace, id), pod)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+			}
+		})
+
+		It("Should evict the oldest non-live entries first regardless of which terminal state they hold", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(10),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: capacity},
+			)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+
+			Expect(app.Status.ExecutorState).To(HaveLen(capacity))
+			for _, id := range liveIDs {
+				name := getExecutorNamespacedName(appName, appNamespace, id).Name
+				Expect(app.Status.ExecutorState).To(HaveKeyWithValue(name, v1beta2.ExecutorStateRunning))
+			}
+			Expect(app.Status.ExecutorState).NotTo(HaveKey(getExecutorNamespacedName(appName, appNamespace, 1).Name))
+			Expect(app.Status.ExecutorState).NotTo(HaveKey(getExecutorNamespacedName(appName, appNamespace, 2).Name))
+			Expect(app.Status.ExecutorState).To(HaveKeyWithValue(getExecutorNamespacedName(appName, appNamespace, 3).Name, v1beta2.ExecutorStateUnknown))
+			Expect(app.Status.ExecutorState).To(HaveKeyWithValue(getExecutorNamespacedName(appName, appNamespace, 4).Name, v1beta2.ExecutorStateCompleted))
+		})
+	})
+
+	Context("When evicted executors share the same parsed ID", func() {
+		ctx := context.Background()
+		appName := "test-tie"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+		// All three names parse to the same executor ID (7) but differ by
+		// prefix, so eviction order is decided solely by the name tie-breaker.
+		tiedNames := []string{"test-tie-a-exec7", "test-tie-m-exec7", "test-tie-z-exec7"}
+
+		BeforeEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec:       v1beta2.SparkApplicationSpec{MainApplicationFile: ptr.To("local:///dummy.jar")},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			}
+			driverPod := createDriverPod(appName, appNamespace)
+			Expect(k8sClient.Create(ctx, driverPod)).To(Succeed())
+			driverPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, driverPod)).To(Succeed())
+
+			app.Status.DriverInfo.PodName = driverPod.Name
+			app.Status.AppState.State = v1beta2.ApplicationStateRunning
+			app.Status.ExecutorState = map[string]v1beta2.ExecutorState{}
+			for _, name := range tiedNames {
+				app.Status.ExecutorState[name] = v1beta2.ExecutorStateCompleted
+			}
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+
+			driverPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, getDriverNamespacedName(appName, appNamespace), driverPod)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, driverPod)).To(Succeed())
+		})
+
+		It("Should break ID ties deterministically by name when evicting", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(10),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, MaxTrackedExecutorPerApp: 2},
+			)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
+
+			// Terminated entries sort ascending by (id, name) and are evicted
+			// from the front, so the lexicographically smallest name is dropped
+			// and the larger two are retained. Without the name tie-breaker this
+			// outcome would depend on random map iteration order.
+			Expect(app.Status.ExecutorState).To(HaveLen(2))
+			Expect(app.Status.ExecutorState).NotTo(HaveKey("test-tie-a-exec7"))
+			Expect(app.Status.ExecutorState).To(HaveKey("test-tie-m-exec7"))
+			Expect(app.Status.ExecutorState).To(HaveKey("test-tie-z-exec7"))
+		})
+	})
+
 	Context("When reconciling a succeeding SparkApplication with Always retry policy", func() {
 		ctx := context.Background()
 		appName := "test"

--- a/pkg/util/sparkpod.go
+++ b/pkg/util/sparkpod.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
@@ -40,6 +42,25 @@ func IsExecutorPod(pod *corev1.Pod) bool {
 // GetSparkExecutorID returns the Spark executor ID by checking out pod labels.
 func GetSparkExecutorID(pod *corev1.Pod) string {
 	return pod.Labels[common.LabelSparkExecutorID]
+}
+
+// ParseExecutorIDFromPodName returns the trailing integer in a Spark executor
+// pod name. Returns 0 if no trailing digits are present.
+// NOTE: This is a fallback for contexts where only the pod name is available
+// and the pod object (with its LabelSparkExecutorID label) can no longer be
+// retrieved — e.g. iterating Status.ExecutorState keys for terminated/UNKNOWN
+// executors whose pods are gone. For live pods, prefer GetSparkExecutorID.
+func ParseExecutorIDFromPodName(name string) int {
+	end := len(name)
+	start := end
+	for start > 0 && name[start-1] >= '0' && name[start-1] <= '9' {
+		start--
+	}
+	if start == end {
+		return 0
+	}
+	id, _ := strconv.Atoi(name[start:end])
+	return id
 }
 
 // GetAppName returns the spark application name by checking out pod labels.

--- a/pkg/util/sparkpod_test.go
+++ b/pkg/util/sparkpod_test.go
@@ -347,3 +347,18 @@ var _ = Describe("GetSparkExecutorID", func() {
 		})
 	})
 })
+
+var _ = Describe("ParseExecutorIDFromPodName", func() {
+	DescribeTable("extracts trailing digits",
+		func(name string, expected int) {
+			Expect(util.ParseExecutorIDFromPodName(name)).To(Equal(expected))
+		},
+		Entry("real Spark pod name with hash and hyphen", "cc-spark-ops-test-7bc5a69e8c8c89fd-exec-12345", 12345),
+		Entry("test-style pod name without separator", "test-app-exec1", 1),
+		Entry("single digit trailing", "anything-9", 9),
+		Entry("multi-digit trailing", "anything-987654", 987654),
+		Entry("empty string", "", 0),
+		Entry("no trailing digits", "driver-pod", 0),
+		Entry("digits in the middle only", "exec-42-driver", 0),
+	)
+})


### PR DESCRIPTION
## Purpose of this PR

Fixes a regression introduced in #2181 where executors with IDs above the `MaxTrackedExecutorPerApp` cap were silently dropped, and the state map was never pruned — causing `Status.ExecutorState` to report zero running executors on long-running drivers with executor churn.

**Proposed changes:**

- Remove the id-based skip in `updateExecutorState` that dropped any executor whose numeric ID exceeded `MaxTrackedExecutorPerApp`
- Add `enforceExecutorStateCap`: runs after the missing-pod pass; evicts terminated/UNKNOWN entries oldest-ID-first, and only drops live entries newest-ID-first (with a warning log) when the cap is fully occupied by live executors
- Break ID ties by entry name in both eviction sorts so eviction is deterministic across reconciles (entries are gathered from a map, so input order is otherwise random)
- Add `util.ParseExecutorIDFromPodName` to recover executor IDs from pod names for terminated entries whose pods are already gone

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

PR #2181 introduced the cap by skipping any executor with `ID > MaxTrackedExecutorPerApp`. This had two failure modes on long-running drivers:

1. **Invisible executors**: new executors spawned after the ID threshold never appeared in `Status.ExecutorState`, so the operator's running-count was permanently wrong.
2. **Stale entry crowding**: terminated executor entries accumulated without bound, consuming the entire cap budget and leaving no room for live executors.

On applications with high executor churn (pods deleted, replacements spawn with higher IDs), the net effect was `Status.ExecutorState` showing zero running executors despite live pods.

The fix enforces the cap as a size bound at write time rather than a filter on IDs. `Status.ExecutorState` semantics shift from cumulative (every ID ever seen, up to cap) to instantaneous (at most `cap` entries at any time, preferring live over terminated). No CRD or schema changes; `MaxTrackedExecutorPerApp` default (1000) is unchanged.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly. _(N/A — flag name/default/help text unchanged; `Status.ExecutorState` semantics covered in Rationale above.)_
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

**New test coverage** (`internal/controller/sparkapplication/controller_test.go`):
- Live high-ID executor tracked correctly (regression for #2181 skip)
- Churn replacement executors reported Running after prior IDs terminated
- Cap=3 churn eviction reproduces the original crowding scenario
- All-live overflow: drops newest, keeps oldest
- Cap ≤ 0: no-op
- Mixed COMPLETED/FAILED/UNKNOWN eviction ordering
- Same parsed ID: eviction broken deterministically by name

**New unit test** (`pkg/util/sparkpod_test.go`): table-driven `ParseExecutorIDFromPodName` covering valid names, malformed names, and missing numeric suffix.

`go test ./pkg/util/... ./internal/controller/sparkapplication/...` passes. `golangci-lint` and `gofmt` clean.
