### PR TITLE
chore(controller): replace deprecated Result.Requeue with RequeueAfter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,13 +48,6 @@ linters:
         - pkg: sigs.k8s.io/controller-runtime
           alias: ctrl
 
-  exclusions:
-    rules:
-      # exclude staticcheck SA1019 for Result.Requeue.
-      - linters:
-          - staticcheck
-        text: "SA1019: .*\\.Requeue is deprecated: Use `RequeueAfter` instead."
-
 issues:
   # Maximum issues count per one linter.
   # Set to 0 to disable.
@@ -69,4 +62,3 @@ formatters:
   enable:
     # Check import statements are formatted according to the 'goimport' command.
     - goimports
-

--- a/internal/controller/mutatingwebhookconfiguration/controller.go
+++ b/internal/controller/mutatingwebhookconfiguration/controller.go
@@ -79,7 +79,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger.Info("Updating CA bundle of MutatingWebhookConfiguration", "name", req.Name)
 	if err := r.updateMutatingWebhookConfiguration(ctx, req.NamespacedName); err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/scheduledsparkapplication/controller.go
+++ b/internal/controller/scheduledsparkapplication/controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 	scheduledApp := oldScheduledApp.DeepCopy()
 	logger.Info("Reconciling ScheduledSparkApplication", "name", scheduledApp.Name, "namespace", scheduledApp.Namespace, "state", scheduledApp.Status.ScheduleState)
@@ -144,7 +144,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			scheduledApp.Status.ScheduleState = v1beta2.ScheduleStateFailedValidation
 			scheduledApp.Status.Reason = fmt.Sprintf("Invalid timezone: %v", err)
 			if updateErr := r.updateScheduledSparkApplicationStatus(ctx, scheduledApp); updateErr != nil {
-				return ctrl.Result{Requeue: true}, updateErr
+				return ctrl.Result{}, updateErr
 			}
 			return ctrl.Result{}, nil
 		}
@@ -162,7 +162,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		scheduledApp.Status.ScheduleState = v1beta2.ScheduleStateFailedValidation
 		scheduledApp.Status.Reason = parseErr.Error()
 		if updateErr := r.updateScheduledSparkApplicationStatus(ctx, scheduledApp); updateErr != nil {
-			return ctrl.Result{Requeue: true}, updateErr
+			return ctrl.Result{}, updateErr
 		}
 		return ctrl.Result{}, nil
 	}
@@ -177,7 +177,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		scheduledApp.Status.ScheduleState = v1beta2.ScheduleStateScheduled
 		if err := r.updateScheduledSparkApplicationStatus(ctx, scheduledApp); err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: nextRunTime.Sub(now)}, err
 	case v1beta2.ScheduleStateScheduled:
@@ -186,7 +186,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if nextRunTime.IsZero() {
 			scheduledApp.Status.NextRun = metav1.NewTime(schedule.Next(now))
 			if err := r.updateScheduledSparkApplicationStatus(ctx, scheduledApp); err != nil {
-				return ctrl.Result{Requeue: true}, err
+				return ctrl.Result{}, err
 			}
 			return ctrl.Result{RequeueAfter: schedule.Next(now).Sub(now)}, nil
 		}
@@ -197,7 +197,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		ok, err := r.shouldStartNextRun(scheduledApp)
 		if err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 		if !ok {
 			return ctrl.Result{RequeueAfter: schedule.Next(now).Sub(now)}, nil
@@ -214,10 +214,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		scheduledApp.Status.LastRunName = app.Name
 		scheduledApp.Status.NextRun = metav1.NewTime(schedule.Next(now))
 		if err = r.checkAndUpdatePastRuns(ctx, scheduledApp); err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 		if err := r.updateScheduledSparkApplicationStatus(ctx, scheduledApp); err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: schedule.Next(now).Sub(now)}, nil
 	case v1beta2.ScheduleStateFailedValidation:

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -186,7 +186,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	logger.Info("Reconciling SparkApplication", "state", app.Status.AppState.State)
@@ -290,12 +290,12 @@ func (r *Reconciler) handleSparkApplicationDeletion(ctx context.Context, req ctr
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.deleteSparkResources(ctx, app); err != nil {
 		logger.Error(err, "Failed to delete resources associated with SparkApplication")
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }
@@ -324,7 +324,7 @@ func (r *Reconciler) reconcileNewSparkApplication(ctx context.Context, req ctrl.
 	)
 	if retryErr != nil {
 		logger.Error(retryErr, "Failed to reconcile SparkApplication")
-		return ctrl.Result{Requeue: true}, retryErr
+		return ctrl.Result{}, retryErr
 	}
 	return ctrl.Result{}, nil
 }
@@ -667,7 +667,7 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 	key := req.NamespacedName
 	old, err := r.getSparkApplication(ctx, key)
 	if err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	app := old.DeepCopy()
@@ -678,22 +678,22 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 	if util.IsExpired(app) {
 		logger.Info("Deleting expired SparkApplication", "state", app.Status.AppState.State)
 		if err := r.client.Delete(ctx, app); err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
 
 	if err := r.updateExecutorState(ctx, app); err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.updateSparkApplicationStatus(ctx, app); err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.cleanUpOnTermination(ctx, old, app); err != nil {
 		logger.Error(err, "Failed to clean up resources for SparkApplication", "state", old.Status.AppState.State)
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	// If termination time or TTL is not set, will not requeue this application.
@@ -706,9 +706,9 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 	ttl := time.Duration(*app.Spec.TimeToLiveSeconds) * time.Second
 	survival := now.Sub(app.Status.TerminationTime.Time)
 
-	// If survival time is greater than TTL, requeue the application immediately.
+	// If survival time is greater than TTL, requeue the application shortly for deletion.
 	if survival >= ttl {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 	// Otherwise, requeue the application after (TTL - survival) seconds.
 	return ctrl.Result{RequeueAfter: ttl - survival}, nil
@@ -851,7 +851,7 @@ func (r *Reconciler) reconcileResumingSparkApplication(ctx context.Context, req 
 	)
 	if retryErr != nil {
 		logger.Error(retryErr, "Failed to reconcile SparkApplication")
-		return ctrl.Result{Requeue: true}, retryErr
+		return ctrl.Result{}, retryErr
 	}
 	return ctrl.Result{}, nil
 }
@@ -878,7 +878,7 @@ func (r *Reconciler) transitionToSuspending(ctx context.Context, req ctrl.Reques
 	)
 	if retryErr != nil {
 		logger.Error(retryErr, "Failed to reconcile SparkApplication")
-		return ctrl.Result{Requeue: true}, retryErr
+		return ctrl.Result{}, retryErr
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -342,7 +342,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
@@ -409,7 +409,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
@@ -471,7 +471,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 
@@ -531,7 +531,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 
@@ -586,7 +586,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 
@@ -646,7 +646,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 
@@ -729,7 +729,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -749,7 +749,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			app := &v1beta2.SparkApplication{}
 			Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -1079,7 +1079,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					app := &v1beta2.SparkApplication{}
 					Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -1145,7 +1145,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					app := &v1beta2.SparkApplication{}
 					Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -1179,7 +1179,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					app := &v1beta2.SparkApplication{}
 					Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -1213,7 +1213,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					app := &v1beta2.SparkApplication{}
 					Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -1257,7 +1257,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(driverPod), &corev1.Pod{})).To(Satisfy(errors.IsNotFound))
 					app := &v1beta2.SparkApplication{}
@@ -1294,7 +1294,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					app := &v1beta2.SparkApplication{}
 					Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
@@ -1338,7 +1338,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					)
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(driverPod), &corev1.Pod{})).To(Satisfy(errors.IsNotFound))
 					app := &v1beta2.SparkApplication{}
@@ -1348,7 +1348,7 @@ var _ = Describe("SparkApplication Controller", func() {
 					By("Reconciling the Suspended SparkApplication with Suspend=false")
 					result, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(result.Requeue).To(BeFalse())
+					Expect(result.RequeueAfter).To(BeZero())
 					app = &v1beta2.SparkApplication{}
 					Expect(k8sClient.Get(ctx, key, app)).NotTo(HaveOccurred())
 					Expect(app.Status.AppState).To(BeEquivalentTo(v1beta2.ApplicationState{State: v1beta2.ApplicationStateResuming}))

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -230,7 +231,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile
 	if err := r.updateSparkConnectStatus(ctx, old, conn); err != nil {
 		if errors.IsConflict(err) {
 			logger.V(1).Info("conflict updating SparkConnect status")
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to update SparkConnect status: %v", err)
 	}

--- a/internal/controller/validatingwebhookconfiguration/controller.go
+++ b/internal/controller/validatingwebhookconfiguration/controller.go
@@ -80,7 +80,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger.Info("Updating CA bundle of ValidatingWebhookConfiguration", "name", req.Name)
 	if err := r.updateValidatingWebhookConfiguration(ctx, req.NamespacedName); err != nil {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
## Purpose of this PR

`reconcile.Result.Requeue` is deprecated in controller-runtime in favor of `RequeueAfter`. After the Kubernetes 1.35 / controller-runtime bump, staticcheck (SA1019) flags every use of it, and `.golangci.yaml` currently suppresses the warning instead of fixing the code. This PR removes the deprecated field everywhere and drops the lint exclusion.

Fixes #2991

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
