### PR TITLE
(#2963) feat(webhook): reject disallowed URL schemes in SparkApplication fetch fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,10 @@ e2e-test: envtest kind-load-image kind-load-spark-image ## Run the e2e tests aga
 	@echo "Running e2e tests (deploy_method=$(DEPLOY_METHOD))..."
 	DEPLOY_METHOD=$(DEPLOY_METHOD) IMAGE_TAG=$(IMAGE_TAG) KUBECONFIG=$(KIND_KUBE_CONFIG) go test ./test/e2e/ -v -ginkgo.v -timeout 30m
 
+.PHONY: kind-e2e-test
+kind-e2e-test: IMAGE_TAG=local
+kind-e2e-test: kind-load-image e2e-test ## Build image, load into Kind cluster, and run the e2e suite.
+
 ##@ Kustomize
 
 .PHONY: kustomize-set-image

--- a/Makefile
+++ b/Makefile
@@ -202,10 +202,6 @@ e2e-test: envtest kind-load-image kind-load-spark-image ## Run the e2e tests aga
 	@echo "Running e2e tests (deploy_method=$(DEPLOY_METHOD))..."
 	DEPLOY_METHOD=$(DEPLOY_METHOD) IMAGE_TAG=$(IMAGE_TAG) KUBECONFIG=$(KIND_KUBE_CONFIG) go test ./test/e2e/ -v -ginkgo.v -timeout 30m
 
-.PHONY: kind-e2e-test
-kind-e2e-test: IMAGE_TAG=local
-kind-e2e-test: kind-load-image e2e-test ## Build image, load into Kind cluster, and run the e2e suite.
-
 ##@ Kustomize
 
 .PHONY: kustomize-set-image

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -170,6 +170,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.kubeAPIQPS | int | `20` | Maximum QPS to the API server from the controller client. |
 | webhook.kubeAPIBurst | int | `30` | Maximum burst for throttle from the controller client. |
 | webhook.resourceQuotaEnforcement.enable | bool | `false` | Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources. |
+| webhook.sparkAllowedURLSchemes | list | `[]` | URL schemes permitted in fetch-capable SparkApplication fields (spec.sparkConf values, spec.deps.*, spec.mainApplicationFile) at admission time, in addition to the always-allowed local schemes (schemeless, file://, local://). Any other URL scheme is rejected. Add schemes your workloads require (e.g. gs, s3a, hdfs). |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the webhook. |
 | webhook.serviceAccount.name | string | `""` | Optional name for the webhook service account. |
 | webhook.serviceAccount.annotations | object | `{}` | Extra annotations for the webhook service account. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -170,7 +170,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.kubeAPIQPS | int | `20` | Maximum QPS to the API server from the controller client. |
 | webhook.kubeAPIBurst | int | `30` | Maximum burst for throttle from the controller client. |
 | webhook.resourceQuotaEnforcement.enable | bool | `false` | Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources. |
-| webhook.sparkAllowedURLSchemes | list | `[]` | URL schemes permitted in fetch-capable SparkApplication fields (spec.sparkConf values, spec.deps.*, spec.mainApplicationFile) at admission time, in addition to the always-allowed local schemes (schemeless, file://, local://). Any other URL scheme is rejected. Add schemes your workloads require (e.g. gs, s3a, hdfs). |
+| webhook.urlSchemeValidation.enable | bool | `false` | Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission time. Opt-in and disabled by default so existing SparkApplications using remote schemes are not rejected on upgrade. |
+| webhook.urlSchemeValidation.allowedSchemes | list | `[]` | URL schemes permitted in fetch-capable SparkApplication fields when validation is enabled, in addition to the always-allowed local schemes (schemeless, file://, local://). Any other URL scheme is rejected. Add schemes your workloads require (e.g. gs, s3a, hdfs). |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the webhook. |
 | webhook.serviceAccount.name | string | `""` | Optional name for the webhook service account. |
 | webhook.serviceAccount.annotations | object | `{}` | Extra annotations for the webhook service account. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -175,6 +175,11 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.kubeAPIQPS | int | `20` | Maximum QPS to the API server from the controller client. |
 | webhook.kubeAPIBurst | int | `30` | Maximum burst for throttle from the controller client. |
 | webhook.resourceQuotaEnforcement.enable | bool | `false` | Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources. |
+| webhook.urlSchemeValidation.enable | bool | `false` | Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication and ScheduledSparkApplication template fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission time. Opt-in and disabled by default so existing applications using remote schemes are not rejected on upgrade. |
+| webhook.urlSchemeValidation.allowedSchemes | list | `[]` | URL schemes permitted in fetch-capable SparkApplication fields when validation is enabled. Remote URLs must also match allowedHosts or allowedWildcardHosts unless their scheme is in allowedSchemesAnyHost. |
+| webhook.urlSchemeValidation.allowedSchemesAnyHost | list | `[]` | Allowed URL schemes permitted to access any host, such as `s3a` where a VPC endpoint and network policy constrain reachable buckets. Each scheme must also appear in allowedSchemes. |
+| webhook.urlSchemeValidation.allowedHosts | list | `[]` | Exact scheme-qualified URL hosts permitted in fetch-capable SparkApplication fields when validation is enabled, such as `https://repo.example.com` or `s3a://bucket`. Empty host lists deny all remote URLs. |
+| webhook.urlSchemeValidation.allowedWildcardHosts | list | `[]` | Scheme-qualified leftmost wildcard URL hosts permitted in fetch-capable SparkApplication fields when validation is enabled, such as `https://*.maven.apache.org`. Empty host lists deny all remote URLs. |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the webhook. |
 | webhook.serviceAccount.name | string | `""` | Optional name for the webhook service account. |
 | webhook.serviceAccount.annotations | object | `{}` | Extra annotations for the webhook service account. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -71,6 +71,12 @@ This removes all the Kubernetes resources associated with the chart and deletes 
 
 See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command documentation.
 
+## URL Validation and SSRF
+
+URL-scheme validation is opt-in and disabled by default. Setting allowed schemes or hosts does not enable it. Set `webhook.urlSchemeValidation.enable=true` to validate declared application and dependency URLs.
+
+This validation reduces server-side request forgery (SSRF) risk, but it is not a complete SSRF defense. It checks only the supported fetch-capable fields at admission time. It does not restrict ports, inspect runtime application traffic, prevent DNS rebinding, validate redirect destinations, or protect against a compromised allowed host. Use restricted egress, least-privilege identities, and trusted artifact sources with this feature. See [Validating Remote Dependency URLs](../../docs/website/user-guide/url-scheme-validation.md) for the validation scope and configuration guidance.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -175,9 +181,9 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.kubeAPIQPS | int | `20` | Maximum QPS to the API server from the controller client. |
 | webhook.kubeAPIBurst | int | `30` | Maximum burst for throttle from the controller client. |
 | webhook.resourceQuotaEnforcement.enable | bool | `false` | Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources. |
-| webhook.urlSchemeValidation.enable | bool | `false` | Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication and ScheduledSparkApplication template fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission time. Opt-in and disabled by default so existing applications using remote schemes are not rejected on upgrade. |
+| webhook.urlSchemeValidation.enable | bool | `false` | Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication and ScheduledSparkApplication template fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission time. Opt-in and disabled by default so existing applications using remote schemes are not rejected on upgrade. This reduces SSRF risk for the checked fields, but it is not a complete SSRF defense. Use restricted egress and least-privilege identities with this feature. |
 | webhook.urlSchemeValidation.allowedSchemes | list | `[]` | URL schemes permitted in fetch-capable SparkApplication fields when validation is enabled. Remote URLs must also match allowedHosts or allowedWildcardHosts unless their scheme is in allowedSchemesAnyHost. |
-| webhook.urlSchemeValidation.allowedSchemesAnyHost | list | `[]` | Allowed URL schemes permitted to access any host, such as `s3a` where a VPC endpoint and network policy constrain reachable buckets. Each scheme must also appear in allowedSchemes. |
+| webhook.urlSchemeValidation.allowedSchemesAnyHost | list | `[]` | Allowed URL schemes permitted to access any host. Each scheme must also appear in allowedSchemes. Use only when separate network and service authorization policies constrain the endpoints and resources that the scheme can access. |
 | webhook.urlSchemeValidation.allowedHosts | list | `[]` | Exact scheme-qualified URL hosts permitted in fetch-capable SparkApplication fields when validation is enabled, such as `https://repo.example.com` or `s3a://bucket`. Empty host lists deny all remote URLs. |
 | webhook.urlSchemeValidation.allowedWildcardHosts | list | `[]` | Scheme-qualified leftmost wildcard URL hosts permitted in fetch-capable SparkApplication fields when validation is enabled, such as `https://*.maven.apache.org`. Empty host lists deny all remote URLs. |
 | webhook.serviceAccount.create | bool | `true` | Specifies whether to create a service account for the webhook. |

--- a/charts/spark-operator-chart/README.md.gotmpl
+++ b/charts/spark-operator-chart/README.md.gotmpl
@@ -73,6 +73,12 @@ This removes all the Kubernetes resources associated with the chart and deletes 
 
 See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command documentation.
 
+## URL Validation and SSRF
+
+URL-scheme validation is opt-in and disabled by default. Setting allowed schemes or hosts does not enable it. Set `webhook.urlSchemeValidation.enable=true` to validate declared application and dependency URLs.
+
+This validation reduces server-side request forgery (SSRF) risk, but it is not a complete SSRF defense. It checks only the supported fetch-capable fields at admission time. It does not restrict ports, inspect runtime application traffic, prevent DNS rebinding, validate redirect destinations, or protect against a compromised allowed host. Use restricted egress, least-privilege identities, and trusted artifact sources with this feature. See [Validating Remote Dependency URLs](../../docs/website/user-guide/url-scheme-validation.md) for the validation scope and configuration guidance.
+
 {{ template "chart.valuesSection" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/spark-operator-chart/ci/ci-values.yaml
+++ b/charts/spark-operator-chart/ci/ci-values.yaml
@@ -19,3 +19,8 @@ controller:
 webhook:
   kubeAPIQPS: 100
   kubeAPIBurst: 100
+  # Enable URL-scheme validation so the e2e SSRF rejection/acceptance specs exercise it; the
+  # feature is opt-in and off by default. No extra allowedSchemes: the specs only rely on the
+  # always-allowed local schemes (file://) passing and http:// being rejected.
+  urlSchemeValidation:
+    enable: true

--- a/charts/spark-operator-chart/ci/ci-values.yaml
+++ b/charts/spark-operator-chart/ci/ci-values.yaml
@@ -19,3 +19,10 @@ controller:
 webhook:
   kubeAPIQPS: 100
   kubeAPIBurst: 100
+  # Enable URL validation so E2E exercises local URLs plus configured remote-host policy.
+  urlSchemeValidation:
+    enable: true
+    allowedSchemes:
+      - https
+    allowedHosts:
+      - https://test1.example.com

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -75,8 +75,11 @@ spec:
         {{- with .Values.webhook.resourceQuotaEnforcement.enable }}
         - --enable-resource-quota-enforcement=true
         {{- end }}
-        {{- with .Values.webhook.sparkAllowedURLSchemes }}
+        {{- if .Values.webhook.urlSchemeValidation.enable }}
+        - --enable-url-scheme-validation=true
+        {{- with .Values.webhook.urlSchemeValidation.allowedSchemes }}
         - --spark-allowed-url-schemes={{ . | join "," }}
+        {{- end }}
         {{- end }}
         {{- if .Values.certManager.enable }}
         - --enable-cert-manager=true

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -75,6 +75,9 @@ spec:
         {{- with .Values.webhook.resourceQuotaEnforcement.enable }}
         - --enable-resource-quota-enforcement=true
         {{- end }}
+        {{- with .Values.webhook.sparkAllowedURLSchemes }}
+        - --spark-allowed-url-schemes={{ . | join "," }}
+        {{- end }}
         {{- if .Values.certManager.enable }}
         - --enable-cert-manager=true
         {{- end }}

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -75,6 +75,21 @@ spec:
         {{- with .Values.webhook.resourceQuotaEnforcement.enable }}
         - --enable-resource-quota-enforcement=true
         {{- end }}
+        {{- if .Values.webhook.urlSchemeValidation.enable }}
+        - --enable-url-scheme-validation=true
+        {{- with .Values.webhook.urlSchemeValidation.allowedSchemes }}
+        - --allowed-url-schemes={{ . | join "," }}
+        {{- end }}
+        {{- with .Values.webhook.urlSchemeValidation.allowedSchemesAnyHost }}
+        - --allowed-url-schemes-any-host={{ . | join "," }}
+        {{- end }}
+        {{- with .Values.webhook.urlSchemeValidation.allowedHosts }}
+        - --allowed-url-hosts={{ . | join "," }}
+        {{- end }}
+        {{- with .Values.webhook.urlSchemeValidation.allowedWildcardHosts }}
+        - --allowed-wildcard-url-hosts={{ . | join "," }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.certManager.enable }}
         - --enable-cert-manager=true
         {{- end }}

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -190,6 +190,44 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
           content: --metrics-labels=app_type
 
+  - it: Should not contain URL-scheme validation args by default (opt-in, off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --enable-url-scheme-validation=true
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --spark-allowed-url-schemes=gs,s3a
+
+  - it: Should contain `--enable-url-scheme-validation` arg if `webhook.urlSchemeValidation.enable` is `true`
+    set:
+      webhook:
+        urlSchemeValidation:
+          enable: true
+          allowedSchemes:
+            - gs
+            - s3a
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --enable-url-scheme-validation=true
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --spark-allowed-url-schemes=gs,s3a
+
+  - it: Should not contain `--spark-allowed-url-schemes` arg when validation is enabled but no schemes are set
+    set:
+      webhook:
+        urlSchemeValidation:
+          enable: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --enable-url-scheme-validation=true
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --spark-allowed-url-schemes
+
   - it: Should enable leader election by default
     asserts:
       - contains:

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -190,6 +190,78 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
           content: --metrics-labels=app_type
 
+  - it: Should not contain URL-scheme validation args by default (opt-in, off)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --enable-url-scheme-validation=true
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-schemes=gs,s3a
+
+  - it: Should contain `--enable-url-scheme-validation` arg if `webhook.urlSchemeValidation.enable` is `true`
+    set:
+      webhook:
+        urlSchemeValidation:
+          enable: true
+          allowedSchemes:
+            - gs
+            - s3a
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --enable-url-scheme-validation=true
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-schemes=gs,s3a
+
+  - it: Should render exact and wildcard URL host policy args when configured
+    set:
+      webhook:
+        urlSchemeValidation:
+          enable: true
+          allowedSchemes:
+            - s3a
+          allowedHosts:
+            - https://test1.example.com
+            - s3a://artifacts-bucket
+          allowedWildcardHosts:
+            - 'https://*.maven.apache.org'
+          allowedSchemesAnyHost:
+            - s3a
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-hosts=https://test1.example.com,s3a://artifacts-bucket
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-wildcard-url-hosts=https://*.maven.apache.org
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-schemes-any-host=s3a
+
+  - it: Should not contain `--allowed-url-schemes` arg when validation is enabled but no schemes are set
+    set:
+      webhook:
+        urlSchemeValidation:
+          enable: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --enable-url-scheme-validation=true
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-schemes
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-schemes-any-host
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-url-hosts
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --allowed-wildcard-url-hosts
+
   - it: Should enable leader election by default
     asserts:
       - contains:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -388,6 +388,12 @@ webhook:
     # -- Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources.
     enable: false
 
+  # -- URL schemes permitted in fetch-capable SparkApplication fields (spec.sparkConf values,
+  # spec.deps.*, spec.mainApplicationFile) at admission time, in addition to the always-allowed
+  # local schemes (schemeless, file://, local://). Any other URL scheme is rejected.
+  # Add schemes your workloads require (e.g. gs, s3a, hdfs).
+  sparkAllowedURLSchemes: []
+
   serviceAccount:
     # -- Specifies whether to create a service account for the webhook.
     create: true

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -388,11 +388,16 @@ webhook:
     # -- Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources.
     enable: false
 
-  # -- URL schemes permitted in fetch-capable SparkApplication fields (spec.sparkConf values,
-  # spec.deps.*, spec.mainApplicationFile) at admission time, in addition to the always-allowed
-  # local schemes (schemeless, file://, local://). Any other URL scheme is rejected.
-  # Add schemes your workloads require (e.g. gs, s3a, hdfs).
-  sparkAllowedURLSchemes: []
+  urlSchemeValidation:
+    # -- Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication
+    # fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission
+    # time. Opt-in and disabled by default so existing SparkApplications using remote schemes are
+    # not rejected on upgrade.
+    enable: false
+    # -- URL schemes permitted in fetch-capable SparkApplication fields when validation is enabled,
+    # in addition to the always-allowed local schemes (schemeless, file://, local://). Any other
+    # URL scheme is rejected. Add schemes your workloads require (e.g. gs, s3a, hdfs).
+    allowedSchemes: []
 
   serviceAccount:
     # -- Specifies whether to create a service account for the webhook.

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -413,14 +413,17 @@ webhook:
     # -- Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication and
     # ScheduledSparkApplication template fields (submit-time spec.sparkConf keys, spec.deps.*,
     # spec.mainApplicationFile) at admission time. Opt-in and disabled by default so existing
-    # applications using remote schemes are not rejected on upgrade.
+    # applications using remote schemes are not rejected on upgrade. This reduces SSRF risk for
+    # the checked fields, but it is not a complete SSRF defense. Use restricted egress and
+    # least-privilege identities with this feature.
     enable: false
     # -- URL schemes permitted in fetch-capable SparkApplication fields when validation is enabled.
     # Remote URLs must also match allowedHosts or allowedWildcardHosts unless their scheme is in
     # allowedSchemesAnyHost.
     allowedSchemes: []
-    # -- Allowed URL schemes permitted to access any host, such as `s3a` where a VPC endpoint and
-    # network policy constrain reachable buckets. Each scheme must also appear in allowedSchemes.
+    # -- Allowed URL schemes permitted to access any host. Each scheme must also appear in
+    # allowedSchemes. Use only when separate network and service authorization policies constrain
+    # the endpoints and resources that the scheme can access.
     allowedSchemesAnyHost: []
     # -- Exact scheme-qualified URL hosts permitted in fetch-capable SparkApplication fields when
     # validation is enabled, such as `https://repo.example.com` or `s3a://bucket`. Empty host

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -409,6 +409,28 @@ webhook:
     # -- Specifies whether to enable the ResourceQuota enforcement for SparkApplication resources.
     enable: false
 
+  urlSchemeValidation:
+    # -- Specifies whether to enable URL-scheme validation of fetch-capable SparkApplication and
+    # ScheduledSparkApplication template fields (submit-time spec.sparkConf keys, spec.deps.*,
+    # spec.mainApplicationFile) at admission time. Opt-in and disabled by default so existing
+    # applications using remote schemes are not rejected on upgrade.
+    enable: false
+    # -- URL schemes permitted in fetch-capable SparkApplication fields when validation is enabled.
+    # Remote URLs must also match allowedHosts or allowedWildcardHosts unless their scheme is in
+    # allowedSchemesAnyHost.
+    allowedSchemes: []
+    # -- Allowed URL schemes permitted to access any host, such as `s3a` where a VPC endpoint and
+    # network policy constrain reachable buckets. Each scheme must also appear in allowedSchemes.
+    allowedSchemesAnyHost: []
+    # -- Exact scheme-qualified URL hosts permitted in fetch-capable SparkApplication fields when
+    # validation is enabled, such as `https://repo.example.com` or `s3a://bucket`. Empty host
+    # lists deny all remote URLs.
+    allowedHosts: []
+    # -- Scheme-qualified leftmost wildcard URL hosts permitted in fetch-capable SparkApplication
+    # fields when validation is enabled, such as `https://*.maven.apache.org`. Empty host lists
+    # deny all remote URLs.
+    allowedWildcardHosts: []
+
   serviceAccount:
     # -- Specifies whether to create a service account for the webhook.
     create: true

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -73,6 +73,7 @@ var (
 
 	// Webhook
 	enableResourceQuotaEnforcement bool
+	sparkAllowedURLSchemes         []string
 	webhookCertDir                 string
 	webhookCertName                string
 	webhookKeyName                 string
@@ -149,6 +150,7 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&webhookServiceName, "webhook-svc-name", "spark-webhook", "The name of the Service for the webhook server.")
 	command.Flags().StringVar(&webhookServiceNamespace, "webhook-svc-namespace", "spark-webhook", "The name of the Service for the webhook server.")
 	command.Flags().BoolVar(&enableResourceQuotaEnforcement, "enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
+	command.Flags().StringSliceVar(&sparkAllowedURLSchemes, "spark-allowed-url-schemes", []string{}, "Comma-separated list of URL schemes permitted in fetch-capable SparkApplication fields (spec.sparkConf values, spec.deps.*, spec.mainApplicationFile) at admission time, in addition to the always-allowed local schemes (schemeless, file://, local://). Any other URL scheme is rejected. Add schemes your workloads require (e.g. gs,s3a,hdfs).")
 
 	// Cert Manager
 	command.Flags().BoolVar(&enableCertManager, "enable-cert-manager", false, "Enable cert-manager to manage the webhook server's TLS certificate.")
@@ -315,7 +317,7 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.SparkApplication{}).
 		WithDefaulter(webhook.NewSparkApplicationDefaulter()).
-		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement)).
+		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement, sparkAllowedURLSchemes)).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Spark application")

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -73,6 +73,7 @@ var (
 
 	// Webhook
 	enableResourceQuotaEnforcement bool
+	enableURLSchemeValidation      bool
 	sparkAllowedURLSchemes         []string
 	webhookCertDir                 string
 	webhookCertName                string
@@ -150,7 +151,8 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&webhookServiceName, "webhook-svc-name", "spark-webhook", "The name of the Service for the webhook server.")
 	command.Flags().StringVar(&webhookServiceNamespace, "webhook-svc-namespace", "spark-webhook", "The name of the Service for the webhook server.")
 	command.Flags().BoolVar(&enableResourceQuotaEnforcement, "enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
-	command.Flags().StringSliceVar(&sparkAllowedURLSchemes, "spark-allowed-url-schemes", []string{}, "Comma-separated list of URL schemes permitted in fetch-capable SparkApplication fields (spec.sparkConf values, spec.deps.*, spec.mainApplicationFile) at admission time, in addition to the always-allowed local schemes (schemeless, file://, local://). Any other URL scheme is rejected. Add schemes your workloads require (e.g. gs,s3a,hdfs).")
+	command.Flags().BoolVar(&enableURLSchemeValidation, "enable-url-scheme-validation", false, "Whether to enable URL-scheme validation of fetch-capable SparkApplication fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission time. Opt-in and off by default so existing SparkApplications using remote schemes are not broken on upgrade. When enabled, only the always-allowed local schemes (schemeless, file://, local://) and any listed in --spark-allowed-url-schemes are accepted.")
+	command.Flags().StringSliceVar(&sparkAllowedURLSchemes, "spark-allowed-url-schemes", []string{}, "Comma-separated list of URL schemes permitted in fetch-capable SparkApplication fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) when --enable-url-scheme-validation is set, in addition to the always-allowed local schemes (schemeless, file://, local://). Any other URL scheme is rejected. Add schemes your workloads require (e.g. gs,s3a,hdfs).")
 
 	// Cert Manager
 	command.Flags().BoolVar(&enableCertManager, "enable-cert-manager", false, "Enable cert-manager to manage the webhook server's TLS certificate.")
@@ -317,7 +319,7 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.SparkApplication{}).
 		WithDefaulter(webhook.NewSparkApplicationDefaulter()).
-		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement, sparkAllowedURLSchemes)).
+		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement, enableURLSchemeValidation, sparkAllowedURLSchemes)).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Spark application")

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -73,6 +73,11 @@ var (
 
 	// Webhook
 	enableResourceQuotaEnforcement bool
+	enableURLSchemeValidation      bool
+	sparkAllowedURLSchemes         []string
+	sparkAllowedURLSchemesAnyHost  []string
+	sparkAllowedURLHosts           []string
+	sparkAllowedWildcardURLHosts   []string
 	webhookCertDir                 string
 	webhookCertName                string
 	webhookKeyName                 string
@@ -118,8 +123,12 @@ func NewStartCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "Start controller and webhook",
-		PreRun: func(_ *cobra.Command, args []string) {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			development = viper.GetBool("development")
+			if err := webhook.ValidateAllowedURLHosts(sparkAllowedURLHosts, sparkAllowedWildcardURLHosts); err != nil {
+				return err
+			}
+			return webhook.ValidateAllowAllURLHostsSchemes(sparkAllowedURLSchemes, sparkAllowedURLSchemesAnyHost)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			version.PrintVersion(false)
@@ -149,6 +158,11 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&webhookServiceName, "webhook-svc-name", "spark-webhook", "The name of the Service for the webhook server.")
 	command.Flags().StringVar(&webhookServiceNamespace, "webhook-svc-namespace", "spark-webhook", "The name of the Service for the webhook server.")
 	command.Flags().BoolVar(&enableResourceQuotaEnforcement, "enable-resource-quota-enforcement", false, "Whether to enable ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled.")
+	command.Flags().BoolVar(&enableURLSchemeValidation, "enable-url-scheme-validation", false, "Whether to enable URL validation of fetch-capable SparkApplication and ScheduledSparkApplication template fields (submit-time spec.sparkConf keys, spec.deps.*, spec.mainApplicationFile) at admission time. Opt-in and off by default so existing applications using remote URLs are not rejected on upgrade. When enabled, remote URLs must match both --allowed-url-schemes and an allowed host.")
+	command.Flags().StringSliceVar(&sparkAllowedURLSchemes, "allowed-url-schemes", []string{}, "Comma-separated list of URL schemes permitted in fetch-capable SparkApplication and ScheduledSparkApplication template fields when --enable-url-scheme-validation is set. Remote URLs must also match --allowed-url-hosts or --allowed-wildcard-url-hosts.")
+	command.Flags().StringSliceVar(&sparkAllowedURLSchemesAnyHost, "allowed-url-schemes-any-host", []string{}, "Comma-separated list of allowed URL schemes permitted to access any host in fetch-capable SparkApplication and ScheduledSparkApplication template fields. Each scheme must also be listed in --allowed-url-schemes. Use only where network policy constrains reachable hosts.")
+	command.Flags().StringSliceVar(&sparkAllowedURLHosts, "allowed-url-hosts", []string{}, "Comma-separated list of exact scheme-qualified URL hosts permitted in fetch-capable SparkApplication and ScheduledSparkApplication template fields when --enable-url-scheme-validation is set, such as https://repo.example.com or s3a://bucket. Empty host lists deny all remote URLs.")
+	command.Flags().StringSliceVar(&sparkAllowedWildcardURLHosts, "allowed-wildcard-url-hosts", []string{}, "Comma-separated list of scheme-qualified leftmost wildcard URL hosts permitted in fetch-capable SparkApplication and ScheduledSparkApplication template fields when --enable-url-scheme-validation is set, such as https://*.maven.apache.org. Empty host lists deny all remote URLs.")
 
 	// Cert Manager
 	command.Flags().BoolVar(&enableCertManager, "enable-cert-manager", false, "Enable cert-manager to manage the webhook server's TLS certificate.")
@@ -318,7 +332,7 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.SparkApplication{}).
 		WithDefaulter(webhook.NewSparkApplicationDefaulter()).
-		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement)).
+		WithValidator(webhook.NewSparkApplicationValidator(mgr.GetClient(), enableResourceQuotaEnforcement, enableURLSchemeValidation, sparkAllowedURLSchemes, sparkAllowedURLSchemesAnyHost, sparkAllowedURLHosts, sparkAllowedWildcardURLHosts)).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Spark application")
@@ -327,7 +341,7 @@ func start() {
 
 	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.ScheduledSparkApplication{}).
 		WithDefaulter(webhook.NewScheduledSparkApplicationDefaulter()).
-		WithValidator(webhook.NewScheduledSparkApplicationValidator()).
+		WithValidator(webhook.NewScheduledSparkApplicationValidator(enableURLSchemeValidation, sparkAllowedURLSchemes, sparkAllowedURLSchemesAnyHost, sparkAllowedURLHosts, sparkAllowedWildcardURLHosts)).
 		WithLogConstructor(webhook.LogConstructor).
 		Complete(); err != nil {
 		logger.Error(err, "Failed to create mutating webhook for Scheduled Spark application")

--- a/config/overlays/driver-pdb/enable-url-scheme-validation-patch.yaml
+++ b/config/overlays/driver-pdb/enable-url-scheme-validation-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --enable-url-scheme-validation=true

--- a/config/overlays/driver-pdb/kustomization.yaml
+++ b/config/overlays/driver-pdb/kustomization.yaml
@@ -1,12 +1,15 @@
-# Opt-in overlay that enables the driver PodDisruptionBudget feature.
+# Opt-in overlay that enables off-by-default operator features for e2e and for
+# kustomize-based deployments that want them:
+#   - controller: --enable-driver-pdb=true (driver PodDisruptionBudget)
+#   - webhook:    --enable-url-scheme-validation=true (fetch-field SSRF hardening)
 #
 # Usage:
 #   kustomize build config/overlays/driver-pdb/ | kubectl apply --server-side -f -
 #
-# It builds on config/default and appends --enable-driver-pdb=true to the
-# controller container args. The flag defaults to false in the binary, so this
-# overlay is the supported way to turn the feature on for kustomize-based
-# deployments.
+# It builds on config/default and appends the flags to the respective container
+# args. Both flags default to false in the binary, so this overlay is the
+# supported way to turn the features on for kustomize-based deployments; it keeps
+# the e2e kustomize deployment aligned with the helm ci-values.yaml.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -19,3 +22,7 @@ patches:
     target:
       kind: Deployment
       name: spark-operator-controller
+  - path: enable-url-scheme-validation-patch.yaml
+    target:
+      kind: Deployment
+      name: spark-operator-webhook

--- a/config/overlays/driver-pdb/kustomization.yaml
+++ b/config/overlays/driver-pdb/kustomization.yaml
@@ -1,12 +1,11 @@
-# Opt-in overlay that enables the driver PodDisruptionBudget feature.
+# Opt-in overlay that enables driver PodDisruptionBudget support for
+# kustomize-based deployments.
 #
 # Usage:
 #   kustomize build config/overlays/driver-pdb/ | kubectl apply --server-side -f -
 #
 # It builds on config/default and appends --enable-driver-pdb=true to the
-# controller container args. The flag defaults to false in the binary, so this
-# overlay is the supported way to turn the feature on for kustomize-based
-# deployments.
+# controller args. The flag defaults to false in the binary.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/overlays/e2e/enable-driver-pdb-patch.yaml
+++ b/config/overlays/e2e/enable-driver-pdb-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --enable-driver-pdb=true

--- a/config/overlays/e2e/enable-url-scheme-validation-patch.yaml
+++ b/config/overlays/e2e/enable-url-scheme-validation-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --enable-url-scheme-validation=true
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --allowed-url-schemes=https
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --allowed-url-hosts=https://test1.example.com

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -1,0 +1,19 @@
+# E2E overlay enables opt-in features exercised by the Helm CI values:
+#   - controller: --enable-driver-pdb=true
+#   - webhook: --enable-url-scheme-validation=true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../default
+
+patches:
+  - path: enable-driver-pdb-patch.yaml
+    target:
+      kind: Deployment
+      name: spark-operator-controller
+  - path: enable-url-scheme-validation-patch.yaml
+    target:
+      kind: Deployment
+      name: spark-operator-webhook

--- a/config/overlays/url-scheme-validation/enable-url-scheme-validation-patch.yaml
+++ b/config/overlays/url-scheme-validation/enable-url-scheme-validation-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --enable-url-scheme-validation=true

--- a/config/overlays/url-scheme-validation/kustomization.yaml
+++ b/config/overlays/url-scheme-validation/kustomization.yaml
@@ -1,0 +1,20 @@
+# Opt-in overlay that enables URL-scheme validation for SparkApplication and
+# ScheduledSparkApplication fetch fields in kustomize-based deployments.
+#
+# Usage:
+#   kustomize build config/overlays/url-scheme-validation/ | kubectl apply --server-side -f -
+#
+# It builds on config/default and appends --enable-url-scheme-validation=true to
+# the webhook args. The flag defaults to false in the binary.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../default
+
+patches:
+  - path: enable-url-scheme-validation-patch.yaml
+    target:
+      kind: Deployment
+      name: spark-operator-webhook

--- a/config/overlays/url-scheme-validation/kustomization.yaml
+++ b/config/overlays/url-scheme-validation/kustomization.yaml
@@ -5,7 +5,9 @@
 #   kustomize build config/overlays/url-scheme-validation/ | kubectl apply --server-side -f -
 #
 # It builds on config/default and appends --enable-url-scheme-validation=true to
-# the webhook args. The flag defaults to false in the binary.
+# the webhook args. The flag defaults to false in the binary. This validation
+# reduces SSRF risk for declared fetch URLs, but it is not a complete defense.
+# Also enforce restricted egress and least-privilege identities.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/docs/kustomize-installation.md
+++ b/docs/kustomize-installation.md
@@ -87,7 +87,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubeflow/spark-operator/refs/
 
 ## Component Guide
 
-Three optional capabilities are shipped as standalone Kustomize directories
+Four optional capabilities are shipped as standalone Kustomize directories
 under `config/`.  Enable them by adding them to the `resources` list in
 your overlay.
 
@@ -128,6 +128,18 @@ annotations (`prometheus.io/scrape`, `prometheus.io/port`,
 `prometheus.io/path`), so basic annotation-based scraping works without this
 resource.  The `PodMonitor` is for clusters using the Prometheus Operator's
 CRD-based service discovery.
+
+### URL Scheme Validation (config/overlays/url-scheme-validation)
+
+URL-scheme validation is opt-in and disabled in `config/default`. Apply the overlay to enable admission checks for declared application and dependency URLs:
+
+```bash
+kubectl apply -k config/overlays/url-scheme-validation --server-side
+```
+
+The overlay allows local paths but does not allow any remote schemes or hosts. Add `--allowed-url-schemes` and `--allowed-url-hosts` arguments in your own overlay if applications need remote URLs.
+
+This validation reduces SSRF risk, but it is not a complete defense. It does not inspect runtime traffic, prevent DNS rebinding, validate redirect destinations, or protect against a compromised allowed host. Use restricted egress, least-privilege identities, and trusted artifact sources with this feature. See the [URL scheme validation guide](website/user-guide/url-scheme-validation.md) for the full scope and configuration options.
 
 ### cert-manager Integration (config/certmanager)
 

--- a/docs/website/user-guide/index.md
+++ b/docs/website/user-guide/index.md
@@ -93,6 +93,13 @@ Deploy several operator instances scoped to different namespaces
 Enforce Kubernetes resource quotas on Spark workloads
 ::::
 
+::::{grid-item-card} URL Scheme Validation
+:link: url-scheme-validation
+:link-type: doc
+
+Limit declared remote dependency URLs and understand the SSRF security boundary
+::::
+
 :::::
 
 ## Monitoring & Scheduling
@@ -160,6 +167,7 @@ building-custom-images
 leader-election
 running-multiple-instances-of-the-operator
 resource-quota-enforcement
+url-scheme-validation
 monitoring-with-jmx-and-prometheus
 volcano-integration
 yunikorn-integration

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -1018,7 +1018,7 @@ func (r *Reconciler) submitSparkApplication(ctx context.Context, app *v1beta2.Sp
 
 	if err := r.submitter.Submit(ctx, submitApp); err != nil {
 		r.recordSparkApplicationEvent(app)
-		submitErr = fmt.Errorf("failed to submit spark application: %v", err)
+		submitErr = fmt.Errorf("failed to submit spark application: %w", err)
 		return
 	}
 

--- a/internal/controller/sparkapplication/rest_submission.go
+++ b/internal/controller/sparkapplication/rest_submission.go
@@ -160,7 +160,7 @@ type SubmitError struct {
 }
 
 func (e *SubmitError) Error() string {
-	return fmt.Sprintf("submitter service returned error: %s (HTTP %d, error code: %s)", e.Message, e.StatusCode, e.Code)
+	return fmt.Sprintf("submitter service returned error (HTTP %d, error code: %s)", e.StatusCode, e.Code)
 }
 
 func (e *SubmitError) IsRetryable() bool {

--- a/internal/controller/sparkapplication/rest_submission_test.go
+++ b/internal/controller/sparkapplication/rest_submission_test.go
@@ -276,7 +276,6 @@ func TestParseSubmitResponse(t *testing.T) {
 		resp := &http.Response{StatusCode: http.StatusConflict, Body: io.NopCloser(bytes.NewReader(body))}
 		result, err := parseSubmitResponse(resp)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "Failed to submit")
 		assert.Contains(t, err.Error(), "DRIVER_POD_ALREADY_EXISTS")
 		var submitErr *SubmitError
 		assert.True(t, errors.As(err, &submitErr))
@@ -295,7 +294,6 @@ func TestParseSubmitResponse(t *testing.T) {
 		resp := &http.Response{StatusCode: 400, Body: io.NopCloser(bytes.NewReader(body))}
 		result, err := parseSubmitResponse(resp)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "Invalid job configuration")
 		assert.Contains(t, err.Error(), "BAD_REQUEST")
 	})
 
@@ -336,6 +334,16 @@ func TestCanRetry(t *testing.T) {
 	assert.False(t, s.canRetry(0, podExists), "DRIVER_POD_ALREADY_EXISTS should not retry")
 	assert.False(t, s.canRetry(0, invalidTemplate), "INVALID_POD_TEMPLATE should not retry")
 	assert.False(t, s.canRetry(2, overloaded), "last attempt should not retry")
+}
+
+func TestSubmitErrorDoesNotExposeResponseMessage(t *testing.T) {
+	err := &SubmitError{
+		Code:       ErrorCodeInvalidSparkSubmitArgs,
+		StatusCode: 400,
+		Message:    "https://user:password@example.com/repo?token=secret",
+	}
+
+	assert.Equal(t, "submitter service returned error (HTTP 400, error code: INVALID_SPARK_SUBMIT_ARGS)", err.Error())
 }
 
 // --- Test helpers ---

--- a/internal/controller/sparkapplication/submission.go
+++ b/internal/controller/sparkapplication/submission.go
@@ -18,6 +18,7 @@ package sparkapplication
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -46,6 +47,24 @@ type SparkApplicationSubmitter interface {
 type SparkSubmitter struct {
 }
 
+// SparkSubmitError keeps the command error for operator-side diagnostics while exposing a
+// stable, non-sensitive message to SparkApplication status and Kubernetes Events.
+type SparkSubmitError struct {
+	err      error
+	exitCode int
+}
+
+func (e *SparkSubmitError) Error() string {
+	if e.exitCode >= 0 {
+		return fmt.Sprintf("spark-submit failed with exit code %d", e.exitCode)
+	}
+	return "spark-submit failed"
+}
+
+func (e *SparkSubmitError) Unwrap() error {
+	return e.err
+}
+
 // SparkSubmitter implements SparkApplicationSubmitter interface.
 // This interface is highly experimental and may go under significant changes or removed in the future.
 var _ SparkApplicationSubmitter = &SparkSubmitter{}
@@ -62,7 +81,12 @@ func (*SparkSubmitter) Submit(ctx context.Context, app *v1beta2.SparkApplication
 	// Try submitting the application by running spark-submit.
 	logger.Info("Running spark-submit", "arguments", args)
 	if err := runSparkSubmit(args); err != nil {
-		return fmt.Errorf("failed to run spark-submit: %v", err)
+		exitCode := -1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		return &SparkSubmitError{err: err, exitCode: exitCode}
 	}
 
 	return nil
@@ -86,9 +110,9 @@ func runSparkSubmit(args []string) error {
 			return fmt.Errorf("driver pod already exist")
 		}
 		if errorMsg != "" {
-			return fmt.Errorf("failed to run spark-submit: %s", errorMsg)
+			return fmt.Errorf("failed to run spark-submit: %s: %w", errorMsg, err)
 		}
-		return fmt.Errorf("failed to run spark-submit: %v", err)
+		return fmt.Errorf("failed to run spark-submit: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/sparkapplication/submission_test.go
+++ b/internal/controller/sparkapplication/submission_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sparkapplication
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -36,6 +37,18 @@ import (
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
+
+func TestSparkSubmitErrorPreservesCauseAndSanitizesMessage(t *testing.T) {
+	cause := errors.New("failed to run spark-submit: remote artifact fetch failed")
+	err := &SparkSubmitError{err: cause, exitCode: 17}
+
+	assert.Equal(t, "spark-submit failed with exit code 17", err.Error())
+	assert.ErrorIs(t, err, cause)
+
+	var got *SparkSubmitError
+	assert.ErrorAs(t, err, &got)
+	assert.Same(t, err, got)
+}
 
 func TestExecutorConfOption(t *testing.T) {
 	tests := []struct {

--- a/internal/webhook/scheduledsparkapplication_validator.go
+++ b/internal/webhook/scheduledsparkapplication_validator.go
@@ -34,11 +34,20 @@ import (
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:admissionReviewVersions=v1,failurePolicy=fail,groups=sparkoperator.k8s.io,matchPolicy=Exact,mutating=false,name=validate-scheduledsparkapplication.sparkoperator.k8s.io,path=/validate-sparkoperator-k8s-io-v1beta2-scheduledsparkapplication,reinvocationPolicy=Never,resources=scheduledsparkapplications,sideEffects=None,verbs=create;update,versions=v1beta2,webhookVersions=v1
 
-type ScheduledSparkApplicationValidator struct{}
+type ScheduledSparkApplicationValidator struct {
+	enableURLSchemeValidation bool
+	urlValidationPolicy
+}
 
 // NewScheduledSparkApplicationValidator creates a new ScheduledSparkApplicationValidator instance.
-func NewScheduledSparkApplicationValidator() *ScheduledSparkApplicationValidator {
-	return &ScheduledSparkApplicationValidator{}
+// enableURLSchemeValidation turns on fetch-field URL validation (default off / opt-in).
+// The remaining arguments define allowed schemes and scheme-qualified exact, wildcard, or
+// all-host URL policies for the scheduled application's template.
+func NewScheduledSparkApplicationValidator(enableURLSchemeValidation bool, allowedURLSchemes, allowAllURLHostsSchemes, allowedURLHosts, allowedWildcardURLHosts []string) *ScheduledSparkApplicationValidator {
+	return &ScheduledSparkApplicationValidator{
+		enableURLSchemeValidation: enableURLSchemeValidation,
+		urlValidationPolicy:       newURLValidationPolicy(allowedURLSchemes, allowAllURLHostsSchemes, allowedURLHosts, allowedWildcardURLHosts),
+	}
 }
 
 var _ admission.Validator[*v1beta2.ScheduledSparkApplication] = &ScheduledSparkApplicationValidator{}
@@ -100,7 +109,14 @@ func (v *ScheduledSparkApplicationValidator) validate(app *v1beta2.ScheduledSpar
 	if err := validateSparkConf(app.Spec.Template.SparkConf, app.Namespace); err != nil {
 		return err
 	}
-	return validateConfigMaps(&app.Spec.Template, field.NewPath("spec", "template"))
+	if err := validateConfigMaps(&app.Spec.Template, field.NewPath("spec", "template")); err != nil {
+		return err
+	}
+	if !v.enableURLSchemeValidation {
+		return nil
+	}
+
+	return (&SparkApplicationValidator{urlValidationPolicy: v.urlValidationPolicy}).validateURLSchemes(&app.Spec.Template, "spec.template.")
 }
 
 // validateName ensures the ScheduledSparkApplication metadata.name, when combined with suffixes,

--- a/internal/webhook/scheduledsparkapplication_validator_test.go
+++ b/internal/webhook/scheduledsparkapplication_validator_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
 
 func TestScheduledSparkApplicationValidatorValidateCreate(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	t.Run("accepts ScheduledSparkApplication instances", func(t *testing.T) {
 		app := &v1beta2.ScheduledSparkApplication{
@@ -48,7 +49,7 @@ func TestScheduledSparkApplicationValidatorValidateCreate(t *testing.T) {
 }
 
 func TestScheduledSparkApplicationValidatorValidateUpdate(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	t.Run("accepts ScheduledSparkApplication instances", func(t *testing.T) {
 		oldApp := &v1beta2.ScheduledSparkApplication{
@@ -74,7 +75,7 @@ func TestScheduledSparkApplicationValidatorValidateUpdate(t *testing.T) {
 }
 
 func TestScheduledSparkApplicationValidatorValidateDelete(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	t.Run("accepts ScheduledSparkApplication instances", func(t *testing.T) {
 		warnings, err := validator.ValidateDelete(context.Background(), &v1beta2.ScheduledSparkApplication{})
@@ -101,7 +102,7 @@ func newScheduledSparkApplication() *v1beta2.ScheduledSparkApplication {
 }
 
 func TestScheduledSparkApplicationValidatorSparkConf_SecurityVectorsRejected(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	for _, tt := range sparkConfSecurityVectors {
 		t.Run(tt.name, func(t *testing.T) {
@@ -116,7 +117,7 @@ func TestScheduledSparkApplicationValidatorSparkConf_SecurityVectorsRejected(t *
 }
 
 func TestScheduledSparkApplicationValidatorSparkConf_UpdateRejected(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	oldApp := newScheduledSparkApplication()
 	newApp := newScheduledSparkApplication()
@@ -128,7 +129,7 @@ func TestScheduledSparkApplicationValidatorSparkConf_UpdateRejected(t *testing.T
 }
 
 func TestScheduledSparkApplicationValidatorValidateName(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	tests := []struct {
 		name      string
@@ -183,7 +184,7 @@ func TestScheduledSparkApplicationValidatorValidateName(t *testing.T) {
 }
 
 func TestScheduledSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
-	validator := NewScheduledSparkApplicationValidator()
+	validator := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
 
 	app := newScheduledSparkApplication()
 	app.Spec.Template.Driver.ConfigMaps = configMapRefs("MY_CONFIG")
@@ -191,5 +192,60 @@ func TestScheduledSparkApplicationValidatorValidateCreate_ConfigMapNames(t *test
 	_, err := validator.ValidateCreate(context.Background(), app)
 	if err == nil || !strings.Contains(err.Error(), `spec.template.driver.configMaps[0].name has invalid ConfigMap name "MY_CONFIG"`) {
 		t.Fatalf("expected an invalid ConfigMap name error, got %v", err)
+	}
+}
+
+func TestScheduledSparkApplicationValidatorURLSchemes(t *testing.T) {
+	app := newScheduledSparkApplication()
+	app.Spec.Template.MainApplicationFile = ptr.To("http://attacker.example.com/app.py")
+	app.Spec.Template.Deps.Repositories = []string{"http://attacker.example.com/maven"}
+	app.Spec.Template.SparkConf = map[string]string{
+		"spark.jars": "http://attacker.example.com/evil.jar",
+	}
+
+	disabled := NewScheduledSparkApplicationValidator(false, nil, nil, nil, nil)
+	if _, err := disabled.ValidateCreate(context.Background(), app); err != nil {
+		t.Fatalf("expected no error when URL-scheme validation is disabled, got %v", err)
+	}
+
+	enabled := NewScheduledSparkApplicationValidator(true, nil, nil, nil, nil)
+	_, err := enabled.ValidateCreate(context.Background(), app)
+	requireURLValidationErrors(t, err,
+		urlValidationErrorExpectation{
+			field:  "spec.template.mainApplicationFile",
+			value:  "http://attacker.example.com/app.py",
+			scheme: "http",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+		urlValidationErrorExpectation{
+			field:  "spec.template.deps.repositories",
+			value:  "http://attacker.example.com/maven",
+			scheme: "http",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+		urlValidationErrorExpectation{
+			field:  `spec.template.sparkConf["spark.jars"]`,
+			value:  "http://attacker.example.com/evil.jar",
+			scheme: "http",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+	)
+
+	oldApp := newScheduledSparkApplication()
+	newApp := oldApp.DeepCopy()
+	newApp.Spec.Template.MainApplicationFile = ptr.To("http://attacker.example.com/app.py")
+	_, err = enabled.ValidateUpdate(context.Background(), oldApp, newApp)
+	requireURLValidationErrors(t, err, urlValidationErrorExpectation{
+		field:  "spec.template.mainApplicationFile",
+		value:  "http://attacker.example.com/app.py",
+		scheme: "http",
+		kind:   URLValidationSchemeNotAllowed,
+	})
+
+	allowed := NewScheduledSparkApplicationValidator(true, []string{"https"}, nil, []string{"https://test1.example.com"}, nil)
+	allowedApp := newScheduledSparkApplication()
+	allowedApp.Spec.Template.MainApplicationFile = ptr.To("https://test1.example.com/app.py")
+	if _, err := allowed.ValidateCreate(context.Background(), allowedApp); err != nil {
+		t.Fatalf("expected allowed scheduled URL to pass validation, got %v", err)
 	}
 }

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -19,6 +19,9 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"reflect"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,14 +43,31 @@ type SparkApplicationValidator struct {
 	client client.Client
 
 	enableResourceQuotaEnforcement bool
+	// allowedURLSchemes is the set of additional URL schemes permitted in fetch-capable spec
+	// fields (sparkConf values, deps.*, mainApplicationFile) beyond the always-allowed local
+	// schemes (schemeless, file://, local://). Any value whose URL scheme is not always-allowed
+	// and not in this set is rejected at admission time. Add schemes your workloads require
+	// (e.g. gs, s3a, hdfs).
+	allowedURLSchemes map[string]struct{}
 }
 
 // NewSparkApplicationValidator creates a new SparkApplicationValidator instance.
-func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnforcement bool) *SparkApplicationValidator {
+// allowedURLSchemes lists URL schemes permitted in fetch-capable spec fields (sparkConf values,
+// deps.*, mainApplicationFile) in addition to the always-allowed local schemes (schemeless,
+// file://, local://). Any other scheme is rejected.
+func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnforcement bool, allowedURLSchemes []string) *SparkApplicationValidator {
+	allowed := make(map[string]struct{}, len(allowedURLSchemes))
+	for _, s := range allowedURLSchemes {
+		s = strings.TrimSpace(strings.ToLower(s))
+		if s != "" {
+			allowed[s] = struct{}{}
+		}
+	}
 	return &SparkApplicationValidator{
 		client: client,
 
 		enableResourceQuotaEnforcement: enableResourceQuotaEnforcement,
+		allowedURLSchemes:              allowed,
 	}
 }
 
@@ -156,6 +176,159 @@ func (v *SparkApplicationValidator) validateSpec(ctx context.Context, app *v1bet
 		return err
 	}
 
+	if err := v.validateURLSchemes(app); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// alwaysAllowedURLSchemes are URL schemes that never reach the operator's network: they
+// reference files already present on the submitter/driver/executor filesystem or baked into
+// the container image, so they are not SSRF vectors and are always permitted.
+//   - "" (schemeless): a relative or absolute local path.
+//   - "file": a file:// URI on the local filesystem.
+//   - "local": a local:// URI resolved inside the driver/executor container image.
+var alwaysAllowedURLSchemes = []string{"", "file", "local"}
+
+// depsURLFieldsExempt are v1beta2.Dependencies json tags whose values are NOT dereferenced as
+// URLs and so are deliberately skipped by the URL-scheme check: they are Maven coordinates
+// (groupId:artifactId:version), not fetchable URLs. Every other []string field of Dependencies
+// is URL-checked automatically (see depsURLFields), so a newly-added fetch-capable field is
+// covered without code changes; a new non-URL field must be added here.
+var depsURLFieldsExempt = []string{"packages", "excludePackages"}
+
+// sparkConfKeysExempt are sparkConf keys whose comma-separated values are NOT dereferenced as
+// URLs: they hold Maven coordinates (groupId:artifactId:version) or Ivy XML paths resolved by
+// the Spark Ivy subsystem, not operator-fetched URLs. spark.jars.packages is the primary case:
+// a value like "org.postgresql:postgresql:42.7.3" parses as scheme "org.postgresql" but is not
+// a URL. spark.jars.excludePackages and spark.jars.ivySettings follow the same pattern.
+var sparkConfKeysExempt = map[string]struct{}{
+	"spark.jars.packages":        {},
+	"spark.jars.excludePackages": {},
+	"spark.jars.ivySettings":     {},
+}
+
+// depsURLField is one []string field of v1beta2.Dependencies to URL-check: its struct field
+// index and the error label derived from its json tag.
+type depsURLField struct {
+	index int
+	label string
+}
+
+// depsURLFields is the URL-check plan for v1beta2.Dependencies, computed once from the struct's
+// json tags rather than re-reflected on every admission. See depsURLFieldsExempt for exclusions.
+var depsURLFields = buildDepsURLFields()
+
+func buildDepsURLFields() []depsURLField {
+	var fields []depsURLField
+	rt := reflect.TypeFor[v1beta2.Dependencies]()
+	stringSlice := reflect.TypeFor[[]string]()
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		if f.Type != stringSlice {
+			continue
+		}
+		tag := strings.Split(f.Tag.Get("json"), ",")[0]
+		if tag == "" || tag == "-" || slices.Contains(depsURLFieldsExempt, tag) {
+			continue
+		}
+		fields = append(fields, depsURLField{index: i, label: "spec.deps." + tag})
+	}
+	return fields
+}
+
+// validateURLSchemes rejects any user-supplied value that is forwarded to the operator's
+// spark-submit and dereferenced as a remote URL whose scheme is not in the allowed set.
+// spark-submit runs in the operator pod, so an http/https/etc. URL in any of these fields is
+// fetched by the operator's principal (its ServiceAccount, mounted secrets, IRSA/Workload
+// Identity, VPC reachability) - an SSRF vector.
+//
+// Comma-separated sparkConf values (spark.jars, spark.files, ...) are split.
+//
+// spec.hadoopConf is out of scope: its values become spark.hadoop.* config consumed by the
+// driver/executor at runtime, not URLs the operator fetches at submit time, and many are
+// legitimately host/endpoint-shaped (fs.s3a.endpoint, ...) that a scheme check would wrongly reject.
+func (v *SparkApplicationValidator) validateURLSchemes(app *v1beta2.SparkApplication) error {
+	// spec.mainApplicationFile is a single URI forwarded as the final spark-submit argument.
+	if app.Spec.MainApplicationFile != nil {
+		if err := v.checkURLScheme("spec.mainApplicationFile", *app.Spec.MainApplicationFile); err != nil {
+			return err
+		}
+	}
+
+	// spec.deps fetch-capable lists (--jars, --files, --py-files, --archives, --repositories).
+	if err := v.validateDepsURLSchemes(&app.Spec.Deps); err != nil {
+		return err
+	}
+
+	// spec.sparkConf values; some conf keys carry comma-separated URI lists, but some
+	// (spark.jars.packages, spark.jars.excludePackages, spark.jars.ivySettings) hold Maven
+	// coordinates or Ivy XML paths that parse as invalid URL schemes and are exempt.
+	for key, value := range app.Spec.SparkConf {
+		if _, exempt := sparkConfKeysExempt[key]; exempt {
+			continue
+		}
+		field := fmt.Sprintf("spec.sparkConf[%q]", key)
+		if err := v.checkURLSchemes(field, strings.Split(value, ",")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateDepsURLSchemes URL-checks the fetch-capable []string fields of spec.deps, using the
+// field plan computed once in depsURLFields. The error label is the field's json tag, so there
+// is no hand-maintained name-to-field mapping to drift from the type.
+func (v *SparkApplicationValidator) validateDepsURLSchemes(deps *v1beta2.Dependencies) error {
+	rv := reflect.ValueOf(deps).Elem()
+	for _, f := range depsURLFields {
+		values := rv.Field(f.index).Interface().([]string)
+		if err := v.checkURLSchemes(f.label, values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkURLSchemes runs checkURLScheme over each value of a field that holds a list of URIs.
+func (v *SparkApplicationValidator) checkURLSchemes(field string, values []string) error {
+	for _, value := range values {
+		if err := v.checkURLScheme(field, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkURLScheme rejects value unless its URL scheme is always allowed (schemeless, file://,
+// local://) or in the operator's configured allow list. It fails closed: anything url.Parse
+// can't handle (e.g. embedded control chars, which java.net.URI also rejects) is treated as
+// suspect, not waved through. "//host/path" is the one tricky case - it parses with an empty
+// scheme but a non-empty host, so guard on Host to tell a real local path (no host) from a
+// network-path reference.
+func (v *SparkApplicationValidator) checkURLScheme(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	u, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("%s contains a value that is not a valid URL: %q: %w", field, value, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if slices.Contains(alwaysAllowedURLSchemes, scheme) {
+		// "//host/x" has an empty scheme but a host - it's a network path, not a local one,
+		// so don't let the empty-scheme exemption cover it.
+		if scheme == "" && u.Host != "" {
+			return fmt.Errorf("%s contains a scheme-relative URL with host %q which is not a local path: %q", field, u.Host, value)
+		}
+		return nil
+	}
+	if _, allowed := v.allowedURLSchemes[scheme]; !allowed {
+		return fmt.Errorf("%s contains a value with URL scheme %q which is not in the allowed list: %q", field, scheme, value)
+	}
 	return nil
 }
 

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -18,7 +18,9 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"reflect"
 	"slices"
@@ -250,56 +252,57 @@ func buildDepsURLFields() []depsURLField {
 // driver/executor at runtime, not URLs the operator fetches at submit time, and many are
 // legitimately host/endpoint-shaped (fs.s3a.endpoint, ...) that a scheme check would wrongly reject.
 func (v *SparkApplicationValidator) validateURLSchemes(app *v1beta2.SparkApplication) error {
+	// Collect every scheme violation rather than returning on the first: a user with several
+	// bad URLs should see them all in one admission response instead of fixing them one round-trip
+	// at a time. The order below is deterministic (mainApplicationFile, then deps.* in struct-field
+	// order, then sparkConf keys sorted) so the same spec always yields the same error text - map
+	// iteration order is randomized in Go, so the sparkConf keys must be sorted explicitly.
+	var errs []error
+
 	// spec.mainApplicationFile is a single URI forwarded as the final spark-submit argument.
 	if app.Spec.MainApplicationFile != nil {
-		if err := v.checkURLScheme("spec.mainApplicationFile", *app.Spec.MainApplicationFile); err != nil {
-			return err
-		}
+		errs = append(errs, v.checkURLScheme("spec.mainApplicationFile", *app.Spec.MainApplicationFile)...)
 	}
 
 	// spec.deps fetch-capable lists (--jars, --files, --py-files, --archives, --repositories).
-	if err := v.validateDepsURLSchemes(&app.Spec.Deps); err != nil {
-		return err
-	}
+	errs = append(errs, v.validateDepsURLSchemes(&app.Spec.Deps)...)
 
 	// spec.sparkConf values; some conf keys carry comma-separated URI lists, but some
 	// (spark.jars.packages, spark.jars.excludePackages, spark.jars.ivySettings) hold Maven
 	// coordinates or Ivy XML paths that parse as invalid URL schemes and are exempt.
-	for key, value := range app.Spec.SparkConf {
+	for _, key := range slices.Sorted(maps.Keys(app.Spec.SparkConf)) {
 		if _, exempt := sparkConfKeysExempt[key]; exempt {
 			continue
 		}
 		field := fmt.Sprintf("spec.sparkConf[%q]", key)
-		if err := v.checkURLSchemes(field, strings.Split(value, ",")); err != nil {
-			return err
-		}
+		errs = append(errs, v.checkURLSchemes(field, strings.Split(app.Spec.SparkConf[key], ","))...)
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // validateDepsURLSchemes URL-checks the fetch-capable []string fields of spec.deps, using the
 // field plan computed once in depsURLFields. The error label is the field's json tag, so there
-// is no hand-maintained name-to-field mapping to drift from the type.
-func (v *SparkApplicationValidator) validateDepsURLSchemes(deps *v1beta2.Dependencies) error {
+// is no hand-maintained name-to-field mapping to drift from the type. It returns every violation
+// found (see validateURLSchemes) rather than stopping at the first.
+func (v *SparkApplicationValidator) validateDepsURLSchemes(deps *v1beta2.Dependencies) []error {
+	var errs []error
 	rv := reflect.ValueOf(deps).Elem()
 	for _, f := range depsURLFields {
 		values := rv.Field(f.index).Interface().([]string)
-		if err := v.checkURLSchemes(f.label, values); err != nil {
-			return err
-		}
+		errs = append(errs, v.checkURLSchemes(f.label, values)...)
 	}
-	return nil
+	return errs
 }
 
-// checkURLSchemes runs checkURLScheme over each value of a field that holds a list of URIs.
-func (v *SparkApplicationValidator) checkURLSchemes(field string, values []string) error {
+// checkURLSchemes runs checkURLScheme over each value of a field that holds a list of URIs,
+// returning every violation rather than stopping at the first.
+func (v *SparkApplicationValidator) checkURLSchemes(field string, values []string) []error {
+	var errs []error
 	for _, value := range values {
-		if err := v.checkURLScheme(field, value); err != nil {
-			return err
-		}
+		errs = append(errs, v.checkURLScheme(field, value)...)
 	}
-	return nil
+	return errs
 }
 
 // checkURLScheme rejects value unless its URL scheme is always allowed (schemeless, file://,
@@ -308,26 +311,29 @@ func (v *SparkApplicationValidator) checkURLSchemes(field string, values []strin
 // suspect, not waved through. "//host/path" is the one tricky case - it parses with an empty
 // scheme but a non-empty host, so guard on Host to tell a real local path (no host) from a
 // network-path reference.
-func (v *SparkApplicationValidator) checkURLScheme(field, value string) error {
+//
+// It returns a slice of at most one error (empty when the value is allowed) so callers can
+// accumulate violations across many fields and surface them together; see validateURLSchemes.
+func (v *SparkApplicationValidator) checkURLScheme(field, value string) []error {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return nil
 	}
 	u, err := url.Parse(value)
 	if err != nil {
-		return fmt.Errorf("%s contains a value that is not a valid URL: %q: %w", field, value, err)
+		return []error{fmt.Errorf("%s contains a value that is not a valid URL: %q: %w", field, value, err)}
 	}
 	scheme := strings.ToLower(u.Scheme)
 	if slices.Contains(alwaysAllowedURLSchemes, scheme) {
 		// "//host/x" has an empty scheme but a host - it's a network path, not a local one,
 		// so don't let the empty-scheme exemption cover it.
 		if scheme == "" && u.Host != "" {
-			return fmt.Errorf("%s contains a scheme-relative URL with host %q which is not a local path: %q", field, u.Host, value)
+			return []error{fmt.Errorf("%s contains a scheme-relative URL with host %q which is not a local path: %q", field, u.Host, value)}
 		}
 		return nil
 	}
 	if _, allowed := v.allowedURLSchemes[scheme]; !allowed {
-		return fmt.Errorf("%s contains a value with URL scheme %q which is not in the allowed list: %q", field, scheme, value)
+		return []error{fmt.Errorf("%s contains a value with URL scheme %q which is not in the allowed list: %q", field, scheme, value)}
 	}
 	return nil
 }

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -219,14 +219,8 @@ var depsURLFieldsExempt = []string{"packages", "excludePackages"}
 // wrongly reject legitimate values and couple submit-time policy to runtime config.
 //
 // This is a positive allow-set rather than a scan-with-deny-list precisely so runtime keys are
-// untouched by default. Some keys are deliberately absent because they are not remote-fetch
-// vectors even though spark-submit reads them at submit time:
-//   - spark.jars.packages / spark.jars.excludePackages hold Maven coordinates
-//     (groupId:artifactId:version), not fetchable URLs.
-//   - spark.jars.ivySettings is loaded at submit time, but Spark restricts it to the "file"
-//     scheme (SparkSubmit.loadIvySettings throws on any other scheme before touching the
-//     network), so it can only ever reference a local file and cannot reach the operator's
-//     network. Scheme-checking it would be redundant with the always-allowed "file"/schemeless.
+// untouched by default. Maven-coordinate keys (spark.jars.packages, spark.jars.excludePackages)
+// are deliberately absent because they are not fetchable URLs.
 //
 // spark.jars / spark.files / spark.submit.pyFiles / spark.archives mirror spec.deps.{jars,files,
 // pyFiles,archives}. spark.jars.repositories mirrors spec.deps.repositories: in KUBERNETES cluster

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -45,19 +46,26 @@ type SparkApplicationValidator struct {
 	client client.Client
 
 	enableResourceQuotaEnforcement bool
+
+	// enableURLSchemeValidation gates the fetch-field URL-scheme check. It is strictly opt-in
+	// (default off): when false, validateURLSchemes is not run at all and admission behaviour is
+	// unchanged from before the check existed, so upgrading operators that already submit remote
+	// deps are never broken. Operators turn it on to harden against operator-privileged SSRF.
+	enableURLSchemeValidation bool
 	// allowedURLSchemes is the set of additional URL schemes permitted in fetch-capable spec
-	// fields (sparkConf values, deps.*, mainApplicationFile) beyond the always-allowed local
-	// schemes (schemeless, file://, local://). Any value whose URL scheme is not always-allowed
-	// and not in this set is rejected at admission time. Add schemes your workloads require
-	// (e.g. gs, s3a, hdfs).
+	// fields (submit-time sparkConf keys, deps.*, mainApplicationFile) beyond the always-allowed
+	// local schemes (schemeless, file://, local://). Any value whose URL scheme is not
+	// always-allowed and not in this set is rejected at admission time. Add schemes your workloads
+	// require (e.g. gs, s3a, hdfs). Only consulted when enableURLSchemeValidation is true.
 	allowedURLSchemes map[string]struct{}
 }
 
 // NewSparkApplicationValidator creates a new SparkApplicationValidator instance.
-// allowedURLSchemes lists URL schemes permitted in fetch-capable spec fields (sparkConf values,
-// deps.*, mainApplicationFile) in addition to the always-allowed local schemes (schemeless,
-// file://, local://). Any other scheme is rejected.
-func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnforcement bool, allowedURLSchemes []string) *SparkApplicationValidator {
+// enableURLSchemeValidation turns on the fetch-field URL-scheme check (default off / opt-in).
+// allowedURLSchemes lists URL schemes permitted in fetch-capable spec fields (submit-time
+// sparkConf keys, deps.*, mainApplicationFile) in addition to the always-allowed local schemes
+// (schemeless, file://, local://) when that check is enabled. Any other scheme is rejected.
+func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnforcement bool, enableURLSchemeValidation bool, allowedURLSchemes []string) *SparkApplicationValidator {
 	allowed := make(map[string]struct{}, len(allowedURLSchemes))
 	for _, s := range allowedURLSchemes {
 		s = strings.TrimSpace(strings.ToLower(s))
@@ -69,6 +77,7 @@ func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnfor
 		client: client,
 
 		enableResourceQuotaEnforcement: enableResourceQuotaEnforcement,
+		enableURLSchemeValidation:      enableURLSchemeValidation,
 		allowedURLSchemes:              allowed,
 	}
 }
@@ -178,8 +187,10 @@ func (v *SparkApplicationValidator) validateSpec(ctx context.Context, app *v1bet
 		return err
 	}
 
-	if err := v.validateURLSchemes(app); err != nil {
-		return err
+	if v.enableURLSchemeValidation {
+		if err := v.validateURLSchemes(app); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -200,15 +211,28 @@ var alwaysAllowedURLSchemes = []string{"", "file", "local"}
 // covered without code changes; a new non-URL field must be added here.
 var depsURLFieldsExempt = []string{"packages", "excludePackages"}
 
-// sparkConfKeysExempt are sparkConf keys whose comma-separated values are NOT dereferenced as
-// URLs: they hold Maven coordinates (groupId:artifactId:version) or Ivy XML paths resolved by
-// the Spark Ivy subsystem, not operator-fetched URLs. spark.jars.packages is the primary case:
-// a value like "org.postgresql:postgresql:42.7.3" parses as scheme "org.postgresql" but is not
-// a URL. spark.jars.excludePackages and spark.jars.ivySettings follow the same pattern.
-var sparkConfKeysExempt = map[string]struct{}{
-	"spark.jars.packages":        {},
-	"spark.jars.excludePackages": {},
-	"spark.jars.ivySettings":     {},
+// sparkConfURLKeys is the allow-set of sparkConf keys the operator forwards to spark-submit and
+// dereferences at submit time, so a remote URL in one of them is fetched by the operator's own
+// principal (an SSRF vector). Only these keys are URL-checked; every other sparkConf entry is a
+// runtime config consumed by the driver/executor (spark.eventLog.dir, spark.sql.warehouse.dir,
+// spark.kubernetes.driverEnv.*, ...) that the operator never fetches, so scheme-checking it would
+// wrongly reject legitimate values and couple submit-time policy to runtime config.
+//
+// This is a positive allow-set rather than a scan-with-deny-list precisely so runtime keys are
+// untouched by default. Maven-coordinate keys (spark.jars.packages, spark.jars.excludePackages)
+// and Ivy settings (spark.jars.ivySettings) are simply absent here and therefore never checked.
+//
+// spark.jars / spark.files / spark.submit.pyFiles / spark.archives mirror spec.deps.{jars,files,
+// pyFiles,archives}; spark.kubernetes.file.upload.path is the staging location the operator uploads
+// local deps to; the podTemplateFile keys point at pod templates the operator writes and reads.
+var sparkConfURLKeys = map[string]struct{}{
+	"spark.jars":                                  {},
+	"spark.files":                                 {},
+	"spark.submit.pyFiles":                        {},
+	"spark.archives":                              {},
+	"spark.kubernetes.file.upload.path":           {},
+	common.SparkKubernetesDriverPodTemplateFile:   {},
+	common.SparkKubernetesExecutorPodTemplateFile: {},
 }
 
 // depsURLField is one []string field of v1beta2.Dependencies to URL-check: its struct field
@@ -246,7 +270,9 @@ func buildDepsURLFields() []depsURLField {
 // fetched by the operator's principal (its ServiceAccount, mounted secrets, IRSA/Workload
 // Identity, VPC reachability) - an SSRF vector.
 //
-// Comma-separated sparkConf values (spark.jars, spark.files, ...) are split.
+// Only the submit-time sparkConf keys the operator forwards to spark-submit (sparkConfURLKeys)
+// are checked; their comma-separated values (spark.jars, spark.files, ...) are split. Runtime
+// sparkConf keys are left untouched - see sparkConfURLKeys for why.
 //
 // spec.hadoopConf is out of scope: its values become spark.hadoop.* config consumed by the
 // driver/executor at runtime, not URLs the operator fetches at submit time, and many are
@@ -267,15 +293,17 @@ func (v *SparkApplicationValidator) validateURLSchemes(app *v1beta2.SparkApplica
 	// spec.deps fetch-capable lists (--jars, --files, --py-files, --archives, --repositories).
 	errs = append(errs, v.validateDepsURLSchemes(&app.Spec.Deps)...)
 
-	// spec.sparkConf values; some conf keys carry comma-separated URI lists, but some
-	// (spark.jars.packages, spark.jars.excludePackages, spark.jars.ivySettings) hold Maven
-	// coordinates or Ivy XML paths that parse as invalid URL schemes and are exempt.
-	for _, key := range slices.Sorted(maps.Keys(app.Spec.SparkConf)) {
-		if _, exempt := sparkConfKeysExempt[key]; exempt {
+	// spec.sparkConf: only the submit-time keys the operator itself dereferences (sparkConfURLKeys)
+	// are checked; runtime keys are left alone. Iterate the allow-set in sorted order so the error
+	// text is deterministic regardless of Go's randomized map iteration. Values may be comma-
+	// separated URI lists (spark.jars, spark.files, ...) and are split.
+	for _, key := range slices.Sorted(maps.Keys(sparkConfURLKeys)) {
+		value, ok := app.Spec.SparkConf[key]
+		if !ok {
 			continue
 		}
 		field := fmt.Sprintf("spec.sparkConf[%q]", key)
-		errs = append(errs, v.checkURLSchemes(field, strings.Split(app.Spec.SparkConf[key], ","))...)
+		errs = append(errs, v.checkURLSchemes(field, strings.Split(value, ","))...)
 	}
 
 	return errors.Join(errs...)

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -219,17 +219,38 @@ var depsURLFieldsExempt = []string{"packages", "excludePackages"}
 // wrongly reject legitimate values and couple submit-time policy to runtime config.
 //
 // This is a positive allow-set rather than a scan-with-deny-list precisely so runtime keys are
-// untouched by default. Maven-coordinate keys (spark.jars.packages, spark.jars.excludePackages)
-// and Ivy settings (spark.jars.ivySettings) are simply absent here and therefore never checked.
+// untouched by default. Some keys are deliberately absent because they are not remote-fetch
+// vectors even though spark-submit reads them at submit time:
+//   - spark.jars.packages / spark.jars.excludePackages hold Maven coordinates
+//     (groupId:artifactId:version), not fetchable URLs.
+//   - spark.jars.ivySettings is loaded at submit time, but Spark restricts it to the "file"
+//     scheme (SparkSubmit.loadIvySettings throws on any other scheme before touching the
+//     network), so it can only ever reference a local file and cannot reach the operator's
+//     network. Scheme-checking it would be redundant with the always-allowed "file"/schemeless.
 //
 // spark.jars / spark.files / spark.submit.pyFiles / spark.archives mirror spec.deps.{jars,files,
-// pyFiles,archives}; spark.kubernetes.file.upload.path is the staging location the operator uploads
-// local deps to; the podTemplateFile keys point at pod templates the operator writes and reads.
+// pyFiles,archives}. spark.jars.repositories mirrors spec.deps.repositories: in KUBERNETES cluster
+// mode (the operator's mode) spark-submit calls DependencyUtils.resolveMavenDependencies at submit
+// time (SparkSubmit.scala, the !isStandAloneCluster branch), which queries these repositories from
+// the operator pod to resolve --packages, so a remote repo URL is fetched with the operator's
+// principal. spark.kubernetes.file.upload.path is the destination the operator's spark-submit
+// uploads local deps to: BasicDriverFeatureStep/DriverCommandFeatureStep call
+// KubernetesUtils.uploadFileUri inside KubernetesDriverBuilder, which runs submit-side in
+// KubernetesClientApplication, again with the operator's credentials.
+//
+// The podTemplateFile keys are included defensively. Only the DRIVER template is loaded submit-side
+// (KubernetesDriverBuilder.buildFromFeatures -> loadPodFromTemplate -> downloadFile, in the operator
+// pod); the EXECUTOR template is loaded later in the driver pod by KubernetesClusterManager, so it
+// is not itself an operator-credential vector. In practice the operator overwrites both keys with a
+// local /tmp path it writes itself (submission.go driver/executorPodTemplateOption, appended after
+// the user's sparkConf so it wins), so a user value never reaches spark-submit; the keys stay here
+// so the check still bites if that override is ever removed or bypassed.
 var sparkConfURLKeys = map[string]struct{}{
 	"spark.jars":                                  {},
 	"spark.files":                                 {},
 	"spark.submit.pyFiles":                        {},
 	"spark.archives":                              {},
+	"spark.jars.repositories":                     {},
 	"spark.kubernetes.file.upload.path":           {},
 	common.SparkKubernetesDriverPodTemplateFile:   {},
 	common.SparkKubernetesExecutorPodTemplateFile: {},

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -18,7 +18,13 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
+	"net"
+	"net/url"
+	"reflect"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -41,15 +48,165 @@ type SparkApplicationValidator struct {
 	client client.Client
 
 	enableResourceQuotaEnforcement bool
+
+	// enableURLSchemeValidation gates the fetch-field URL-scheme check. It is strictly opt-in
+	// (default off): when false, validateURLSchemes is not run at all and admission behaviour is
+	// unchanged from before the check existed, so upgrading operators that already submit remote
+	// deps are never broken. Operators turn it on to harden against operator-privileged SSRF.
+	enableURLSchemeValidation bool
+	urlValidationPolicy
+}
+
+// urlValidationPolicy defines allowed schemes and host rules for remote URLs.
+type urlValidationPolicy struct {
+	allowedURLSchemes       map[string]struct{}
+	allowAllURLHostsSchemes map[string]struct{}
+	allowedURLHosts         map[string]map[string]struct{}
+	allowedWildcardURLHosts map[string][]string
+}
+
+// URLValidationErrorKind identifies why a URL failed validation.
+type URLValidationErrorKind string
+
+const (
+	// URLValidationInvalidURL indicates that a value could not be parsed as a URL.
+	URLValidationInvalidURL URLValidationErrorKind = "invalid URL"
+	// URLValidationHostNotAllowed indicates that a URL host is not permitted.
+	URLValidationHostNotAllowed URLValidationErrorKind = "host not allowed"
+	// URLValidationSchemeNotAllowed indicates that a URL scheme is not permitted.
+	URLValidationSchemeNotAllowed URLValidationErrorKind = "scheme not allowed"
+)
+
+// URLValidationError describes a URL validation failure in a SparkApplication field.
+type URLValidationError struct {
+	Field  string
+	Value  string
+	Scheme string
+	Host   string
+	Kind   URLValidationErrorKind
+	Err    error
+}
+
+func (e *URLValidationError) Error() string {
+	switch e.Kind {
+	case URLValidationInvalidURL:
+		return fmt.Sprintf("%s contains a value that is not a valid URL: %q: %v", e.Field, e.Value, e.Err)
+	case URLValidationHostNotAllowed:
+		return fmt.Sprintf("%s contains a URL with host %q which is not in the allowed list: %q", e.Field, e.Host, e.Value)
+	default:
+		return fmt.Sprintf("%s contains a value with URL scheme %q which is not in the allowed list: %q", e.Field, e.Scheme, e.Value)
+	}
+}
+
+func (e *URLValidationError) Unwrap() error {
+	return e.Err
 }
 
 // NewSparkApplicationValidator creates a new SparkApplicationValidator instance.
-func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnforcement bool) *SparkApplicationValidator {
+// enableURLSchemeValidation turns on the fetch-field URL-scheme check (default off / opt-in).
+// allowedURLSchemes, allowAllURLHostsSchemes, and scheme-qualified allowedURLHosts describe remote
+// URL policy for fetch-capable spec fields. A remote URL must use an allowed scheme. Its host must
+// match a scheme-qualified exact or wildcard rule unless its scheme is explicitly configured to allow
+// all hosts. Local paths, file://, and local:// remain allowed without host configuration.
+func NewSparkApplicationValidator(client client.Client, enableResourceQuotaEnforcement bool, enableURLSchemeValidation bool, allowedURLSchemes, allowAllURLHostsSchemes, allowedURLHosts, allowedWildcardURLHosts []string) *SparkApplicationValidator {
 	return &SparkApplicationValidator{
 		client: client,
 
 		enableResourceQuotaEnforcement: enableResourceQuotaEnforcement,
+		enableURLSchemeValidation:      enableURLSchemeValidation,
+		urlValidationPolicy:            newURLValidationPolicy(allowedURLSchemes, allowAllURLHostsSchemes, allowedURLHosts, allowedWildcardURLHosts),
 	}
+}
+
+func newURLValidationPolicy(allowedURLSchemes, allowAllURLHostsSchemes, allowedURLHosts, allowedWildcardURLHosts []string) urlValidationPolicy {
+	return urlValidationPolicy{
+		allowedURLSchemes:       normalizedURLSchemes(allowedURLSchemes),
+		allowAllURLHostsSchemes: normalizedURLSchemes(allowAllURLHostsSchemes),
+		allowedURLHosts:         normalizedURLHosts(allowedURLHosts),
+		allowedWildcardURLHosts: normalizedWildcardURLHosts(allowedWildcardURLHosts),
+	}
+}
+
+func normalizedURLSchemes(schemes []string) map[string]struct{} {
+	allowed := make(map[string]struct{}, len(schemes))
+	for _, scheme := range schemes {
+		scheme = strings.TrimSpace(strings.ToLower(scheme))
+		if scheme != "" {
+			allowed[scheme] = struct{}{}
+		}
+	}
+	return allowed
+}
+
+func normalizedURLHosts(hosts []string) map[string]map[string]struct{} {
+	allowed := make(map[string]map[string]struct{})
+	for _, host := range hosts {
+		scheme, hostname, _ := parseAllowedURLHost(host, false)
+		if allowed[scheme] == nil {
+			allowed[scheme] = make(map[string]struct{})
+		}
+		allowed[scheme][hostname] = struct{}{}
+	}
+	return allowed
+}
+
+func normalizedWildcardURLHosts(hosts []string) map[string][]string {
+	allowed := make(map[string][]string)
+	for _, host := range hosts {
+		scheme, hostname, _ := parseAllowedURLHost(host, true)
+		allowed[scheme] = append(allowed[scheme], strings.TrimPrefix(hostname, "*."))
+	}
+	return allowed
+}
+
+func parseAllowedURLHost(value string, wildcard bool) (string, string, error) {
+	value = strings.TrimSpace(value)
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil || u.Port() != "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", "", fmt.Errorf("invalid allowed URL host %q: use a scheme-qualified authority such as https://example.com", value)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	if wildcard {
+		if !strings.HasPrefix(host, "*.") || len(host) == len("*.") || strings.Contains(host[2:], "*") {
+			return "", "", fmt.Errorf("invalid allowed wildcard URL host %q: use a scheme-qualified leftmost wildcard such as https://*.example.com", value)
+		}
+	} else if strings.Contains(host, "*") {
+		return "", "", fmt.Errorf("invalid allowed URL host %q: use --allowed-wildcard-url-hosts for wildcard hosts", value)
+	}
+	return scheme, host, nil
+}
+
+// ValidateAllowedURLHosts rejects unqualified, malformed, or misplaced wildcard host entries
+// before webhook startup.
+func ValidateAllowedURLHosts(hosts, wildcardHosts []string) error {
+	for _, host := range hosts {
+		if _, _, err := parseAllowedURLHost(host, false); err != nil {
+			return err
+		}
+	}
+	for _, host := range wildcardHosts {
+		if _, _, err := parseAllowedURLHost(host, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateAllowAllURLHostsSchemes requires every host-policy bypass scheme to also be present in
+// the remote URL scheme allowlist.
+func ValidateAllowAllURLHostsSchemes(allowedSchemes, allowAllHostsSchemes []string) error {
+	allowed := normalizedURLSchemes(allowedSchemes)
+	for _, scheme := range allowAllHostsSchemes {
+		scheme = strings.TrimSpace(strings.ToLower(scheme))
+		if scheme == "" {
+			return fmt.Errorf("allowed URL scheme with all hosts cannot be empty")
+		}
+		if _, ok := allowed[scheme]; !ok {
+			return fmt.Errorf("allowed URL scheme with all hosts %q must also be listed in --allowed-url-schemes", scheme)
+		}
+	}
+	return nil
 }
 
 var _ admission.Validator[*v1beta2.SparkApplication] = &SparkApplicationValidator{}
@@ -160,8 +317,255 @@ func (v *SparkApplicationValidator) validateSpec(ctx context.Context, app *v1bet
 	if err := validateConfigMaps(&app.Spec, field.NewPath("spec")); err != nil {
 		return err
 	}
+	if v.enableURLSchemeValidation {
+		if err := v.validateURLSchemes(&app.Spec, "spec."); err != nil {
+			return err
+		}
+	}
 
 	return nil
+}
+
+// alwaysAllowedURLSchemes are URL schemes that never reach the operator's network when they
+// have no authority: they reference files already present on the submitter/driver/executor
+// filesystem or baked into the container image, so they are not SSRF vectors and are always
+// permitted.
+//   - "" (schemeless): a relative or absolute local path.
+//   - "file": a file:// URI on the local filesystem.
+//   - "local": a local:// URI resolved inside the driver/executor container image.
+var alwaysAllowedURLSchemes = []string{"", "file", "local"}
+
+// depsURLFieldsExempt are v1beta2.Dependencies json tags whose values are NOT dereferenced as
+// URLs and so are deliberately skipped by the URL-scheme check: they are Maven coordinates
+// (groupId:artifactId:version), not fetchable URLs. Every other []string field of Dependencies
+// is URL-checked automatically (see depsURLFields), so a newly-added fetch-capable field is
+// covered without code changes; a new non-URL field must be added here.
+var depsURLFieldsExempt = []string{"packages", "excludePackages"}
+
+// sparkConfURLKeys is the allow-set of sparkConf keys the operator forwards to spark-submit and
+// dereferences at submit time, so a remote URL in one of them is fetched by the operator's own
+// principal (an SSRF vector). Only these keys are URL-checked; every other sparkConf entry is a
+// runtime config consumed by the driver/executor (spark.eventLog.dir, spark.sql.warehouse.dir,
+// spark.kubernetes.driverEnv.*, ...) that the operator never fetches, so scheme-checking it would
+// wrongly reject legitimate values and couple submit-time policy to runtime config.
+//
+// This is a positive allow-set rather than a scan-with-deny-list precisely so runtime keys are
+// untouched by default. Maven-coordinate keys (spark.jars.packages, spark.jars.excludePackages)
+// are deliberately absent because they are not fetchable URLs.
+//
+// spark.jars / spark.files / spark.submit.pyFiles / spark.archives mirror
+// spec.deps.{jars,files,pyFiles,archives}. spark.jars.repositories mirrors
+// spec.deps.repositories: spark-submit resolves package dependencies from the operator pod at
+// submit time, so repository URLs are fetched with the operator's principal.
+//
+// spark.kubernetes.file.upload.path is deliberately excluded. It selects an upload destination for
+// local artifacts; it is not a source URL that spark-submit retrieves. Destination policy belongs to
+// workload egress and artifact-storage controls, not this fetch-source scheme allow-list.
+//
+// Pod-template keys are included defensively. A driver template can be fetched during submission;
+// executor templates are normally fetched later by the driver. The operator currently overwrites
+// both user values with local /tmp paths before spark-submit, so user URLs do not reach either
+// fetch path. Keep validating them in case that override is removed or bypassed.
+const (
+	sparkJarsConfigKey                     = "spark.jars"
+	sparkFilesConfigKey                    = "spark.files"
+	sparkSubmitPyFilesConfigKey            = "spark.submit.pyFiles"
+	sparkArchivesConfigKey                 = "spark.archives"
+	sparkJarsRepositoriesConfigKey         = "spark.jars.repositories"
+	sparkKubernetesFileUploadPathConfigKey = "spark.kubernetes.file.upload.path"
+)
+
+var sparkConfURLKeys = map[string]struct{}{
+	sparkJarsConfigKey:                            {},
+	sparkFilesConfigKey:                           {},
+	sparkSubmitPyFilesConfigKey:                   {},
+	sparkArchivesConfigKey:                        {},
+	sparkJarsRepositoriesConfigKey:                {},
+	common.SparkKubernetesDriverPodTemplateFile:   {},
+	common.SparkKubernetesExecutorPodTemplateFile: {},
+}
+
+// depsURLField is one []string field of v1beta2.Dependencies to URL-check: its struct field
+// index and the error label derived from its json tag.
+type depsURLField struct {
+	index int
+	label string
+}
+
+// depsURLFields is the URL-check plan for v1beta2.Dependencies, computed once from the struct's
+// json tags rather than re-reflected on every admission. See depsURLFieldsExempt for exclusions.
+var depsURLFields = buildDepsURLFields()
+
+func buildDepsURLFields() []depsURLField {
+	var fields []depsURLField
+	rt := reflect.TypeFor[v1beta2.Dependencies]()
+	stringSlice := reflect.TypeFor[[]string]()
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		if f.Type != stringSlice {
+			continue
+		}
+		tag := strings.Split(f.Tag.Get("json"), ",")[0]
+		if tag == "" || tag == "-" || slices.Contains(depsURLFieldsExempt, tag) {
+			continue
+		}
+		fields = append(fields, depsURLField{index: i, label: "spec.deps." + tag})
+	}
+	return fields
+}
+
+// validateURLSchemes rejects any user-supplied value that is forwarded to the operator's
+// spark-submit and dereferenced as a remote URL whose scheme is not in the allowed set.
+// spark-submit runs in the operator pod, so an http/https/etc. URL in any of these fields is
+// fetched by the operator's principal (its ServiceAccount, mounted secrets, IRSA/Workload
+// Identity, VPC reachability) - an SSRF vector.
+//
+// Only the submit-time sparkConf keys the operator forwards to spark-submit (sparkConfURLKeys)
+// are checked; their comma-separated values (spark.jars, spark.files, ...) are split. Runtime
+// sparkConf keys are left untouched - see sparkConfURLKeys for why.
+//
+// spec.hadoopConf is out of scope: its values become spark.hadoop.* config consumed by the
+// driver/executor at runtime, not URLs the operator fetches at submit time, and many are
+// legitimately host/endpoint-shaped (fs.s3a.endpoint, ...) that a scheme check would wrongly reject.
+func (v *SparkApplicationValidator) validateURLSchemes(spec *v1beta2.SparkApplicationSpec, fieldPrefix string) error {
+	// Collect every scheme violation rather than returning on the first: a user with several
+	// bad URLs should see them all in one admission response instead of fixing them one round-trip
+	// at a time. The order below is deterministic (mainApplicationFile, then deps.* in struct-field
+	// order, then sparkConf keys sorted) so the same spec always yields the same error text - map
+	// iteration order is randomized in Go, so the sparkConf keys must be sorted explicitly.
+	var errs []error
+
+	// spec.mainApplicationFile is a single URI forwarded as the final spark-submit argument.
+	if spec.MainApplicationFile != nil {
+		if err := v.checkURLScheme(fieldPrefix+"mainApplicationFile", *spec.MainApplicationFile); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// spec.deps fetch-capable lists (--jars, --files, --py-files, --archives, --repositories).
+	errs = append(errs, v.validateDepsURLSchemes(&spec.Deps, fieldPrefix+"deps.")...)
+
+	// spec.sparkConf: only the submit-time keys the operator itself dereferences (sparkConfURLKeys)
+	// are checked; runtime keys are left alone. Iterate the allow-set in sorted order so the error
+	// text is deterministic regardless of Go's randomized map iteration. Values may be comma-
+	// separated URI lists (spark.jars, spark.files, ...) and are split.
+	for _, key := range slices.Sorted(maps.Keys(sparkConfURLKeys)) {
+		value, ok := spec.SparkConf[key]
+		if !ok {
+			continue
+		}
+		field := fmt.Sprintf("%ssparkConf[%q]", fieldPrefix, key)
+		errs = append(errs, v.checkURLSchemes(field, strings.Split(value, ","))...)
+	}
+
+	return errors.Join(errs...)
+}
+
+// validateDepsURLSchemes URL-checks the fetch-capable []string fields of spec.deps, using the
+// field plan computed once in depsURLFields. Each value is split on commas because
+// dependenciesOption joins these slices into Spark's comma-delimited CLI arguments. The error
+// label is the field's json tag, so there is no hand-maintained name-to-field mapping to drift
+// from the type. It returns every violation found (see validateURLSchemes) rather than stopping
+// at the first.
+func (v *SparkApplicationValidator) validateDepsURLSchemes(deps *v1beta2.Dependencies, fieldPrefix string) []error {
+	var errs []error
+	rv := reflect.ValueOf(deps).Elem()
+	for _, f := range depsURLFields {
+		values := rv.Field(f.index).Interface().([]string)
+		field := fieldPrefix + strings.TrimPrefix(f.label, "spec.deps.")
+
+		for _, value := range values {
+			errs = append(errs, v.checkURLSchemes(field, strings.Split(value, ","))...)
+		}
+	}
+	return errs
+}
+
+// checkURLSchemes runs checkURLScheme over each value of a field that holds a list of URIs,
+// returning every violation rather than stopping at the first.
+func (v *SparkApplicationValidator) checkURLSchemes(field string, values []string) []error {
+	var errs []error
+	for _, value := range values {
+		if err := v.checkURLScheme(field, value); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// checkURLScheme rejects value unless its URL scheme is always allowed (schemeless, file://,
+// local://) or in the operator's configured allow list. It fails closed: anything url.Parse
+// can't handle (e.g. embedded control chars, which java.net.URI also rejects) is treated as
+// suspect, not waved through. "//host/path" is the one tricky case - it parses with an empty
+// scheme but a non-empty host, so guard on Host to tell a real local path (no host) from a
+// network-path reference.
+func (v *SparkApplicationValidator) checkURLScheme(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	u, err := url.Parse(value)
+	if err != nil {
+		return &URLValidationError{
+			Field: field,
+			Value: value,
+			Kind:  URLValidationInvalidURL,
+			Err:   err,
+		}
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if slices.Contains(alwaysAllowedURLSchemes, scheme) {
+		// Any authority makes an otherwise local form ambiguous or remote. In particular,
+		// "//host/x", "file://host/x", and "local://host/x" must not use this exemption.
+		if u.Host != "" {
+			return &URLValidationError{
+				Field: field,
+				Value: value,
+				Host:  u.Host,
+				Kind:  URLValidationHostNotAllowed,
+			}
+		}
+		return nil
+	}
+	if _, allowed := v.allowedURLSchemes[scheme]; !allowed {
+		return &URLValidationError{
+			Field:  field,
+			Value:  value,
+			Scheme: scheme,
+			Kind:   URLValidationSchemeNotAllowed,
+		}
+	}
+	if !v.isAllowedURLHost(scheme, u.Hostname()) {
+		return &URLValidationError{
+			Field: field,
+			Value: value,
+			Host:  u.Hostname(),
+			Kind:  URLValidationHostNotAllowed,
+		}
+	}
+	return nil
+}
+
+func (v *SparkApplicationValidator) isAllowedURLHost(scheme, host string) bool {
+	host = strings.ToLower(host)
+	if host == "" {
+		return false
+	}
+	if _, allowed := v.allowAllURLHostsSchemes[scheme]; allowed {
+		return true
+	}
+	if _, allowed := v.allowedURLHosts[scheme][host]; allowed {
+		return true
+	}
+	if net.ParseIP(host) != nil {
+		return false
+	}
+	for _, wildcardHost := range v.allowedWildcardURLHosts[scheme] {
+		if strings.HasSuffix(host, "."+wildcardHost) && host != wildcardHost {
+			return true
+		}
+	}
+	return false
 }
 
 // validateName ensures the SparkApplication metadata.name is a valid DNS-1035 label

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -225,10 +225,12 @@ func TestSparkApplicationValidatorValidateDelete_Success(t *testing.T) {
 
 func newTestValidator(t *testing.T, enforceQuota bool, objs ...client.Object) *SparkApplicationValidator {
 	t.Helper()
-	return newTestValidatorWithSchemes(t, enforceQuota, nil, objs...)
+	// URL-scheme validation is opt-in and off here; the dedicated URL-scheme tests enable it
+	// explicitly via newTestValidatorWithSchemes.
+	return newTestValidatorWithSchemes(t, enforceQuota, false, nil, objs...)
 }
 
-func newTestValidatorWithSchemes(t *testing.T, enforceQuota bool, allowedSchemes []string, objs ...client.Object) *SparkApplicationValidator {
+func newTestValidatorWithSchemes(t *testing.T, enforceQuota bool, enableURLSchemeValidation bool, allowedSchemes []string, objs ...client.Object) *SparkApplicationValidator {
 	t.Helper()
 
 	scheme := newTestScheme(t)
@@ -238,7 +240,7 @@ func newTestValidatorWithSchemes(t *testing.T, enforceQuota bool, allowedSchemes
 		builder = builder.WithObjects(objs...)
 	}
 
-	return NewSparkApplicationValidator(builder.Build(), enforceQuota, allowedSchemes)
+	return NewSparkApplicationValidator(builder.Build(), enforceQuota, enableURLSchemeValidation, allowedSchemes)
 }
 
 func newTestScheme(t *testing.T) *runtime.Scheme {
@@ -351,7 +353,16 @@ func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
 		{
 			name:           "schemeless path always allowed with empty list",
 			allowedSchemes: nil,
-			sparkConf:      map[string]string{"spark.driver.extraJavaOptions": "-Dfoo=bar"},
+			sparkConf:      map[string]string{"spark.jars": "/opt/spark/jars/app.jar"},
+			wantError:      false,
+		},
+		{
+			// Runtime-only sparkConf keys are not forwarded to spark-submit by the operator, so
+			// they are never scheme-checked even with a scheme that would otherwise be rejected.
+			// This is the key-based allow-set at work (sparkConfURLKeys): submit-time keys only.
+			name:           "runtime-only key not checked",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.eventLog.dir": "s3a://logs/bucket"},
 			wantError:      false,
 		},
 		{
@@ -433,7 +444,7 @@ func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validator := newTestValidatorWithSchemes(t, false, tt.allowedSchemes)
+			validator := newTestValidatorWithSchemes(t, false, true, tt.allowedSchemes)
 			app := newSparkApplication()
 			app.Spec.SparkConf = tt.sparkConf
 
@@ -460,7 +471,7 @@ func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
 // that the message is deterministic: sparkConf keys are sorted rather than emitted in Go's
 // randomized map order, so the same spec always produces byte-identical error text.
 func TestSparkApplicationValidatorURLSchemesAggregateAllErrors(t *testing.T) {
-	validator := newTestValidatorWithSchemes(t, false, nil)
+	validator := newTestValidatorWithSchemes(t, false, true, nil)
 
 	app := newSparkApplication()
 	app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
@@ -503,10 +514,34 @@ func TestSparkApplicationValidatorURLSchemesAggregateAllErrors(t *testing.T) {
 	}
 }
 
+// TestSparkApplicationValidatorURLSchemesOptIn proves the check is strictly opt-in: a spec that
+// is rejected when validation is enabled is accepted unchanged when it is disabled (the default),
+// so operators already submitting remote deps are not broken on upgrade.
+func TestSparkApplicationValidatorURLSchemesOptIn(t *testing.T) {
+	app := newSparkApplication()
+	app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
+	app.Spec.Deps.Repositories = []string{"http://repo.example.com/maven"}
+	app.Spec.SparkConf = map[string]string{"spark.jars": "https://a.example.com/a.jar"}
+
+	// Disabled (default): the http/https values must be accepted.
+	disabled := newTestValidatorWithSchemes(t, false, false, nil)
+	if _, err := disabled.ValidateCreate(context.Background(), app); err != nil {
+		t.Fatalf("expected no error when URL-scheme validation is disabled, got: %v", err)
+	}
+
+	// Enabled: the very same spec must now be rejected, proving the gate is what flips behaviour.
+	enabled := newTestValidatorWithSchemes(t, false, true, nil)
+	if _, err := enabled.ValidateCreate(context.Background(), app); err == nil {
+		t.Fatalf("expected error when URL-scheme validation is enabled, got none")
+	}
+}
+
 // TestSparkApplicationValidatorURLSchemesOtherFields proves the check is applied to the
-// fetch-capable fields beyond sparkConf (mainApplicationFile and the reflected deps.* lists)
-// and that the Maven-coordinate fields are carved out. Scheme rules themselves are covered by
-// the sparkConf table above; these cases only pin field wiring.
+// fetch-capable fields beyond sparkConf (mainApplicationFile and the reflected deps.* lists),
+// that the Maven-coordinate deps fields are carved out, and that sparkConf keys the operator does
+// not dereference at submit time (Maven/Ivy keys) are simply not in the allow-set and therefore
+// not checked. Scheme rules themselves are covered by the sparkConf table above; these cases only
+// pin field wiring.
 func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -540,7 +575,7 @@ func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 		{
 			// spark.jars.packages holds Maven coordinates, not URLs; net/url parses
 			// "org.postgresql:postgresql:42.7.3" as scheme "org.postgresql" but the key
-			// is exempted so the value is not URL-checked.
+			// is not in the submit-time allow-set (sparkConfURLKeys) so it is never checked.
 			name: "sparkConf spark.jars.packages maven coordinates not rejected",
 			mutate: func(app *v1beta2.SparkApplication) {
 				if app.Spec.SparkConf == nil {
@@ -551,7 +586,7 @@ func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 			wantError: false,
 		},
 		{
-			// spark.jars.excludePackages is also Maven coordinates.
+			// spark.jars.excludePackages is also Maven coordinates and not in the allow-set.
 			name: "sparkConf spark.jars.excludePackages maven coordinates not rejected",
 			mutate: func(app *v1beta2.SparkApplication) {
 				if app.Spec.SparkConf == nil {
@@ -562,9 +597,10 @@ func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 			wantError: false,
 		},
 		{
-			// spark.jars.ivySettings is a local or remote path to an Ivy XML, typically a
-			// Maven coordinate fragment or a file:// path, but can parse as an arbitrary scheme.
-			name: "sparkConf spark.jars.ivySettings local path not rejected",
+			// spark.jars.ivySettings is consumed by Spark's Ivy subsystem in the driver, not
+			// dereferenced by the operator at submit time, so it is not in sparkConfURLKeys and is
+			// never checked - not even a remote scheme is rejected here.
+			name: "sparkConf spark.jars.ivySettings not checked",
 			mutate: func(app *v1beta2.SparkApplication) {
 				if app.Spec.SparkConf == nil {
 					app.Spec.SparkConf = make(map[string]string)
@@ -589,7 +625,7 @@ func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validator := newTestValidatorWithSchemes(t, false, nil)
+			validator := newTestValidatorWithSchemes(t, false, true, nil)
 			app := newSparkApplication()
 			tt.mutate(app)
 

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -224,6 +225,11 @@ func TestSparkApplicationValidatorValidateDelete_Success(t *testing.T) {
 
 func newTestValidator(t *testing.T, enforceQuota bool, objs ...client.Object) *SparkApplicationValidator {
 	t.Helper()
+	return newTestValidatorWithSchemes(t, enforceQuota, nil, objs...)
+}
+
+func newTestValidatorWithSchemes(t *testing.T, enforceQuota bool, allowedSchemes []string, objs ...client.Object) *SparkApplicationValidator {
+	t.Helper()
 
 	scheme := newTestScheme(t)
 
@@ -232,7 +238,7 @@ func newTestValidator(t *testing.T, enforceQuota bool, objs ...client.Object) *S
 		builder = builder.WithObjects(objs...)
 	}
 
-	return NewSparkApplicationValidator(builder.Build(), enforceQuota)
+	return NewSparkApplicationValidator(builder.Build(), enforceQuota, allowedSchemes)
 }
 
 func newTestScheme(t *testing.T) *runtime.Scheme {
@@ -294,6 +300,260 @@ func TestSparkApplicationValidatorValidateName(t *testing.T) {
 
 			if hasError && err.Error() == "" {
 				t.Errorf("validateName(%q) should return a non-empty error message, got: %v", tt.appName, err)
+			}
+		})
+	}
+}
+
+// TestDepsURLFieldsExempt guards the depsURLFieldsExempt carve-out. validateDepsURLSchemes
+// URL-checks every []string field of v1beta2.Dependencies by reflection except the exempt tags,
+// so a newly-added fetch field is covered automatically. This test only has to ensure the
+// exempt set does not drift: every exempt tag must name a real []string field on the struct
+// (a stale entry would silently skip a future field that reused the name).
+func TestDepsURLFieldsExempt(t *testing.T) {
+	depsType := reflect.TypeFor[v1beta2.Dependencies]()
+	stringListTags := make(map[string]struct{}, depsType.NumField())
+	for i := range depsType.NumField() {
+		f := depsType.Field(i)
+		if f.Type != reflect.TypeFor[[]string]() {
+			continue
+		}
+		tag := strings.Split(f.Tag.Get("json"), ",")[0]
+		if tag == "" || tag == "-" {
+			continue
+		}
+		stringListTags[tag] = struct{}{}
+	}
+
+	for _, tag := range depsURLFieldsExempt {
+		if _, ok := stringListTags[tag]; !ok {
+			t.Errorf("depsURLFieldsExempt tag %q does not name a []string field on v1beta2.Dependencies; "+
+				"remove it or fix the tag", tag)
+		}
+	}
+}
+
+func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedSchemes []string
+		sparkConf      map[string]string
+		wantError      bool
+		errContains    string
+	}{
+		// file:// and schemeless are always allowed regardless of the list.
+		{
+			name:           "file:// always allowed with empty list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "file:///opt/spark/jars/app.jar"},
+			wantError:      false,
+		},
+		{
+			name:           "schemeless path always allowed with empty list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.driver.extraJavaOptions": "-Dfoo=bar"},
+			wantError:      false,
+		},
+		{
+			name:           "local:// always allowed with empty list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "local:///opt/spark/jars/app.jar"},
+			wantError:      false,
+		},
+		// Any scheme not in the always-allowed set or the extra list is rejected; the
+		// error names the offending key. http represents all such schemes (https, ftp, gs, ...).
+		{
+			name:           "disallowed scheme rejected with empty extra list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "http://example.com/app.jar"},
+			wantError:      true,
+			errContains:    `spec.sparkConf["spark.jars"]`,
+		},
+		// A scheme is allowed once added to the extra list.
+		{
+			name:           "scheme allowed when added to extra list",
+			allowedSchemes: []string{"gs", "s3a"},
+			sparkConf:      map[string]string{"spark.jars": "gs://my-bucket/app.jar"},
+			wantError:      false,
+		},
+		// Comma-separated values are each checked.
+		{
+			name:           "comma-separated: one disallowed entry rejects",
+			allowedSchemes: []string{"gs"},
+			sparkConf:      map[string]string{"spark.jars": "gs://ok.jar,https://evil.com/bad.jar"},
+			wantError:      true,
+			errContains:    "https",
+		},
+		{
+			name:           "comma-separated: all in extra list passes",
+			allowedSchemes: []string{"gs", "s3a"},
+			sparkConf:      map[string]string{"spark.jars": "gs://bucket/a.jar,s3a://bucket/b.jar"},
+			wantError:      false,
+		},
+		{
+			// Allow-list entries are normalized to lower case in the constructor, so an
+			// uppercase entry still matches a lower-case URL scheme.
+			name:           "allow-list entry is case-insensitive",
+			allowedSchemes: []string{"GS"},
+			sparkConf:      map[string]string{"spark.jars": "gs://my-bucket/app.jar"},
+			wantError:      false,
+		},
+		{
+			name:           "empty sparkConf always passes",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{},
+			wantError:      false,
+		},
+		{
+			// Empty and whitespace-only values (incl. empty comma elements) are skipped.
+			name:           "empty and blank values pass",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "  ", "spark.files": "file:///a.jar,,file:///b.jar"},
+			wantError:      false,
+		},
+		// Defense-in-depth: scheme-relative "//host/path" has an empty scheme but a host, so it
+		// is not a local path and must be rejected.
+		{
+			name:           "scheme-relative //host rejected",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "//attacker.example.com/evil.jar"},
+			wantError:      true,
+			errContains:    "scheme-relative",
+		},
+		// Defense-in-depth: a value with embedded control characters is not a valid URL and
+		// must be rejected (fail closed) rather than waved through.
+		{
+			name:           "value with control character rejected",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "ht\ttp://attacker.example.com/evil.jar"},
+			wantError:      true,
+			errContains:    "not a valid URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := newTestValidatorWithSchemes(t, false, tt.allowedSchemes)
+			app := newSparkApplication()
+			app.Spec.SparkConf = tt.sparkConf
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestSparkApplicationValidatorURLSchemesOtherFields proves the check is applied to the
+// fetch-capable fields beyond sparkConf (mainApplicationFile and the reflected deps.* lists)
+// and that the Maven-coordinate fields are carved out. Scheme rules themselves are covered by
+// the sparkConf table above; these cases only pin field wiring.
+func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(app *v1beta2.SparkApplication)
+		wantError   bool
+		errContains string
+	}{
+		{
+			name: "mainApplicationFile http rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
+			},
+			wantError:   true,
+			errContains: "spec.mainApplicationFile",
+		},
+		{
+			name: "deps.repositories http rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Deps.Repositories = []string{"http://repo.example.com/maven"}
+			},
+			wantError:   true,
+			errContains: "spec.deps.repositories",
+		},
+		{
+			// Maven coordinates (groupId:artifactId:version) are not URLs and must not be
+			// rejected even though url.Parse reads "com.example" as a scheme-like prefix.
+			name:      "deps.packages maven coordinates not rejected",
+			mutate:    func(app *v1beta2.SparkApplication) { app.Spec.Deps.Packages = []string{"com.example:my-lib:1.2.3"} },
+			wantError: false,
+		},
+		{
+			// spark.jars.packages holds Maven coordinates, not URLs; net/url parses
+			// "org.postgresql:postgresql:42.7.3" as scheme "org.postgresql" but the key
+			// is exempted so the value is not URL-checked.
+			name: "sparkConf spark.jars.packages maven coordinates not rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars.packages"] = "org.postgresql:postgresql:42.7.3"
+			},
+			wantError: false,
+		},
+		{
+			// spark.jars.excludePackages is also Maven coordinates.
+			name: "sparkConf spark.jars.excludePackages maven coordinates not rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars.excludePackages"] = "org.slf4j:slf4j-api"
+			},
+			wantError: false,
+		},
+		{
+			// spark.jars.ivySettings is a local or remote path to an Ivy XML, typically a
+			// Maven coordinate fragment or a file:// path, but can parse as an arbitrary scheme.
+			name: "sparkConf spark.jars.ivySettings local path not rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars.ivySettings"] = "/etc/ivy-settings.xml"
+			},
+			wantError: false,
+		},
+		{
+			// spark.jars is still URL-checked; it holds JAR URLs, not Maven coordinates.
+			name: "sparkConf spark.jars http rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars"] = "http://evil.example.com/app.jar"
+			},
+			wantError:   true,
+			errContains: `spec.sparkConf["spark.jars"]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := newTestValidatorWithSchemes(t, false, nil)
+			app := newSparkApplication()
+			tt.mutate(app)
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
 			}
 		})
 	}

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -454,6 +454,55 @@ func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
 	}
 }
 
+// TestSparkApplicationValidatorURLSchemesAggregateAllErrors proves that a spec with several
+// scheme violations across mainApplicationFile, deps.*, and sparkConf surfaces every violation
+// in one admission response (so a user does not have to fix them one round-trip at a time), and
+// that the message is deterministic: sparkConf keys are sorted rather than emitted in Go's
+// randomized map order, so the same spec always produces byte-identical error text.
+func TestSparkApplicationValidatorURLSchemesAggregateAllErrors(t *testing.T) {
+	validator := newTestValidatorWithSchemes(t, false, nil)
+
+	app := newSparkApplication()
+	app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
+	app.Spec.Deps.Repositories = []string{"http://repo.example.com/maven"}
+	app.Spec.SparkConf = map[string]string{
+		"spark.jars":  "https://a.example.com/a.jar",
+		"spark.files": "ftp://b.example.com/b.txt",
+	}
+
+	_, err := validator.ValidateCreate(context.Background(), app)
+	if err == nil {
+		t.Fatalf("expected error but got none")
+	}
+
+	// Every offending field must appear in the aggregated message.
+	wantSubstrings := []string{
+		"spec.mainApplicationFile",
+		"spec.deps.repositories",
+		`spec.sparkConf["spark.files"]`,
+		`spec.sparkConf["spark.jars"]`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected aggregated error to mention %q, got: %v", want, err)
+		}
+	}
+
+	// The message must be stable across repeated validations of the same spec; map iteration
+	// order would otherwise vary the sparkConf portion. Run several times and require identical
+	// output, and require the sorted "spark.files" before "spark.jars" ordering explicitly.
+	first := err.Error()
+	for range 10 {
+		_, e := validator.ValidateCreate(context.Background(), app)
+		if e == nil || e.Error() != first {
+			t.Fatalf("expected deterministic error text across runs;\n first: %v\n later: %v", first, e)
+		}
+	}
+	if fi, ji := strings.Index(first, `spec.sparkConf["spark.files"]`), strings.Index(first, `spec.sparkConf["spark.jars"]`); fi > ji {
+		t.Errorf("expected sparkConf keys in sorted order (spark.files before spark.jars), got: %v", first)
+	}
+}
+
 // TestSparkApplicationValidatorURLSchemesOtherFields proves the check is applied to the
 // fetch-capable fields beyond sparkConf (mainApplicationFile and the reflected deps.* lists)
 // and that the Maven-coordinate fields are carved out. Scheme rules themselves are covered by

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -366,6 +366,18 @@ func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
 			wantError:      false,
 		},
 		{
+			// spark.ui.proxyBase / spark.ui.proxyRedirectUri legitimately carry URL/path values
+			// consumed by the driver's UI at runtime; the operator never fetches them, so they are
+			// not in the submit-time allow-set and must not be rejected even with an http scheme.
+			name:           "spark.ui proxy keys not checked",
+			allowedSchemes: nil,
+			sparkConf: map[string]string{
+				"spark.ui.proxyBase":        "/proxy/app-1",
+				"spark.ui.proxyRedirectUri": "https://gateway.example.com",
+			},
+			wantError: false,
+		},
+		{
 			name:           "local:// always allowed with empty list",
 			allowedSchemes: nil,
 			sparkConf:      map[string]string{"spark.jars": "local:///opt/spark/jars/app.jar"},
@@ -379,6 +391,16 @@ func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
 			sparkConf:      map[string]string{"spark.jars": "http://example.com/app.jar"},
 			wantError:      true,
 			errContains:    `spec.sparkConf["spark.jars"]`,
+		},
+		{
+			// spark.jars.repositories is a submit-time fetch vector: in cluster mode spark-submit
+			// queries these repos from the operator pod to resolve --packages, so a disallowed
+			// scheme must be rejected. (spark.jars.packages itself is Maven coordinates, not a URL.)
+			name:           "spark.jars.repositories disallowed scheme rejected",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars.repositories": "http://repo.example.com/maven"},
+			wantError:      true,
+			errContains:    `spec.sparkConf["spark.jars.repositories"]`,
 		},
 		// A scheme is allowed once added to the extra list.
 		{
@@ -597,9 +619,10 @@ func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 			wantError: false,
 		},
 		{
-			// spark.jars.ivySettings is consumed by Spark's Ivy subsystem in the driver, not
-			// dereferenced by the operator at submit time, so it is not in sparkConfURLKeys and is
-			// never checked - not even a remote scheme is rejected here.
+			// spark.jars.ivySettings is read by spark-submit at submit time, but Spark restricts
+			// it to the "file" scheme (loadIvySettings throws on any other scheme before any I/O),
+			// so it cannot reach the operator's network and is not in sparkConfURLKeys. A local
+			// path is accepted here; a remote scheme would be rejected by Spark itself, not us.
 			name: "sparkConf spark.jars.ivySettings not checked",
 			mutate: func(app *v1beta2.SparkApplication) {
 				if app.Spec.SparkConf == nil {

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -561,7 +561,7 @@ func TestSparkApplicationValidatorURLSchemesOptIn(t *testing.T) {
 // TestSparkApplicationValidatorURLSchemesOtherFields proves the check is applied to the
 // fetch-capable fields beyond sparkConf (mainApplicationFile and the reflected deps.* lists),
 // that the Maven-coordinate deps fields are carved out, and that sparkConf keys the operator does
-// not dereference at submit time (Maven/Ivy keys) are simply not in the allow-set and therefore
+// not dereference at submit time (Maven-coordinate keys) are simply not in the allow-set and therefore
 // not checked. Scheme rules themselves are covered by the sparkConf table above; these cases only
 // pin field wiring.
 func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
@@ -615,20 +615,6 @@ func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
 					app.Spec.SparkConf = make(map[string]string)
 				}
 				app.Spec.SparkConf["spark.jars.excludePackages"] = "org.slf4j:slf4j-api"
-			},
-			wantError: false,
-		},
-		{
-			// spark.jars.ivySettings is read by spark-submit at submit time, but Spark restricts
-			// it to the "file" scheme (loadIvySettings throws on any other scheme before any I/O),
-			// so it cannot reach the operator's network and is not in sparkConfURLKeys. A local
-			// path is accepted here; a remote scheme would be rejected by Spark itself, not us.
-			name: "sparkConf spark.jars.ivySettings not checked",
-			mutate: func(app *v1beta2.SparkApplication) {
-				if app.Spec.SparkConf == nil {
-					app.Spec.SparkConf = make(map[string]string)
-				}
-				app.Spec.SparkConf["spark.jars.ivySettings"] = "/etc/ivy-settings.xml"
 			},
 			wantError: false,
 		},

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -225,6 +226,17 @@ func TestSparkApplicationValidatorValidateDelete_Success(t *testing.T) {
 
 func newTestValidator(t *testing.T, enforceQuota bool, objs ...client.Object) *SparkApplicationValidator {
 	t.Helper()
+	// URL-scheme validation is opt-in and off here; the dedicated URL-scheme tests enable it
+	// explicitly via newTestValidatorWithSchemes.
+	return newTestValidatorWithSchemes(t, enforceQuota, false, nil, objs...)
+}
+
+func newTestValidatorWithSchemes(t *testing.T, enforceQuota bool, enableURLSchemeValidation bool, allowedSchemes []string, objs ...client.Object) *SparkApplicationValidator {
+	return newTestValidatorWithURLPolicy(t, enforceQuota, enableURLSchemeValidation, allowedSchemes, nil, nil, nil, objs...)
+}
+
+func newTestValidatorWithURLPolicy(t *testing.T, enforceQuota bool, enableURLSchemeValidation bool, allowedSchemes, allowedSchemesAnyHost, allowedHosts, allowedWildcardHosts []string, objs ...client.Object) *SparkApplicationValidator {
+	t.Helper()
 
 	scheme := newTestScheme(t)
 
@@ -233,7 +245,7 @@ func newTestValidator(t *testing.T, enforceQuota bool, objs ...client.Object) *S
 		builder = builder.WithObjects(objs...)
 	}
 
-	return NewSparkApplicationValidator(builder.Build(), enforceQuota)
+	return NewSparkApplicationValidator(builder.Build(), enforceQuota, enableURLSchemeValidation, allowedSchemes, allowedSchemesAnyHost, allowedHosts, allowedWildcardHosts)
 }
 
 func newTestScheme(t *testing.T) *runtime.Scheme {
@@ -298,6 +310,728 @@ func TestSparkApplicationValidatorValidateName(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDepsURLFieldsExempt guards the depsURLFieldsExempt carve-out. validateDepsURLSchemes
+// URL-checks every []string field of v1beta2.Dependencies by reflection except the exempt tags,
+// so a newly-added fetch field is covered automatically. This test only has to ensure the
+// exempt set does not drift: every exempt tag must name a real []string field on the struct
+// (a stale entry would silently skip a future field that reused the name).
+func TestDepsURLFieldsExempt(t *testing.T) {
+	depsType := reflect.TypeFor[v1beta2.Dependencies]()
+	stringListTags := make(map[string]struct{}, depsType.NumField())
+	for i := range depsType.NumField() {
+		f := depsType.Field(i)
+		if f.Type != reflect.TypeFor[[]string]() {
+			continue
+		}
+		tag := strings.Split(f.Tag.Get("json"), ",")[0]
+		if tag == "" || tag == "-" {
+			continue
+		}
+		stringListTags[tag] = struct{}{}
+	}
+
+	for _, tag := range depsURLFieldsExempt {
+		if _, ok := stringListTags[tag]; !ok {
+			t.Errorf("depsURLFieldsExempt tag %q does not name a []string field on v1beta2.Dependencies; "+
+				"remove it or fix the tag", tag)
+		}
+	}
+}
+
+func TestSparkApplicationValidatorSparkConfURLSchemes(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedSchemes []string
+		allowedHosts   []string
+		sparkConf      map[string]string
+		wantErrors     []urlValidationErrorExpectation
+	}{
+		// file:// and schemeless are always allowed regardless of the list.
+		{
+			name:           "file:// always allowed with empty list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "file:///opt/spark/jars/app.jar"},
+		},
+		{
+			name:           "schemeless path always allowed with empty list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "/opt/spark/jars/app.jar"},
+		},
+		{
+			// Runtime-only sparkConf keys are not forwarded to spark-submit by the operator, so
+			// they are never scheme-checked even with a scheme that would otherwise be rejected.
+			// This is the key-based allow-set at work (sparkConfURLKeys): submit-time keys only.
+			name:           "runtime-only key not checked",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.eventLog.dir": "s3a://logs/bucket"},
+		},
+		{
+			// spark.ui.proxyBase / spark.ui.proxyRedirectUri legitimately carry URL/path values
+			// consumed by the driver's UI at runtime; the operator never fetches them, so they are
+			// not in the submit-time allow-set and must not be rejected even with an http scheme.
+			name:           "spark.ui proxy keys not checked",
+			allowedSchemes: nil,
+			sparkConf: map[string]string{
+				"spark.ui.proxyBase":        "/proxy/app-1",
+				"spark.ui.proxyRedirectUri": "https://gateway.example.com",
+			},
+		},
+		{
+			// This selects where Spark uploads local artifacts. It is an outbound destination, not
+			// a URL that spark-submit retrieves, so fetch-source scheme validation does not apply.
+			name:           "artifact upload destination not checked",
+			allowedSchemes: nil,
+			sparkConf: map[string]string{
+				"spark.kubernetes.file.upload.path": "s3a://artifact-bucket/submissions",
+			},
+		},
+		{
+			name:           "local:// always allowed with empty list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "local:///opt/spark/jars/app.jar"},
+		},
+		// Any scheme not in the always-allowed set or the extra list is rejected; the
+		// error names the offending key. http represents all such schemes (https, ftp, gs, ...).
+		{
+			name:           "disallowed scheme rejected with empty extra list",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "http://example.com/app.jar"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field:  `spec.sparkConf["spark.jars"]`,
+				value:  "http://example.com/app.jar",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			}},
+		},
+		{
+			// spark.jars.repositories is a submit-time fetch vector: in cluster mode spark-submit
+			// queries these repos from the operator pod to resolve --packages, so a disallowed
+			// scheme must be rejected. (spark.jars.packages itself is Maven coordinates, not a URL.)
+			name:           "spark.jars.repositories disallowed scheme rejected",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars.repositories": "http://repo.example.com/maven"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field:  `spec.sparkConf["spark.jars.repositories"]`,
+				value:  "http://repo.example.com/maven",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			}},
+		},
+		// A scheme is allowed once added to the extra list.
+		{
+			name:           "scheme allowed when added to extra list",
+			allowedSchemes: []string{"gs", "s3a"},
+			allowedHosts:   []string{"gs://my-bucket"},
+			sparkConf:      map[string]string{"spark.jars": "gs://my-bucket/app.jar"},
+		},
+		// Comma-separated values are each checked.
+		{
+			name:           "comma-separated: one disallowed entry rejects",
+			allowedSchemes: []string{"gs"},
+			allowedHosts:   []string{"gs://ok.jar"},
+			sparkConf:      map[string]string{"spark.jars": "gs://ok.jar,https://evil.com/bad.jar"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field:  `spec.sparkConf["spark.jars"]`,
+				value:  "https://evil.com/bad.jar",
+				scheme: "https",
+				kind:   URLValidationSchemeNotAllowed,
+			}},
+		},
+		{
+			name:           "comma-separated: all in extra list passes",
+			allowedSchemes: []string{"gs", "s3a"},
+			allowedHosts:   []string{"gs://bucket", "s3a://bucket"},
+			sparkConf:      map[string]string{"spark.jars": "gs://bucket/a.jar,s3a://bucket/b.jar"},
+		},
+		{
+			// Allow-list entries are normalized to lower case in the constructor, so an
+			// uppercase entry still matches a lower-case URL scheme.
+			name:           "allow-list entry is case-insensitive",
+			allowedSchemes: []string{"GS"},
+			allowedHosts:   []string{"gs://my-bucket"},
+			sparkConf:      map[string]string{"spark.jars": "gs://my-bucket/app.jar"},
+		},
+		{
+			name:           "empty sparkConf always passes",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{},
+		},
+		{
+			// Empty and whitespace-only values (incl. empty comma elements) are skipped.
+			name:           "empty and blank values pass",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "  ", "spark.files": "file:///a.jar,,file:///b.jar"},
+		},
+		// Defense-in-depth: scheme-relative "//host/path" has an empty scheme but a host, so it
+		// is not a local path and must be rejected.
+		{
+			name:           "scheme-relative //host rejected",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "//attacker.example.com/evil.jar"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field: `spec.sparkConf["spark.jars"]`,
+				value: "//attacker.example.com/evil.jar",
+				host:  "attacker.example.com",
+				kind:  URLValidationHostNotAllowed,
+			}},
+		},
+		// Defense-in-depth: a value with embedded control characters is not a valid URL and
+		// must be rejected (fail closed) rather than waved through.
+		{
+			name:           "value with control character rejected",
+			allowedSchemes: nil,
+			sparkConf:      map[string]string{"spark.jars": "ht\ttp://attacker.example.com/evil.jar"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field: `spec.sparkConf["spark.jars"]`,
+				value: "ht\ttp://attacker.example.com/evil.jar",
+				kind:  URLValidationInvalidURL,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := newTestValidatorWithURLPolicy(t, false, true, tt.allowedSchemes, nil, tt.allowedHosts, nil)
+			app := newSparkApplication()
+			app.Spec.SparkConf = tt.sparkConf
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			if len(tt.wantErrors) == 0 {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			} else {
+				requireURLValidationErrors(t, err, tt.wantErrors...)
+			}
+		})
+	}
+}
+
+func TestSparkApplicationValidatorURLSchemeTypedErrors(t *testing.T) {
+	validator := newTestValidatorWithSchemes(t, false, true, nil)
+	tests := []struct {
+		name  string
+		value string
+		want  urlValidationErrorExpectation
+	}{
+		{
+			name:  "invalid URL",
+			value: "ht\ttp://attacker.example.com/evil.jar",
+			want: urlValidationErrorExpectation{
+				field: "spec.sparkConf[\"spark.jars\"]",
+				value: "ht\ttp://attacker.example.com/evil.jar",
+				kind:  URLValidationInvalidURL,
+			},
+		},
+		{
+			name:  "scheme not allowed",
+			value: "https://attacker.example.com/evil.jar",
+			want: urlValidationErrorExpectation{
+				field:  "spec.sparkConf[\"spark.jars\"]",
+				value:  "https://attacker.example.com/evil.jar",
+				scheme: "https",
+				kind:   URLValidationSchemeNotAllowed,
+			},
+		},
+		{
+			name:  "host not allowed",
+			value: "//attacker.example.com/evil.jar",
+			want: urlValidationErrorExpectation{
+				field: "spec.sparkConf[\"spark.jars\"]",
+				value: "//attacker.example.com/evil.jar",
+				host:  "attacker.example.com",
+				kind:  URLValidationHostNotAllowed,
+			},
+		},
+		{
+			name:  "file URL host not allowed",
+			value: "file://attacker.example.com/evil.jar",
+			want: urlValidationErrorExpectation{
+				field: "spec.sparkConf[\"spark.jars\"]",
+				value: "file://attacker.example.com/evil.jar",
+				host:  "attacker.example.com",
+				kind:  URLValidationHostNotAllowed,
+			},
+		},
+		{
+			name:  "local URL host not allowed",
+			value: "local://attacker.example.com/evil.jar",
+			want: urlValidationErrorExpectation{
+				field: "spec.sparkConf[\"spark.jars\"]",
+				value: "local://attacker.example.com/evil.jar",
+				host:  "attacker.example.com",
+				kind:  URLValidationHostNotAllowed,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.checkURLSchemes("spec.sparkConf[\"spark.jars\"]", []string{tt.value})
+			requireURLValidationErrors(t, errors.Join(errs...), tt.want)
+		})
+	}
+}
+
+func TestSparkApplicationValidatorURLHostPolicy(t *testing.T) {
+	tests := []struct {
+		name                  string
+		value                 string
+		allowedSchemes        []string
+		allowedSchemesAnyHost []string
+		allowedHosts          []string
+		allowedWildcardHosts  []string
+		wantErrors            []urlValidationErrorExpectation
+	}{
+		{
+			name:           "remote URL denied without allowed hosts",
+			value:          "https://test1.example.com/maven2/app.jar",
+			allowedSchemes: []string{"https"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field: `spec.sparkConf["spark.jars"]`,
+				value: "https://test1.example.com/maven2/app.jar",
+				host:  "test1.example.com",
+				kind:  URLValidationHostNotAllowed,
+			}},
+		},
+		{
+			name:           "exact host allowed case insensitively with port",
+			value:          "https://TEST1.EXAMPLE.COM:8443/maven2/app.jar",
+			allowedSchemes: []string{"https"},
+			allowedHosts:   []string{"https://test1.example.com"},
+		},
+		{
+			name:                 "wildcard host allows subdomain",
+			value:                "https://repo.maven.apache.org/maven2/app.jar",
+			allowedSchemes:       []string{"https"},
+			allowedWildcardHosts: []string{"https://*.maven.apache.org"},
+		},
+		{
+			name:                 "wildcard host does not allow apex",
+			value:                "https://maven.apache.org/maven2/app.jar",
+			allowedSchemes:       []string{"https"},
+			allowedWildcardHosts: []string{"https://*.maven.apache.org"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field: `spec.sparkConf["spark.jars"]`,
+				value: "https://maven.apache.org/maven2/app.jar",
+				host:  "maven.apache.org",
+				kind:  URLValidationHostNotAllowed,
+			}},
+		},
+		{
+			name:           "S3 bucket authority allowed as host",
+			value:          "s3a://artifacts-bucket/app.jar",
+			allowedSchemes: []string{"s3a"},
+			allowedHosts:   []string{"s3a://artifacts-bucket"},
+		},
+		{
+			name:           "host rule applies only to its configured scheme",
+			value:          "s3a://test1.example.com/app.jar",
+			allowedSchemes: []string{"https", "s3a"},
+			allowedHosts:   []string{"https://test1.example.com"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field: `spec.sparkConf["spark.jars"]`,
+				value: "s3a://test1.example.com/app.jar",
+				host:  "test1.example.com",
+				kind:  URLValidationHostNotAllowed,
+			}},
+		},
+		{
+			name:           "IP address requires exact host entry",
+			value:          "https://192.0.2.10/app.jar",
+			allowedSchemes: []string{"https"},
+			wantErrors: []urlValidationErrorExpectation{{
+				field: `spec.sparkConf["spark.jars"]`,
+				value: "https://192.0.2.10/app.jar",
+				host:  "192.0.2.10",
+				kind:  URLValidationHostNotAllowed,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := newTestValidatorWithURLPolicy(t, false, true, tt.allowedSchemes, tt.allowedSchemesAnyHost, tt.allowedHosts, tt.allowedWildcardHosts)
+			app := newSparkApplication()
+			app.Spec.SparkConf = map[string]string{"spark.jars": tt.value}
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			if len(tt.wantErrors) == 0 {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			requireURLValidationErrors(t, err, tt.wantErrors...)
+		})
+	}
+}
+
+func TestSparkApplicationValidatorURLHostPolicyAllowsAllHostsForConfiguredScheme(t *testing.T) {
+	validator := newTestValidatorWithURLPolicy(t, false, true, []string{"s3a"}, []string{"s3a"}, nil, nil)
+	app := newSparkApplication()
+	app.Spec.SparkConf = map[string]string{"spark.jars": "s3a://any-bucket/app.jar"}
+	if _, err := validator.ValidateCreate(context.Background(), app); err != nil {
+		t.Fatalf("expected scheme configured for all hosts to pass validation, got %v", err)
+	}
+}
+
+func TestValidateAllowedURLHosts(t *testing.T) {
+	for _, tt := range []struct {
+		host     string
+		wildcard bool
+		wantErr  bool
+	}{
+		{host: "https://test1.example.com"},
+		{host: "s3a://artifacts-bucket"},
+		{host: "https://*.maven.apache.org", wildcard: true},
+		{host: "test1.example.com", wantErr: true},
+		{host: "https://test1.example.com:8443", wantErr: true},
+		{host: "https://test1.example.com/path", wantErr: true},
+		{host: "https://*", wildcard: true, wantErr: true},
+		{host: "https://maven.*.org", wildcard: true, wantErr: true},
+		{host: "https://repo*.maven.org", wildcard: true, wantErr: true},
+		{host: "https://maven.apache.org", wildcard: true, wantErr: true},
+	} {
+		hosts, wildcardHosts := []string{tt.host}, []string(nil)
+		if tt.wildcard {
+			hosts, wildcardHosts = nil, []string{tt.host}
+		}
+		err := ValidateAllowedURLHosts(hosts, wildcardHosts)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateAllowedURLHosts(%q) error = %v, wantErr %v", tt.host, err, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateAllowAllURLHostsSchemes(t *testing.T) {
+	for _, tt := range []struct {
+		allowedSchemes        []string
+		allowedSchemesAnyHost []string
+		wantErr               bool
+	}{
+		{allowedSchemes: []string{"s3a"}, allowedSchemesAnyHost: []string{"s3a"}},
+		{allowedSchemes: []string{"https"}, allowedSchemesAnyHost: []string{"s3a"}, wantErr: true},
+		{allowedSchemes: []string{"https"}, allowedSchemesAnyHost: []string{""}, wantErr: true},
+	} {
+		err := ValidateAllowAllURLHostsSchemes(tt.allowedSchemes, tt.allowedSchemesAnyHost)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateAllowAllURLHostsSchemes(%v, %v) error = %v, wantErr %v", tt.allowedSchemes, tt.allowedSchemesAnyHost, err, tt.wantErr)
+		}
+	}
+}
+
+// TestSparkApplicationValidatorURLSchemesAggregateAllErrors proves that a spec with several
+// scheme violations across mainApplicationFile, deps.*, and sparkConf surfaces every violation
+// in one admission response (so a user does not have to fix them one round-trip at a time), and
+// that the message is deterministic: sparkConf keys are sorted rather than emitted in Go's
+// randomized map order, so the same spec always produces byte-identical error text.
+func TestSparkApplicationValidatorURLSchemesAggregateAllErrors(t *testing.T) {
+	validator := newTestValidatorWithSchemes(t, false, true, nil)
+
+	app := newSparkApplication()
+	app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
+	app.Spec.Deps.Repositories = []string{"http://repo.example.com/maven"}
+	app.Spec.SparkConf = map[string]string{
+		"spark.jars":  "https://a.example.com/a.jar",
+		"spark.files": "ftp://b.example.com/b.txt",
+	}
+
+	_, err := validator.ValidateCreate(context.Background(), app)
+	if err == nil {
+		t.Fatalf("expected error but got none")
+	}
+
+	requireURLValidationErrors(t, err,
+		urlValidationErrorExpectation{
+			field:  "spec.mainApplicationFile",
+			value:  "http://evil.example.com/main.py",
+			scheme: "http",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+		urlValidationErrorExpectation{
+			field:  "spec.deps.repositories",
+			value:  "http://repo.example.com/maven",
+			scheme: "http",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+		urlValidationErrorExpectation{
+			field:  `spec.sparkConf["spark.files"]`,
+			value:  "ftp://b.example.com/b.txt",
+			scheme: "ftp",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+		urlValidationErrorExpectation{
+			field:  `spec.sparkConf["spark.jars"]`,
+			value:  "https://a.example.com/a.jar",
+			scheme: "https",
+			kind:   URLValidationSchemeNotAllowed,
+		},
+	)
+
+	// Repeated validation must preserve the typed-error order, including the sorted sparkConf
+	// entries, without coupling this unit test to rendered error prose.
+	for range 10 {
+		_, e := validator.ValidateCreate(context.Background(), app)
+		requireURLValidationErrors(t, e,
+			urlValidationErrorExpectation{
+				field:  "spec.mainApplicationFile",
+				value:  "http://evil.example.com/main.py",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			},
+			urlValidationErrorExpectation{
+				field:  "spec.deps.repositories",
+				value:  "http://repo.example.com/maven",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			},
+			urlValidationErrorExpectation{
+				field:  `spec.sparkConf["spark.files"]`,
+				value:  "ftp://b.example.com/b.txt",
+				scheme: "ftp",
+				kind:   URLValidationSchemeNotAllowed,
+			},
+			urlValidationErrorExpectation{
+				field:  `spec.sparkConf["spark.jars"]`,
+				value:  "https://a.example.com/a.jar",
+				scheme: "https",
+				kind:   URLValidationSchemeNotAllowed,
+			},
+		)
+	}
+}
+
+// TestSparkApplicationValidatorURLSchemesOptIn proves the check is strictly opt-in: a spec that
+// is rejected when validation is enabled is accepted unchanged when it is disabled (the default),
+// so operators already submitting remote deps are not broken on upgrade.
+func TestSparkApplicationValidatorURLSchemesOptIn(t *testing.T) {
+	app := newSparkApplication()
+	app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
+	app.Spec.Deps.Repositories = []string{"http://repo.example.com/maven"}
+	app.Spec.SparkConf = map[string]string{"spark.jars": "https://a.example.com/a.jar"}
+
+	// Disabled (default): the http/https values must be accepted.
+	disabled := newTestValidatorWithSchemes(t, false, false, nil)
+	if _, err := disabled.ValidateCreate(context.Background(), app); err != nil {
+		t.Fatalf("expected no error when URL-scheme validation is disabled, got: %v", err)
+	}
+
+	// Enabled: the very same spec must now be rejected, proving the gate is what flips behaviour.
+	enabled := newTestValidatorWithSchemes(t, false, true, nil)
+	if _, err := enabled.ValidateCreate(context.Background(), app); err == nil {
+		t.Fatalf("expected error when URL-scheme validation is enabled, got none")
+	}
+}
+
+// TestSparkApplicationValidatorURLSchemesOtherFields proves the check is applied to the
+// fetch-capable fields beyond sparkConf (mainApplicationFile and the reflected deps.* lists),
+// that the Maven-coordinate deps fields are carved out, and that sparkConf keys the operator does
+// not dereference at submit time (Maven-coordinate keys) are simply not in the allow-set and therefore
+// not checked. Scheme rules themselves are covered by the sparkConf table above; these cases only
+// pin field wiring.
+func TestSparkApplicationValidatorURLSchemesOtherFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(app *v1beta2.SparkApplication)
+		wantErrors []urlValidationErrorExpectation
+	}{
+		{
+			name: "mainApplicationFile http rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.MainApplicationFile = ptr.To("http://evil.example.com/main.py")
+			},
+			wantErrors: []urlValidationErrorExpectation{{
+				field:  "spec.mainApplicationFile",
+				value:  "http://evil.example.com/main.py",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			}},
+		},
+		{
+			name: "deps.repositories http rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Deps.Repositories = []string{"http://repo.example.com/maven"}
+			},
+			wantErrors: []urlValidationErrorExpectation{{
+				field:  "spec.deps.repositories",
+				value:  "http://repo.example.com/maven",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			}},
+		},
+		{
+			// Maven coordinates (groupId:artifactId:version) are not URLs and must not be
+			// rejected even though url.Parse reads "com.example" as a scheme-like prefix.
+			name:   "deps.packages maven coordinates not rejected",
+			mutate: func(app *v1beta2.SparkApplication) { app.Spec.Deps.Packages = []string{"com.example:my-lib:1.2.3"} },
+		},
+		{
+			// spark.jars.packages holds Maven coordinates, not URLs; net/url parses
+			// "org.postgresql:postgresql:42.7.3" as scheme "org.postgresql" but the key
+			// is not in the submit-time allow-set (sparkConfURLKeys) so it is never checked.
+			name: "sparkConf spark.jars.packages maven coordinates not rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars.packages"] = "org.postgresql:postgresql:42.7.3"
+			},
+		},
+		{
+			// spark.jars.excludePackages is also Maven coordinates and not in the allow-set.
+			name: "sparkConf spark.jars.excludePackages maven coordinates not rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars.excludePackages"] = "org.slf4j:slf4j-api"
+			},
+		},
+		{
+			// spark.jars is still URL-checked; it holds JAR URLs, not Maven coordinates.
+			name: "sparkConf spark.jars http rejected",
+			mutate: func(app *v1beta2.SparkApplication) {
+				if app.Spec.SparkConf == nil {
+					app.Spec.SparkConf = make(map[string]string)
+				}
+				app.Spec.SparkConf["spark.jars"] = "http://evil.example.com/app.jar"
+			},
+			wantErrors: []urlValidationErrorExpectation{{
+				field:  `spec.sparkConf["spark.jars"]`,
+				value:  "http://evil.example.com/app.jar",
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := newTestValidatorWithSchemes(t, false, true, nil)
+			app := newSparkApplication()
+			tt.mutate(app)
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			if len(tt.wantErrors) == 0 && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			} else if len(tt.wantErrors) > 0 {
+				requireURLValidationErrors(t, err, tt.wantErrors...)
+			}
+		})
+	}
+}
+
+func TestSparkApplicationValidatorDependencyURLSchemeTokenization(t *testing.T) {
+	tests := []struct {
+		name        string
+		field       string
+		remoteValue string
+		mutate      func(*v1beta2.Dependencies)
+	}{
+		{
+			name:        "jars",
+			field:       "spec.deps.jars",
+			remoteValue: "http://attacker.example/evil.jar",
+			mutate: func(deps *v1beta2.Dependencies) {
+				deps.Jars = []string{"file:///safe.jar,http://attacker.example/evil.jar"}
+			},
+		},
+		{
+			name:        "files",
+			field:       "spec.deps.files",
+			remoteValue: "http://attacker.example/evil.txt",
+			mutate: func(deps *v1beta2.Dependencies) {
+				deps.Files = []string{"file:///safe.txt,http://attacker.example/evil.txt"}
+			},
+		},
+		{
+			name:        "pyFiles",
+			field:       "spec.deps.pyFiles",
+			remoteValue: "http://attacker.example/evil.py",
+			mutate: func(deps *v1beta2.Dependencies) {
+				deps.PyFiles = []string{"file:///safe.py,http://attacker.example/evil.py"}
+			},
+		},
+		{
+			name:        "archives",
+			field:       "spec.deps.archives",
+			remoteValue: "http://attacker.example/evil.tar",
+			mutate: func(deps *v1beta2.Dependencies) {
+				deps.Archives = []string{"file:///safe.tar,http://attacker.example/evil.tar"}
+			},
+		},
+		{
+			name:        "repositories",
+			field:       "spec.deps.repositories",
+			remoteValue: "http://attacker.example/maven",
+			mutate: func(deps *v1beta2.Dependencies) {
+				deps.Repositories = []string{"file:///safe-repo,http://attacker.example/maven"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := newTestValidatorWithSchemes(t, false, true, nil)
+			app := newSparkApplication()
+			tt.mutate(&app.Spec.Deps)
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			requireURLValidationErrors(t, err, urlValidationErrorExpectation{
+				field:  tt.field,
+				value:  tt.remoteValue,
+				scheme: "http",
+				kind:   URLValidationSchemeNotAllowed,
+			})
+		})
+	}
+}
+
+type urlValidationErrorExpectation struct {
+	field  string
+	value  string
+	scheme string
+	host   string
+	kind   URLValidationErrorKind
+}
+
+func requireURLValidationErrors(t *testing.T, err error, want ...urlValidationErrorExpectation) {
+	t.Helper()
+
+	got := urlValidationErrors(err)
+	if len(got) != len(want) {
+		t.Fatalf("expected %d URL validation errors, got %d: %v", len(want), len(got), err)
+	}
+
+	for i, want := range want {
+		if got[i].Field != want.field || got[i].Value != want.value || got[i].Scheme != want.scheme || got[i].Host != want.host || got[i].Kind != want.kind {
+			t.Errorf("URL validation error %d = %+v, want field=%q value=%q scheme=%q host=%q kind=%q", i, got[i], want.field, want.value, want.scheme, want.host, want.kind)
+		}
+		if got[i].Kind == URLValidationInvalidURL && got[i].Err == nil {
+			t.Errorf("URL validation error %d has no parse error", i)
+		}
+	}
+}
+
+func urlValidationErrors(err error) []*URLValidationError {
+	if err == nil {
+		return nil
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		var errs []*URLValidationError
+		for _, err := range joined.Unwrap() {
+			errs = append(errs, urlValidationErrors(err)...)
+		}
+		return errs
+	}
+	var typed *URLValidationError
+	if errors.As(err, &typed) {
+		return []*URLValidationError{typed}
+	}
+	return nil
 }
 
 func newSparkApplication() *v1beta2.SparkApplication {

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -42,13 +42,10 @@ var _ = Describe("Driver PodDisruptionBudget", func() {
 	Context("when the SparkApplication opts in", func() {
 		var app *v1beta2.SparkApplication
 
-		BeforeEach(func() {
-			app = loadSparkPi("e2e-pdb-on")
-			app.Spec.DriverPodDisruptionBudget = ptr.To(true)
-			Expect(k8sClient.Create(ctx, app)).To(Succeed())
-		})
-
 		AfterEach(func() {
+			if app == nil {
+				return
+			}
 			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
 			if err := k8sClient.Get(ctx, key, app); err == nil {
 				_ = k8sClient.Delete(ctx, app)
@@ -56,6 +53,10 @@ var _ = Describe("Driver PodDisruptionBudget", func() {
 		})
 
 		It("creates a PDB while the driver is running, and the app completes", func() {
+			app = loadSparkPi("e2e-pdb-observe")
+			app.Spec.DriverPodDisruptionBudget = ptr.To(true)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
 			By("Waiting for the driver PDB to appear")
 			pdb := &policyv1.PodDisruptionBudget{}
 			Eventually(func() error {
@@ -77,6 +78,10 @@ var _ = Describe("Driver PodDisruptionBudget", func() {
 		})
 
 		It("garbage-collects the PDB when the SparkApplication is deleted", func() {
+			app = loadSparkPi("e2e-pdb-delete")
+			app.Spec.DriverPodDisruptionBudget = ptr.To(true)
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
 			By("Waiting for the driver PDB to appear")
 			Eventually(func() error {
 				pdb := &policyv1.PodDisruptionBudget{}

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -646,7 +646,8 @@ var _ = Describe("Example SparkApplication", func() {
 	// value with a scheme that is not an always-allowed local scheme (schemeless, file://,
 	// local://) and not in the operator's --spark-allowed-url-schemes list. http:// is never
 	// in the default list so the rejection test runs unconditionally.
-	// The accept test uses dry-run so it never triggers a submission attempt.
+	// Both tests use dry-run so neither ever persists a SparkApplication or triggers a
+	// submission attempt; they still exercise the full admission chain.
 	Context("spark-allowed-url-schemes", func() {
 		ctx := context.Background()
 		mainFile := "local:///app.py"
@@ -681,7 +682,10 @@ var _ = Describe("Example SparkApplication", func() {
 				},
 			}
 
-			err := k8sClient.Create(ctx, app)
+			// Dry-run exercises the full admission chain (the webhook still runs and rejects)
+			// without ever persisting the object, so a future config change that allowed http
+			// could not leak a real SparkApplication for the controller to reconcile.
+			err := k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 			Expect(err).To(HaveOccurred(), "expected admission webhook to reject sparkConf with disallowed URL scheme")
 			Expect(errors.IsInvalid(err) || errors.IsForbidden(err)).To(BeTrue(), "expected Invalid or Forbidden, got: %v", err)
 		})

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -640,4 +640,86 @@ var _ = Describe("Example SparkApplication", func() {
 			checkVolumeAndMount(*driverPod, common.SparkDriverContainerName)
 		})
 	})
+
+	// spark-allowed-url-schemes: the webhook rejects SparkApplications whose fetch-capable
+	// fields (spec.sparkConf values, spec.deps.*, spec.mainApplicationFile) contain a URL
+	// value with a scheme that is not an always-allowed local scheme (schemeless, file://,
+	// local://) and not in the operator's --spark-allowed-url-schemes list. http:// is never
+	// in the default list so the rejection test runs unconditionally.
+	// The accept test uses dry-run so it never triggers a submission attempt.
+	Context("spark-allowed-url-schemes", func() {
+		ctx := context.Background()
+		mainFile := "local:///app.py"
+
+		It("Rejects a SparkApplication whose sparkConf contains a disallowed URL scheme", func() {
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ssrf-reject-test",
+					Namespace: "default",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Type:                v1beta2.SparkApplicationTypeScala,
+					SparkVersion:        "3.5.0",
+					Mode:                v1beta2.DeployModeCluster,
+					MainApplicationFile: &mainFile,
+					SparkConf: map[string]string{
+						"spark.jars": "http://attacker.example.com/evil.jar",
+					},
+					Driver: v1beta2.DriverSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+					},
+					Executor: v1beta2.ExecutorSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+						Instances: ptr.To[int32](1),
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, app)
+			Expect(err).To(HaveOccurred(), "expected admission webhook to reject sparkConf with disallowed URL scheme")
+			Expect(errors.IsInvalid(err) || errors.IsForbidden(err)).To(BeTrue(), "expected Invalid or Forbidden, got: %v", err)
+		})
+
+		It("Accepts a SparkApplication whose sparkConf uses only allowed URL schemes (dry-run)", func() {
+			app := &v1beta2.SparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ssrf-allow-test",
+					Namespace: "default",
+				},
+				Spec: v1beta2.SparkApplicationSpec{
+					Type:                v1beta2.SparkApplicationTypeScala,
+					SparkVersion:        "3.5.0",
+					Mode:                v1beta2.DeployModeCluster,
+					MainApplicationFile: &mainFile,
+					SparkConf: map[string]string{
+						// file:// is always in the default allow list.
+						"spark.jars": "file:///opt/spark/jars/app.jar",
+					},
+					Driver: v1beta2.DriverSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+					},
+					Executor: v1beta2.ExecutorSpec{
+						SparkPodSpec: v1beta2.SparkPodSpec{
+							Cores:  ptr.To[int32](1),
+							Memory: ptr.To("512m"),
+						},
+						Instances: ptr.To[int32](1),
+					},
+				},
+			}
+
+			// Dry-run exercises the full admission chain without persisting the object,
+			// so the controller never reconciles it and there is no submission attempt.
+			Expect(k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})).To(Succeed())
+		})
+	})
 })

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -641,11 +641,12 @@ var _ = Describe("Example SparkApplication", func() {
 		})
 	})
 
-	// spark-allowed-url-schemes: the webhook rejects SparkApplications whose fetch-capable
-	// fields (spec.sparkConf values, spec.deps.*, spec.mainApplicationFile) contain a URL
-	// value with a scheme that is not an always-allowed local scheme (schemeless, file://,
-	// local://) and not in the operator's --spark-allowed-url-schemes list. http:// is never
-	// in the default list so the rejection test runs unconditionally.
+	// spark-allowed-url-schemes: when URL-scheme validation is enabled, the webhook rejects
+	// SparkApplications whose fetch-capable fields (submit-time spec.sparkConf keys, spec.deps.*,
+	// spec.mainApplicationFile) contain a URL value with a scheme that is not an always-allowed
+	// local scheme (schemeless, file://, local://) and not in --spark-allowed-url-schemes. The
+	// feature is opt-in; the e2e deployments enable it (helm ci-values.yaml urlSchemeValidation.enable
+	// and the kustomize driver-pdb overlay), so http:// is always rejected here.
 	// Both tests use dry-run so neither ever persists a SparkApplication or triggers a
 	// submission attempt; they still exercise the full admission chain.
 	Context("spark-allowed-url-schemes", func() {

--- a/test/e2e/sparkapplication_test.go
+++ b/test/e2e/sparkapplication_test.go
@@ -43,6 +43,42 @@ import (
 )
 
 var _ = Describe("Example SparkApplication", func() {
+	Context("invalid Maven dependency", func() {
+		ctx := context.Background()
+		app := &v1beta2.SparkApplication{}
+
+		BeforeEach(func() {
+			app = loadSparkPi("invalid-maven-dependency")
+			app.Spec.Deps.Packages = []string{"com.example:artifact-that-does-not-exist:0.0.0"}
+			app.Spec.RestartPolicy = v1beta2.RestartPolicy{
+				Type:                             v1beta2.RestartPolicyOnFailure,
+				OnSubmissionFailureRetries:       ptr.To(int32(0)),
+				OnSubmissionFailureRetryInterval: ptr.To(int64(1)),
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+		})
+
+		It("fails during spark-submit dependency resolution", func() {
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			apps, err := collectSparkApplicationsUntilTermination(ctx, key)
+			Expect(err).To(HaveOccurred())
+
+			finalApp := apps[len(apps)-1]
+			Expect(finalApp.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
+			Expect(finalApp.Status.AppState.ErrorMessage).To(MatchRegexp(`failed to submit spark application: spark-submit failed with exit code [1-9][0-9]*$`))
+
+			driverPodName := util.GetDriverPodName(app)
+			_, err = clientset.CoreV1().Pods(app.Namespace).Get(ctx, driverPodName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
 	Context("spark-pi", func() {
 		ctx := context.Background()
 		path := filepath.Join("..", "..", "examples", "spark-pi.yaml")
@@ -277,7 +313,7 @@ var _ = Describe("Example SparkApplication", func() {
 			By("Should eventually fail")
 			finalApp := apps[len(apps)-1]
 			Expect(finalApp.Status.AppState.State).To(Equal(v1beta2.ApplicationStateFailed))
-			Expect(finalApp.Status.AppState.ErrorMessage).To(ContainSubstring("failed to run spark-submit"))
+			Expect(finalApp.Status.AppState.ErrorMessage).To(MatchRegexp(`failed to submit spark application: spark-submit failed with exit code [1-9][0-9]*$`))
 			Expect(finalApp.Status.SubmissionAttempts).To(Equal(*app.Spec.RestartPolicy.OnSubmissionFailureRetries + 1))
 
 			By("Only valid statuses appear in other apps")
@@ -640,4 +676,5 @@ var _ = Describe("Example SparkApplication", func() {
 			checkVolumeAndMount(*driverPod, common.SparkDriverContainerName)
 		})
 	})
+
 })

--- a/test/e2e/ssrf_test.go
+++ b/test/e2e/ssrf_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+// The e2e deployments enable URL-scheme validation through Helm CI values and the
+// Kustomize e2e overlay. Dry-run reaches admission without persisting an app or
+// running spark-submit, so these tests prove validation wiring, not runtime egress denial.
+var _ = Describe("SSRF admission", func() {
+	ctx := context.Background()
+
+	newApp := func(name, mainApplicationFile string) *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				Type:                v1beta2.SparkApplicationTypeScala,
+				SparkVersion:        "3.5.0",
+				Mode:                v1beta2.DeployModeCluster,
+				MainApplicationFile: &mainApplicationFile,
+				Driver: v1beta2.DriverSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores:  ptr.To[int32](1),
+						Memory: ptr.To("512m"),
+					},
+				},
+				Executor: v1beta2.ExecutorSpec{
+					SparkPodSpec: v1beta2.SparkPodSpec{
+						Cores:  ptr.To[int32](1),
+						Memory: ptr.To("512m"),
+					},
+					Instances: ptr.To[int32](1),
+				},
+			},
+		}
+	}
+
+	Context("URL scheme and host policy", func() {
+		DescribeTable("rejects a disallowed HTTP URL in each submit-time field family",
+			func(name, expectedField string, configure func(*v1beta2.SparkApplication)) {
+				app := newApp(name, "local:///app.py")
+				configure(app)
+
+				err := k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(), "expected Invalid or Forbidden, got: %v", err)
+				Expect(err.Error()).To(ContainSubstring(expectedField))
+				Expect(err.Error()).To(ContainSubstring("http"))
+				Expect(err.Error()).To(ContainSubstring("not in the allowed list"))
+			},
+			Entry("main application file", "ssrf-main-file", "spec.mainApplicationFile", func(app *v1beta2.SparkApplication) {
+				mainApplicationFile := "http://attacker.example.com/app.py"
+				app.Spec.MainApplicationFile = &mainApplicationFile
+			}),
+			Entry("dependency repository", "ssrf-repository", "spec.deps.repositories", func(app *v1beta2.SparkApplication) {
+				app.Spec.Deps.Repositories = []string{"http://attacker.example.com/maven"}
+			}),
+			Entry("Spark configuration", "ssrf-spark-conf", `spec.sparkConf["spark.jars"]`, func(app *v1beta2.SparkApplication) {
+				app.Spec.SparkConf = map[string]string{"spark.jars": "http://attacker.example.com/evil.jar"}
+			}),
+		)
+
+		It("accepts local URLs and an artifact upload destination", func() {
+			app := newApp("ssrf-local-url", "local:///app.py")
+			app.Spec.SparkConf = map[string]string{
+				"spark.jars":                        "file:///opt/spark/jars/app.jar",
+				"spark.kubernetes.file.upload.path": "s3a://artifact-bucket/submissions",
+			}
+
+			Expect(k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})).To(Succeed())
+		})
+
+		It("accepts a remote URL with an allowed scheme-qualified host", func() {
+			app := newApp("ssrf-allowed-host", "https://test1.example.com/app.py")
+
+			Expect(k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})).To(Succeed())
+		})
+
+		It("rejects a remote URL with an allowed scheme but a different host", func() {
+			app := newApp("ssrf-disallowed-host", "https://attacker.example.com/app.py")
+
+			err := k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(), "expected Invalid or Forbidden, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("spec.mainApplicationFile"))
+			Expect(err.Error()).To(ContainSubstring("attacker.example.com"))
+			Expect(err.Error()).To(ContainSubstring("not in the allowed list"))
+		})
+
+		DescribeTable("rejects authority-bearing local URL forms",
+			func(name, mainApplicationFile string) {
+				app := newApp(name, mainApplicationFile)
+
+				err := k8sClient.Create(ctx, app, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(), "expected Invalid or Forbidden, got: %v", err)
+				Expect(err.Error()).To(ContainSubstring("spec.mainApplicationFile"))
+				Expect(err.Error()).To(ContainSubstring("not in the allowed list"))
+			},
+			Entry("file URL", "ssrf-file-host", "file://attacker.example.com/app.py"),
+			Entry("local URL", "ssrf-local-host", "local://attacker.example.com/app.py"),
+		)
+
+		It("rejects a disallowed URL in a scheduled application template", func() {
+			app := newApp("ssrf-scheduled", "local:///app.py")
+			mainApplicationFile := "http://attacker.example.com/app.py"
+			app.Spec.MainApplicationFile = &mainApplicationFile
+			scheduledApp := &v1beta2.ScheduledSparkApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ssrf-scheduled",
+					Namespace: "default",
+				},
+				Spec: v1beta2.ScheduledSparkApplicationSpec{
+					Schedule: "@every 1h",
+					Template: app.Spec,
+				},
+			}
+
+			err := k8sClient.Create(ctx, scheduledApp, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(BeTrue(), "expected Invalid or Forbidden, got: %v", err)
+			Expect(err.Error()).To(ContainSubstring("spec.template.mainApplicationFile"))
+			Expect(err.Error()).To(ContainSubstring("http"))
+			Expect(err.Error()).To(ContainSubstring("not in the allowed list"))
+		})
+	})
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -222,10 +222,10 @@ func uninstallViaHelm() {
 
 func installViaKustomize() {
 	repoRoot := filepath.Join("..", "..")
-	// Deploy the driver-pdb overlay so e2e exercises the --enable-driver-pdb
-	// feature, matching the helm ci-values.yaml (driverPodDisruptionBudget.enable=true).
-	// The overlay inherits config/default, including the image tag we rewrite below.
-	kustomizeDir := filepath.Join(repoRoot, "config", "overlays", "driver-pdb")
+	// Deploy the e2e overlay so Kustomize exercises the same opt-in features as
+	// the Helm CI values: driver PDB creation and URL-scheme validation. The overlay
+	// inherits config/default, including the image tag we rewrite below.
+	kustomizeDir := filepath.Join(repoRoot, "config", "overlays", "e2e")
 	kustomizationPath := filepath.Join(repoRoot, "config", "default", "kustomization.yaml")
 
 	imageTag := os.Getenv("IMAGE_TAG")
@@ -284,7 +284,7 @@ func uninstallViaKustomize() {
 	rbacDelCmd.Stderr = GinkgoWriter
 	_ = rbacDelCmd.Run()
 
-	kustomizeDir := filepath.Join(repoRoot, "config", "overlays", "driver-pdb")
+	kustomizeDir := filepath.Join(repoRoot, "config", "overlays", "e2e")
 	By("Uninstalling the Spark operator via Kustomize")
 	deleteCmd := exec.Command("kubectl", "delete", "-k", kustomizeDir, "--ignore-not-found", "--timeout=120s")
 	deleteCmd.Stdout = GinkgoWriter


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://www.kubeflow.org/docs/components/spark-operator/developer-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

spark-submit runs inside the operator pod, so any http/https/etc. URL in a
fetch-capable SparkApplication field (spec.mainApplicationFile, spec.sparkConf
values, spec.deps.{jars,files,pyFiles,archives,repositories}) is dereferenced by
the operator's principal: its ServiceAccount, mounted secrets, Workload Identity
/ IRSA, and VPC reachability. That is SSRF. The validating webhook previously did
not inspect these fields and there was no operator-side knob to restrict them.

This adds an admission-time check that validates the URL scheme of every value in
those fields. Schemeless paths and file://, local:// URIs are always allowed (they
reference local or in-image files the operator never fetches); any other scheme
must appear in the operator's allow list or the SparkApplication is rejected with
an error naming the offending field, scheme, and value. The check is value-based
rather than key-based so it stays Spark-version independent and cannot be silently
bypassed by a newly fetch-capable conf key.

Fixes #2963.

**Proposed changes:**

- Add --spark-allowed-url-schemes webhook flag and matching
  webhook.sparkAllowedURLSchemes Helm value (default empty: only schemeless,
  file://, local:// pass; add gs, s3a, hdfs, etc. as needed).
- Check spec.mainApplicationFile, spec.sparkConf (comma-split), and the
  fetch-capable spec.deps.* lists in SparkApplicationValidator.validateSpec.
  spec.deps.packages/excludePackages are excluded (Maven coordinates, not URLs).
- Fail closed: reject values url.Parse cannot handle and scheme-relative
  //host/path references that are not local paths.
- Cover the behavior with unit tests, a deps-field coverage guard, and an e2e
  rejection/acceptance spec; add a kind-e2e-test Make target.

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

A key-based allowlist drifts as Spark evolves and any miss is a silent bypass;
value-scheme checks are Spark-version independent. The default allows only local
references so the hardening is on by default, while operators opt into the remote
schemes their workloads actually need.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

spec.hadoopConf is intentionally out of scope: its values become spark.hadoop.*
config consumed by the driver/executor at runtime, not URLs the operator fetches
at submit time, and many are legitimately host/endpoint-shaped. The issue also
notes an exfil vector (spark-submit stderr propagated to Status.ErrorMessage and
Warning events); sanitizing those side channels is tracked separately.

Signed-off-by: Vincent Janelle <randomfrequency@gmail.com>
Co-authored-by: Claude <claude@anthropic.com>
