### PR TITLE
added cleanup k8s service *-ui-svc (#2984)

### DIFF
--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -1200,8 +1200,10 @@ func (r *Reconciler) deleteDriverPod(ctx context.Context, app *v1beta2.SparkAppl
 func (r *Reconciler) deleteWebUIService(ctx context.Context, app *v1beta2.SparkApplication) error {
 	logger := log.FromContext(ctx)
 	svcName := app.Status.DriverInfo.WebUIServiceName
+	// Fall back to the deterministic default name so the service is not orphaned if the
+	// status update that recorded WebUIServiceName was lost (e.g. failed right after submission).
 	if svcName == "" {
-		return nil
+		svcName = util.GetDefaultUIServiceName(app)
 	}
 	logger.Info("Deleting Spark web UI service", "service", svcName)
 	if err := r.client.Delete(
@@ -1215,6 +1217,26 @@ func (r *Reconciler) deleteWebUIService(ctx context.Context, app *v1beta2.SparkA
 		&client.DeleteOptions{
 			GracePeriodSeconds: ptr.To[int64](0),
 		},
+	); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// deleteDriverIngressServices deletes the per-DriverIngressOptions services created for the
+// application. Their names are not recorded in the status, so they are matched by the
+// SparkApplication name label that the operator stamps on every resource it creates.
+// Leaving them behind causes Kubernetes to inject a pair of environment variables per service
+// into every newly created pod, which eventually overflows the process argument list (#2984).
+func (r *Reconciler) deleteDriverIngressServices(ctx context.Context, app *v1beta2.SparkApplication) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Deleting driver ingress services", "name", app.Name)
+	if err := r.client.DeleteAllOf(
+		ctx,
+		&corev1.Service{},
+		client.InNamespace(app.Namespace),
+		client.MatchingLabels(map[string]string{common.LabelSparkAppName: app.Name}),
+		client.GracePeriodSeconds(0),
 	); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -1294,6 +1316,19 @@ func (r *Reconciler) validateSparkResourceDeletion(ctx context.Context, app *v1b
 		if err := r.client.Get(ctx, types.NamespacedName{Name: sparkUIIngressName, Namespace: app.Namespace}, &networkingv1.Ingress{}); err == nil || !errors.IsNotFound(err) {
 			return false
 		}
+	}
+
+	// Validate whether the driver-ingress services have been deleted. Their names are not
+	// recorded in the status, so they are matched by the SparkApplication name label.
+	services := &corev1.ServiceList{}
+	if err := r.client.List(ctx, services,
+		client.InNamespace(app.Namespace),
+		client.MatchingLabels(map[string]string{common.LabelSparkAppName: app.Name}),
+	); err != nil {
+		return false
+	}
+	if len(services.Items) > 0 {
+		return false
 	}
 
 	return true
@@ -1485,6 +1520,21 @@ func (r *Reconciler) cleanUpOnTermination(ctx context.Context, _, newApp *v1beta
 		if err := scheduler.Cleanup(newApp); err != nil {
 			return err
 		}
+	}
+
+	// Delete the network resources (Spark UI service/ingress and driver-ingress services) that
+	// are owned by the SparkApplication. They would otherwise persist for the entire lifetime of
+	// a retained Completed/Failed SparkApplication and leak per-service environment variables into
+	// every newly created pod (#2984). The driver pod is intentionally left in place so that its
+	// logs remain available for inspection.
+	if err := r.deleteWebUIService(ctx, newApp); err != nil {
+		return err
+	}
+	if err := r.deleteWebUIIngress(ctx, newApp); err != nil {
+		return err
+	}
+	if err := r.deleteDriverIngressServices(ctx, newApp); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -1374,6 +1374,142 @@ var _ = Describe("SparkApplication Controller", func() {
 			})
 		})
 	})
+
+	Context("When reconciling a terminated SparkApplication with a Spark UI service", func() {
+		ctx := context.Background()
+		appName := "test"
+		appNamespace := "default"
+		key := types.NamespacedName{
+			Name:      appName,
+			Namespace: appNamespace,
+		}
+
+		uiServiceKey := types.NamespacedName{
+			Namespace: appNamespace,
+		}
+		driverIngressServiceName := fmt.Sprintf("%s-driver-8080", appName)
+		driverIngressServiceKey := types.NamespacedName{
+			Name:      driverIngressServiceName,
+			Namespace: appNamespace,
+		}
+
+		// createTerminatedAppWithServices creates a Completed/Failed SparkApplication along with
+		// the Spark UI service and a driver-ingress service that the operator would have created
+		// while the application was running.
+		createTerminatedAppWithServices := func(state v1beta2.ApplicationStateType) {
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName,
+					Namespace: appNamespace,
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					MainApplicationFile: ptr.To("local:///dummy.jar"),
+				},
+			}
+			v1beta2.SetSparkApplicationDefaults(app)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			// Re-read to obtain the UID needed for owner references.
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			ownerRef := util.GetOwnerReference(app)
+
+			uiServiceName := util.GetDefaultUIServiceName(app)
+			uiServiceKey.Name = uiServiceName
+			uiService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            uiServiceName,
+					Namespace:       appNamespace,
+					Labels:          util.GetResourceLabels(app),
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Name: "spark-driver-ui-port", Port: 4040}},
+					Selector: map[string]string{
+						common.LabelSparkAppName: appName,
+						common.LabelSparkRole:    common.SparkRoleDriver,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, uiService)).To(Succeed())
+
+			driverIngressService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            driverIngressServiceName,
+					Namespace:       appNamespace,
+					Labels:          util.GetResourceLabels(app),
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Name: "driver-ing-8080", Port: 8080}},
+					Selector: map[string]string{
+						common.LabelSparkAppName: appName,
+						common.LabelSparkRole:    common.SparkRoleDriver,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, driverIngressService)).To(Succeed())
+
+			By("Updating the SparkApplication to a terminated state with the UI service recorded")
+			app.Status.AppState.State = state
+			app.Status.TerminationTime = metav1.Now()
+			app.Status.DriverInfo.WebUIServiceName = uiServiceName
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+		}
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err == nil {
+				By("Deleting the test SparkApplication")
+				Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+			}
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: uiServiceKey.Name, Namespace: appNamespace},
+			}))).To(Succeed())
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: driverIngressServiceName, Namespace: appNamespace},
+			}))).To(Succeed())
+		})
+
+		newReconciler := func() *sparkapplication.Reconciler {
+			return sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				record.NewFakeRecorder(3),
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{EnableUIService: true, Namespaces: []string{appNamespace}},
+			)
+		}
+
+		It("Should delete the Spark UI service when the application is Completed", func() {
+			createTerminatedAppWithServices(v1beta2.ApplicationStateCompleted)
+
+			By("Reconciling the Completed SparkApplication")
+			_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that the Spark UI service has been deleted")
+			Expect(k8sClient.Get(ctx, uiServiceKey, &corev1.Service{})).To(Satisfy(errors.IsNotFound))
+
+			By("Checking that the driver-ingress service has been deleted")
+			Expect(k8sClient.Get(ctx, driverIngressServiceKey, &corev1.Service{})).To(Satisfy(errors.IsNotFound))
+		})
+
+		It("Should delete the Spark UI service when the application is Failed", func() {
+			createTerminatedAppWithServices(v1beta2.ApplicationStateFailed)
+
+			By("Reconciling the Failed SparkApplication")
+			_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that the Spark UI service has been deleted")
+			Expect(k8sClient.Get(ctx, uiServiceKey, &corev1.Service{})).To(Satisfy(errors.IsNotFound))
+
+			By("Checking that the driver-ingress service has been deleted")
+			Expect(k8sClient.Get(ctx, driverIngressServiceKey, &corev1.Service{})).To(Satisfy(errors.IsNotFound))
+		})
+	})
 })
 
 func getDriverNamespacedName(appName string, appNamespace string) types.NamespacedName {

--- a/internal/controller/sparkapplication/driveringress.go
+++ b/internal/controller/sparkapplication/driveringress.go
@@ -358,8 +358,11 @@ func (r *Reconciler) createDriverIngressService(
 		},
 	}
 
-	if len(serviceLabels) != 0 {
-		service.Labels = serviceLabels
+	// Merge any user-provided labels on top of the operator labels rather than replacing
+	// them, so that the SparkApplication name label that owner-reference GC, selectors and
+	// cleanup rely on is always preserved.
+	for key, value := range serviceLabels {
+		service.Labels[key] = value
 	}
 
 	if len(serviceAnnotations) != 0 {


### PR DESCRIPTION

## Purpose of this PR

This PR is for cleaning up the thousands of "*-ui-svc" kubernetes zombi services that still exist after a SparkApplication is COMPLETED or FAILED 


**Proposed changes:**

- added cleanup for k8s resources

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Having clusters in PROD with thousands of SparkApplications launched every day produces blocking ERRORs "argument list too long". 
It forced my company to implement strange workarounds: "automatic sparkApp remover", and split into multiple clusters and multiple namespaces ... 
A better solution is highly recommended

## Checklist

- [ ] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] Existing unit tests pass locally with my changes.

### Additional Notes

Code was "pair-progamming" with Claude Code.
