### PR TITLE
feat: garbage-collect terminated SparkApplications via operator default TTL

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -94,7 +94,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | hook.labels | object | `{}` | Extra labels for the Helm hook Job pod. |
 | hook.annotations | object | `{}` | Extra annotations for the Helm hook Job pod. |
 | controller.replicas | int | `1` | Number of replicas of controller. |
-| controller.featureGates | list | `[{"enabled":false,"name":"PartialRestart"},{"enabled":false,"name":"LoadSparkDefaults"},{"enabled":false,"name":"RestSubmitter"}]` | Feature gates to enable or disable specific features. |
+| controller.featureGates | list | `[{"enabled":false,"name":"PartialRestart"},{"enabled":false,"name":"LoadSparkDefaults"},{"enabled":false,"name":"RestSubmitter"},{"enabled":false,"name":"DefaultTimeToLive"}]` | Feature gates to enable or disable specific features. |
 | controller.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | controller.leaderElection.enable | bool | `true` | Specifies whether to enable leader election for controller. |
 | controller.leaderElection.leaseDuration | string | `"15s"` | Leader election lease duration. |
@@ -105,6 +105,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.logEncoder | string | `"console"` | Configure the encoder of logging, can be one of `console` or `json`. |
 | controller.driverPodCreationGracePeriod | string | `"10s"` | Grace period after a successful spark-submit when driver pod not found errors will be retried. Useful if the driver pod can take some time to be created. |
 | controller.maxTrackedExecutorPerApp | int | `1000` | Specifies the maximum number of Executor pods that can be tracked by the controller per SparkApplication. |
+| controller.defaultTimeToLiveSeconds | int | `0` | Default Time-To-Live (in seconds) applied to terminated SparkApplications that do not set spec.timeToLiveSeconds. Requires the DefaultTimeToLive feature gate to be enabled. 0 (default) disables it. |
 | controller.driverPodDisruptionBudget | object | `{"enable":false}` | Driver PDB feature gate. When true, the controller creates a PodDisruptionBudget for each SparkApplication that sets spec.driverPodDisruptionBudget=true. Default false. |
 | controller.kubeAPIQPS | int | `20` | Maximum QPS to the API server from the controller client. |
 | controller.kubeAPIBurst | int | `30` | Maximum burst for throttle from the controller client. |

--- a/charts/spark-operator-chart/templates/_helpers.tpl
+++ b/charts/spark-operator-chart/templates/_helpers.tpl
@@ -85,3 +85,12 @@ Whether the RestSubmitter feature gate is enabled.
 {{- if and (eq .name "RestSubmitter") .enabled -}}true{{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Whether the DefaultTimeToLive feature gate is enabled.
+*/}}
+{{- define "spark-operator.defaultTimeToLive.enabled" -}}
+{{- range .Values.controller.featureGates -}}
+{{- if and (eq .name "DefaultTimeToLive") .enabled -}}true{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -132,7 +132,7 @@ spec:
         {{- if .Values.controller.maxTrackedExecutorPerApp }}
         - --max-tracked-executor-per-app={{ .Values.controller.maxTrackedExecutorPerApp }}
         {{- end }}
-        {{- if .Values.controller.defaultTimeToLiveSeconds }}
+        {{- if gt (int .Values.controller.defaultTimeToLiveSeconds) 0 }}
         - --default-time-to-live-seconds={{ .Values.controller.defaultTimeToLiveSeconds }}
         {{- end }}
         {{- if .Values.controller.driverPodDisruptionBudget.enable }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -132,7 +132,7 @@ spec:
         {{- if .Values.controller.maxTrackedExecutorPerApp }}
         - --max-tracked-executor-per-app={{ .Values.controller.maxTrackedExecutorPerApp }}
         {{- end }}
-        {{- if gt (int .Values.controller.defaultTimeToLiveSeconds) 0 }}
+        {{- if and (include "spark-operator.defaultTimeToLive.enabled" .) (gt (int .Values.controller.defaultTimeToLiveSeconds) 0) }}
         - --default-time-to-live-seconds={{ .Values.controller.defaultTimeToLiveSeconds }}
         {{- end }}
         {{- if .Values.controller.driverPodDisruptionBudget.enable }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -132,6 +132,9 @@ spec:
         {{- if .Values.controller.maxTrackedExecutorPerApp }}
         - --max-tracked-executor-per-app={{ .Values.controller.maxTrackedExecutorPerApp }}
         {{- end }}
+        {{- if .Values.controller.defaultTimeToLiveSeconds }}
+        - --default-time-to-live-seconds={{ .Values.controller.defaultTimeToLiveSeconds }}
+        {{- end }}
         {{- if .Values.controller.driverPodDisruptionBudget.enable }}
         - --enable-driver-pdb=true
         {{- end }}

--- a/charts/spark-operator-chart/templates/controller/deployment.yaml
+++ b/charts/spark-operator-chart/templates/controller/deployment.yaml
@@ -132,7 +132,7 @@ spec:
         {{- if .Values.controller.maxTrackedExecutorPerApp }}
         - --max-tracked-executor-per-app={{ .Values.controller.maxTrackedExecutorPerApp }}
         {{- end }}
-        {{- if and (include "spark-operator.defaultTimeToLive.enabled" .) (gt (int .Values.controller.defaultTimeToLiveSeconds) 0) }}
+        {{- if and (include "spark-operator.defaultTimeToLive.enabled" .) (ge (int .Values.controller.defaultTimeToLiveSeconds) 0) }}
         - --default-time-to-live-seconds={{ .Values.controller.defaultTimeToLiveSeconds }}
         {{- end }}
         {{- if .Values.controller.driverPodDisruptionBudget.enable }}

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -177,28 +177,58 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --controller-threads=30
 
-  - it: Should contain `--default-time-to-live-seconds` arg if `controller.defaultTimeToLiveSeconds` is set
+  - it: Should contain `--default-time-to-live-seconds` arg if `controller.defaultTimeToLiveSeconds` is set and the `DefaultTimeToLive` feature gate is enabled
     set:
       controller:
         defaultTimeToLiveSeconds: 86400
+        featureGates:
+          - name: DefaultTimeToLive
+            enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --default-time-to-live-seconds=86400
 
-  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is 0
+  - it: Should not contain `--default-time-to-live-seconds` arg when the `DefaultTimeToLive` feature gate is disabled even if `controller.defaultTimeToLiveSeconds` is set
+    set:
+      controller:
+        defaultTimeToLiveSeconds: 86400
+        featureGates:
+          - name: DefaultTimeToLive
+            enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --default-time-to-live-seconds=86400
+
+  - it: Should not contain `--default-time-to-live-seconds` arg when the `DefaultTimeToLive` feature gate is not set even if `controller.defaultTimeToLiveSeconds` is set
+    set:
+      controller:
+        defaultTimeToLiveSeconds: 86400
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --default-time-to-live-seconds=86400
+
+  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is 0 and the `DefaultTimeToLive` feature gate is enabled
     set:
       controller:
         defaultTimeToLiveSeconds: 0
+        featureGates:
+          - name: DefaultTimeToLive
+            enabled: true
     asserts:
       - notContains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --default-time-to-live-seconds=0
 
-  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is negative
+  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is negative and the `DefaultTimeToLive` feature gate is enabled
     set:
       controller:
         defaultTimeToLiveSeconds: -1
+        featureGates:
+          - name: DefaultTimeToLive
+            enabled: true
     asserts:
       - notContains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -177,6 +177,24 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --controller-threads=30
 
+  - it: Should contain `--default-time-to-live-seconds` arg if `controller.defaultTimeToLiveSeconds` is set
+    set:
+      controller:
+        defaultTimeToLiveSeconds: 86400
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --default-time-to-live-seconds=86400
+
+  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is 0
+    set:
+      controller:
+        defaultTimeToLiveSeconds: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --default-time-to-live-seconds=0
+
   - it: Should contain `--enable-ui-service` arg if `controller.uiService.enable` is set to `true`
     set:
       controller:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -195,6 +195,15 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --default-time-to-live-seconds=0
 
+  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is negative
+    set:
+      controller:
+        defaultTimeToLiveSeconds: -1
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
+          content: --default-time-to-live-seconds=-1
+
   - it: Should contain `--enable-ui-service` arg if `controller.uiService.enable` is set to `true`
     set:
       controller:

--- a/charts/spark-operator-chart/tests/controller/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/controller/deployment_test.yaml
@@ -210,7 +210,7 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --default-time-to-live-seconds=86400
 
-  - it: Should not contain `--default-time-to-live-seconds` arg when `controller.defaultTimeToLiveSeconds` is 0 and the `DefaultTimeToLive` feature gate is enabled
+  - it: Should contain `--default-time-to-live-seconds=0` arg when `controller.defaultTimeToLiveSeconds` is 0 and the `DefaultTimeToLive` feature gate is enabled
     set:
       controller:
         defaultTimeToLiveSeconds: 0
@@ -218,7 +218,7 @@ tests:
           - name: DefaultTimeToLive
             enabled: true
     asserts:
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-controller")].args
           content: --default-time-to-live-seconds=0
 

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -95,6 +95,8 @@ controller:
     enabled: false
   - name: RestSubmitter
     enabled: false
+  - name: DefaultTimeToLive
+    enabled: false
 
   # -- The number of old history to retain to allow rollback.
   revisionHistoryLimit: 10
@@ -123,6 +125,11 @@ controller:
 
   # -- Specifies the maximum number of Executor pods that can be tracked by the controller per SparkApplication.
   maxTrackedExecutorPerApp: 1000
+
+  # -- Default Time-To-Live (in seconds) applied to terminated SparkApplications that do not
+  # set spec.timeToLiveSeconds. Requires the DefaultTimeToLive feature gate to be enabled.
+  # 0 (default) disables it.
+  defaultTimeToLiveSeconds: 0
 
   # -- Driver PDB feature gate. When true, the controller creates a PodDisruptionBudget for each SparkApplication that sets spec.driverPodDisruptionBudget=true. Default false.
   driverPodDisruptionBudget:

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -193,6 +193,10 @@ func NewStartCommand() *cobra.Command {
 				}
 			}
 
+			if features.Enabled(features.DefaultTimeToLive) && defaultTimeToLiveSeconds <= 0 {
+				return fmt.Errorf("invalid value %d for --default-time-to-live-seconds, must be a positive value when the DefaultTimeToLive feature gate is enabled", defaultTimeToLiveSeconds)
+			}
+
 			return nil
 		},
 		Run: func(_ *cobra.Command, args []string) {
@@ -289,6 +293,13 @@ func NewStartCommand() *cobra.Command {
 
 func start() {
 	setupLog()
+
+	// The flag is ignored unless the DefaultTimeToLive feature gate is enabled. Warn
+	// here (rather than in PreRunE) because the logger is only initialized by setupLog.
+	if defaultTimeToLiveSeconds > 0 && !features.Enabled(features.DefaultTimeToLive) {
+		logger.Info("Ignoring --default-time-to-live-seconds because the DefaultTimeToLive feature gate is disabled",
+			"defaultTimeToLiveSeconds", defaultTimeToLiveSeconds)
+	}
 
 	// Create the client rest config. Use kubeConfig if given, otherwise assume in-cluster.
 	cfg, err := ctrl.GetConfig()

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -85,6 +85,7 @@ var (
 	controllerThreads        int
 	cacheSyncTimeout         time.Duration
 	maxTrackedExecutorPerApp int
+	defaultTimeToLiveSeconds int64
 
 	// Driver PDB feature gate. When enabled, the controller creates a
 	// PodDisruptionBudget for each SparkApplication that sets
@@ -205,6 +206,10 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&namespaceSelector, "namespace-selector", "", "Label selector for namespaces to watch (e.g., 'spark-operator=enabled,env in (prod,staging)'). Namespaces matching this selector will be watched in addition to those specified via --namespaces. Requires ClusterRole permission to list and watch namespaces.")
 	command.Flags().DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 30*time.Second, "Informer cache sync timeout.")
 	command.Flags().IntVar(&maxTrackedExecutorPerApp, "max-tracked-executor-per-app", 1000, "The maximum number of tracked executors per SparkApplication.")
+	command.Flags().Int64Var(&defaultTimeToLiveSeconds, "default-time-to-live-seconds", 0,
+		"Default Time-To-Live in seconds applied to terminated SparkApplications that do "+
+			"not set spec.timeToLiveSeconds. Requires the DefaultTimeToLive feature gate. "+
+			"0 (default) or negative disables it.")
 	command.Flags().BoolVar(&enableDriverPDB, "enable-driver-pdb", false,
 		"Enable creation of a PodDisruptionBudget for Spark driver pods. "+
 			"Each SparkApplication must additionally opt in via "+
@@ -528,6 +533,7 @@ func newSparkApplicationReconcilerOptions() sparkapplication.Options {
 		SparkExecutorMetrics:         sparkExecutorMetrics,
 		MaxTrackedExecutorPerApp:     maxTrackedExecutorPerApp,
 		EnableDriverPDB:              enableDriverPDB,
+		DefaultTimeToLiveSeconds:     defaultTimeToLiveSeconds,
 	}
 	if enableBatchScheduler {
 		options.KubeSchedulerNames = kubeSchedulerNames

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -296,11 +296,14 @@ func NewStartCommand() *cobra.Command {
 func start() {
 	setupLog()
 
-	// The flag is ignored unless the DefaultTimeToLive feature gate is enabled. Warn
-	// here (rather than in PreRunE) because the logger is only initialized by setupLog.
-	if defaultTimeToLiveSeconds > 0 && !features.Enabled(features.DefaultTimeToLive) {
-		logger.Info("Ignoring --default-time-to-live-seconds because the DefaultTimeToLive feature gate is disabled",
-			"defaultTimeToLiveSeconds", defaultTimeToLiveSeconds)
+	// Normalize the configured TTL before passing it to the controller so downstream
+	// cleanup logic does not need to depend on the global feature gate.
+	if !features.Enabled(features.DefaultTimeToLive) {
+		if defaultTimeToLiveSeconds > 0 {
+			logger.Info("Ignoring --default-time-to-live-seconds because the DefaultTimeToLive feature gate is disabled",
+				"defaultTimeToLiveSeconds", defaultTimeToLiveSeconds)
+		}
+		defaultTimeToLiveSeconds = 0
 	}
 
 	// Create the client rest config. Use kubeConfig if given, otherwise assume in-cluster.

--- a/cmd/operator/controller/start.go
+++ b/cmd/operator/controller/start.go
@@ -193,8 +193,10 @@ func NewStartCommand() *cobra.Command {
 				}
 			}
 
-			if features.Enabled(features.DefaultTimeToLive) && defaultTimeToLiveSeconds <= 0 {
-				return fmt.Errorf("invalid value %d for --default-time-to-live-seconds, must be a positive value when the DefaultTimeToLive feature gate is enabled", defaultTimeToLiveSeconds)
+			// A negative TTL is never meaningful; reject it regardless of the gate.
+			// Zero is the valid "off" sentinel and is left untouched.
+			if defaultTimeToLiveSeconds < 0 {
+				return fmt.Errorf("invalid value %d for --default-time-to-live-seconds, must not be negative", defaultTimeToLiveSeconds)
 			}
 
 			return nil
@@ -213,7 +215,7 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().Int64Var(&defaultTimeToLiveSeconds, "default-time-to-live-seconds", 0,
 		"Default Time-To-Live in seconds applied to terminated SparkApplications that do "+
 			"not set spec.timeToLiveSeconds. Requires the DefaultTimeToLive feature gate. "+
-			"0 (default) or negative disables it.")
+			"0 (default) disables it; a negative value is rejected.")
 	command.Flags().BoolVar(&enableDriverPDB, "enable-driver-pdb", false,
 		"Enable creation of a PodDisruptionBudget for Spark driver pods. "+
 			"Each SparkApplication must additionally opt in via "+

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,7 +87,7 @@ spec:
             - --max-tracked-executor-per-app=1000
             - --kube-api-qps=20
             - --kube-api-burst=30
-            - --feature-gates=PartialRestart=false,LoadSparkDefaults=false,RestSubmitter=false
+            - --feature-gates=PartialRestart=false,LoadSparkDefaults=false,RestSubmitter=false,DefaultTimeToLive=false
             - --scheduled-spark-application-timestamp-precision=nanos
           env:
             - name: OPERATOR_VERSION

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -78,6 +78,12 @@ type Options struct {
 	// When false, the reconciler will not create or delete a PDB regardless of
 	// the SparkApplication spec. Defaults to false.
 	EnableDriverPDB bool
+
+	// DefaultTimeToLiveSeconds is the operator-wide default TTL (in seconds) applied to
+	// terminated SparkApplications that do not set spec.timeToLiveSeconds. Only honored
+	// when the DefaultTimeToLive feature gate is enabled and the value is > 0. Applied as
+	// a runtime fallback for the cleanup decision; the object's spec is never modified.
+	DefaultTimeToLiveSeconds int64
 }
 
 // Reconciler reconciles a SparkApplication object.

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -707,16 +707,6 @@ func (r *Reconciler) reconcileFailedSparkApplication(ctx context.Context, req ct
 	return r.reconcileTerminatedSparkApplication(ctx, req)
 }
 
-// isExpiredWithTTL reports whether the terminated SparkApplication has outlived the
-// given effective TTL (which may originate from the spec or the operator default).
-func isExpiredWithTTL(app *v1beta2.SparkApplication, ttlSeconds *int64) bool {
-	if ttlSeconds == nil || *ttlSeconds <= 0 || app.Status.TerminationTime.IsZero() {
-		return false
-	}
-	ttl := time.Duration(*ttlSeconds) * time.Second
-	return time.Since(app.Status.TerminationTime.Time) > ttl
-}
-
 func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	key := req.NamespacedName
@@ -736,7 +726,7 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 			"ttlSeconds", *effectiveTTLSeconds, "state", app.Status.AppState.State)
 	}
 
-	if isExpiredWithTTL(app, effectiveTTLSeconds) {
+	if util.IsExpiredWithTTL(app, effectiveTTLSeconds) {
 		logger.Info("Deleting expired SparkApplication", "state", app.Status.AppState.State)
 		if err := r.client.Delete(ctx, app); err != nil {
 			return ctrl.Result{Requeue: true}, err

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -275,6 +275,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Optio
 		mgr.GetEventRecorder("spark-application-event-handler"),
 		r.options.Namespaces,
 		r.options.NamespaceSelector,
+		r.options.DefaultTimeToLiveSeconds,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create spark application event filter: %v", err)
@@ -721,13 +722,14 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 	}
 
 	effectiveTTLSeconds, usedDefault := util.EffectiveTimeToLiveSeconds(app, r.options.DefaultTimeToLiveSeconds)
-	if usedDefault {
-		logger.Info("Applying operator default TTL to terminated SparkApplication",
-			"ttlSeconds", *effectiveTTLSeconds, "state", app.Status.AppState.State)
-	}
 
 	if util.IsExpiredWithTTL(app, effectiveTTLSeconds) {
-		logger.Info("Deleting expired SparkApplication", "state", app.Status.AppState.State)
+		if usedDefault {
+			logger.Info("Deleting expired SparkApplication using operator default TTL",
+				"ttlSeconds", *effectiveTTLSeconds, "state", app.Status.AppState.State)
+		} else {
+			logger.Info("Deleting expired SparkApplication", "state", app.Status.AppState.State)
+		}
 		if err := r.client.Delete(ctx, app); err != nil {
 			return ctrl.Result{Requeue: true}, err
 		}

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -707,6 +707,16 @@ func (r *Reconciler) reconcileFailedSparkApplication(ctx context.Context, req ct
 	return r.reconcileTerminatedSparkApplication(ctx, req)
 }
 
+// isExpiredWithTTL reports whether the terminated SparkApplication has outlived the
+// given effective TTL (which may originate from the spec or the operator default).
+func isExpiredWithTTL(app *v1beta2.SparkApplication, ttlSeconds *int64) bool {
+	if ttlSeconds == nil || *ttlSeconds <= 0 || app.Status.TerminationTime.IsZero() {
+		return false
+	}
+	ttl := time.Duration(*ttlSeconds) * time.Second
+	return time.Since(app.Status.TerminationTime.Time) > ttl
+}
+
 func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	key := req.NamespacedName
@@ -720,7 +730,13 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 		return ctrl.Result{}, nil
 	}
 
-	if util.IsExpired(app) {
+	effectiveTTLSeconds, usedDefault := util.EffectiveTimeToLiveSeconds(app, r.options.DefaultTimeToLiveSeconds)
+	if usedDefault {
+		logger.Info("Applying operator default TTL to terminated SparkApplication",
+			"ttlSeconds", *effectiveTTLSeconds, "state", app.Status.AppState.State)
+	}
+
+	if isExpiredWithTTL(app, effectiveTTLSeconds) {
 		logger.Info("Deleting expired SparkApplication", "state", app.Status.AppState.State)
 		if err := r.client.Delete(ctx, app); err != nil {
 			return ctrl.Result{Requeue: true}, err
@@ -741,14 +757,14 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	// If termination time or TTL is not set, will not requeue this application.
-	if app.Status.TerminationTime.IsZero() || app.Spec.TimeToLiveSeconds == nil || *app.Spec.TimeToLiveSeconds <= 0 {
+	// If termination time or effective TTL is not set, will not requeue this application.
+	if app.Status.TerminationTime.IsZero() || effectiveTTLSeconds == nil || *effectiveTTLSeconds <= 0 {
 		return ctrl.Result{}, nil
 	}
 
 	// Otherwise, requeue the application for subsequent deletion.
 	now := time.Now()
-	ttl := time.Duration(*app.Spec.TimeToLiveSeconds) * time.Second
+	ttl := time.Duration(*effectiveTTLSeconds) * time.Second
 	survival := now.Sub(app.Status.TerminationTime.Time)
 
 	// If survival time is greater than TTL, requeue the application immediately.

--- a/internal/controller/sparkapplication/controller.go
+++ b/internal/controller/sparkapplication/controller.go
@@ -79,10 +79,9 @@ type Options struct {
 	// the SparkApplication spec. Defaults to false.
 	EnableDriverPDB bool
 
-	// DefaultTimeToLiveSeconds is the operator-wide default TTL (in seconds) applied to
-	// terminated SparkApplications that do not set spec.timeToLiveSeconds. Only honored
-	// when the DefaultTimeToLive feature gate is enabled and the value is > 0. Applied as
-	// a runtime fallback for the cleanup decision; the object's spec is never modified.
+	// DefaultTimeToLiveSeconds is the normalized operator-wide default TTL (in seconds)
+	// applied to terminated SparkApplications that do not set spec.timeToLiveSeconds when
+	// the value is > 0. It is a cleanup-only fallback and never modifies the spec.
 	DefaultTimeToLiveSeconds int64
 }
 
@@ -723,7 +722,7 @@ func (r *Reconciler) reconcileTerminatedSparkApplication(ctx context.Context, re
 
 	effectiveTTLSeconds, usedDefault := util.EffectiveTimeToLiveSeconds(app, r.options.DefaultTimeToLiveSeconds)
 
-	if util.IsExpiredWithTTL(app, effectiveTTLSeconds) {
+	if util.IsExpired(app, effectiveTTLSeconds) {
 		if usedDefault {
 			logger.Info("Deleting expired SparkApplication using operator default TTL",
 				"ttlSeconds", *effectiveTTLSeconds, "state", app.Status.AppState.State)

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -548,8 +548,10 @@ var _ = Describe("SparkApplication Controller", func() {
 				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
 			})
 
+			// Create the SparkApplication if it does not already exist.
 			app := &v1beta2.SparkApplication{}
-			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+			err := k8sClient.Get(ctx, key, app)
+			if errors.IsNotFound(err) {
 				app = &v1beta2.SparkApplication{
 					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
 					Spec: v1beta2.SparkApplicationSpec{
@@ -558,11 +560,16 @@ var _ = Describe("SparkApplication Controller", func() {
 				}
 				v1beta2.SetSparkApplicationDefaults(app)
 				Expect(k8sClient.Create(ctx, app)).To(Succeed())
-
-				app.Status.AppState.State = v1beta2.ApplicationStateCompleted
-				app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-2 * time.Minute))
-				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
+
+			// Unconditionally drive the app into a terminated state whose TTL has already
+			// elapsed, so the precondition holds regardless of any pre-existing object.
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			app.Status.AppState.State = v1beta2.ApplicationStateCompleted
+			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-2 * time.Minute))
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/internal/controller/sparkapplication"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/features"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -528,6 +529,56 @@ var _ = Describe("SparkApplication Controller", func() {
 				nil,
 				&sparkapplication.SparkSubmitter{},
 				sparkapplication.Options{Namespaces: []string{appNamespace}},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+		})
+	})
+
+	Context("When reconciling a terminated SparkApplication with the operator default TTL", func() {
+		ctx := context.Background()
+		appName := "test-default-ttl"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+
+		BeforeEach(func() {
+			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
+			})
+
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err != nil && errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: ptr.To("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+				app.Status.AppState.State = v1beta2.ApplicationStateCompleted
+				app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-2 * time.Minute))
+				Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(errors.IsNotFound(k8sClient.Get(ctx, key, app))).To(BeTrue())
+		})
+
+		It("Should delete a terminated app past the operator default TTL when it has no spec TTL", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				nil,
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, DefaultTimeToLiveSeconds: 60},
 			)
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -593,6 +593,73 @@ var _ = Describe("SparkApplication Controller", func() {
 		})
 	})
 
+	Context("When reconciling a terminated SparkApplication that has not yet outlived the operator default TTL", func() {
+		ctx := context.Background()
+		appName := "test-default-ttl-not-expired"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+
+		BeforeEach(func() {
+			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
+			})
+
+			// Create the SparkApplication if it does not already exist.
+			app := &v1beta2.SparkApplication{}
+			err := k8sClient.Get(ctx, key, app)
+			if errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: ptr.To("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Terminate the app only 30s ago so it has not yet outlived a 60s default TTL.
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			app.Status.AppState.State = v1beta2.ApplicationStateCompleted
+			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-30 * time.Second))
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err == nil {
+				Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+			}
+		})
+
+		It("Should not delete the app and should requeue it for later deletion using the effective TTL", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				nil,
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, DefaultTimeToLiveSeconds: 60},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The app has not yet expired, so it must be requeued (not deleted immediately)
+			// after roughly the remaining TTL (60s TTL - ~30s survived).
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeNumerically(">", time.Duration(0)))
+			Expect(result.RequeueAfter).To(BeNumerically("<=", 30*time.Second))
+
+			// The app must still exist.
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+		})
+	})
+
 	Context("When reconciling a failed SparkApplication", func() {
 		ctx := context.Background()
 		appName := "test"

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -660,6 +660,72 @@ var _ = Describe("SparkApplication Controller", func() {
 		})
 	})
 
+	Context("When reconciling a terminated SparkApplication with the operator default TTL disabled by a zero value", func() {
+		ctx := context.Background()
+		appName := "test-default-ttl-zero"
+		appNamespace := "default"
+		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
+
+		BeforeEach(func() {
+			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
+			})
+
+			// Create the SparkApplication if it does not already exist.
+			app := &v1beta2.SparkApplication{}
+			err := k8sClient.Get(ctx, key, app)
+			if errors.IsNotFound(err) {
+				app = &v1beta2.SparkApplication{
+					ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: appNamespace},
+					Spec: v1beta2.SparkApplicationSpec{
+						MainApplicationFile: ptr.To("local:///dummy.jar"),
+					},
+				}
+				v1beta2.SetSparkApplicationDefaults(app)
+				Expect(k8sClient.Create(ctx, app)).To(Succeed())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Terminate the app well in the past; a zero default TTL must still leave it alone.
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+			app.Status.AppState.State = v1beta2.ApplicationStateCompleted
+			app.Status.TerminationTime = metav1.NewTime(time.Now().Add(-2 * time.Minute))
+			Expect(k8sClient.Status().Update(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			app := &v1beta2.SparkApplication{}
+			if err := k8sClient.Get(ctx, key, app); err == nil {
+				Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+			}
+		})
+
+		It("Should not delete or requeue the app when the default TTL is zero even with the gate enabled", func() {
+			reconciler := sparkapplication.NewReconciler(
+				nil,
+				k8sClient.Scheme(),
+				k8sClient,
+				nil,
+				nil,
+				&sparkapplication.SparkSubmitter{},
+				sparkapplication.Options{Namespaces: []string{appNamespace}, DefaultTimeToLiveSeconds: 0},
+			)
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// A zero default TTL disables the feature: no default is applied, so the app is
+			// neither deleted nor requeued for later deletion.
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			// The app must still exist.
+			app := &v1beta2.SparkApplication{}
+			Expect(k8sClient.Get(ctx, key, app)).To(Succeed())
+		})
+	})
+
 	Context("When reconciling a failed SparkApplication", func() {
 		ctx := context.Background()
 		appName := "test"

--- a/internal/controller/sparkapplication/controller_test.go
+++ b/internal/controller/sparkapplication/controller_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/internal/controller/sparkapplication"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
-	"github.com/kubeflow/spark-operator/v2/pkg/features"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -543,11 +542,6 @@ var _ = Describe("SparkApplication Controller", func() {
 		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
 
 		BeforeEach(func() {
-			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
-			})
-
 			// Create the SparkApplication if it does not already exist.
 			app := &v1beta2.SparkApplication{}
 			err := k8sClient.Get(ctx, key, app)
@@ -600,11 +594,6 @@ var _ = Describe("SparkApplication Controller", func() {
 		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
 
 		BeforeEach(func() {
-			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
-			})
-
 			// Create the SparkApplication if it does not already exist.
 			app := &v1beta2.SparkApplication{}
 			err := k8sClient.Get(ctx, key, app)
@@ -667,11 +656,6 @@ var _ = Describe("SparkApplication Controller", func() {
 		key := types.NamespacedName{Name: appName, Namespace: appNamespace}
 
 		BeforeEach(func() {
-			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
-			})
-
 			// Create the SparkApplication if it does not already exist.
 			app := &v1beta2.SparkApplication{}
 			err := k8sClient.Get(ctx, key, app)
@@ -702,7 +686,7 @@ var _ = Describe("SparkApplication Controller", func() {
 			}
 		})
 
-		It("Should not delete or requeue the app when the default TTL is zero even with the gate enabled", func() {
+		It("Should not delete or requeue the app when the normalized default TTL is zero", func() {
 			reconciler := sparkapplication.NewReconciler(
 				nil,
 				k8sClient.Scheme(),

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -123,25 +123,27 @@ func (f *sparkPodEventFilter) filter(pod *corev1.Pod) bool {
 }
 
 type EventFilter struct {
-	client           client.Client
-	recorder         events.EventRecorder
-	namespaceMatcher *util.NamespaceMatcher
-	logger           logr.Logger
+	client                   client.Client
+	recorder                 events.EventRecorder
+	namespaceMatcher         *util.NamespaceMatcher
+	logger                   logr.Logger
+	defaultTimeToLiveSeconds int64
 }
 
 var _ predicate.Predicate = &EventFilter{}
 
-func NewSparkApplicationEventFilter(client client.Client, recorder events.EventRecorder, namespaces []string, namespaceSelector string) (*EventFilter, error) {
+func NewSparkApplicationEventFilter(client client.Client, recorder events.EventRecorder, namespaces []string, namespaceSelector string, defaultTimeToLiveSeconds int64) (*EventFilter, error) {
 	matcher, err := util.NewNamespaceMatcher(namespaces, namespaceSelector)
 	if err != nil {
 		return nil, err
 	}
 
 	return &EventFilter{
-		client:           client,
-		recorder:         recorder,
-		namespaceMatcher: matcher,
-		logger:           log.Log.WithName("spark-application-event-filter"),
+		client:                   client,
+		recorder:                 recorder,
+		namespaceMatcher:         matcher,
+		logger:                   log.Log.WithName("spark-application-event-filter"),
+		defaultTimeToLiveSeconds: defaultTimeToLiveSeconds,
 	}, nil
 }
 
@@ -171,7 +173,13 @@ func (f *EventFilter) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	if oldApp.ResourceVersion == newApp.ResourceVersion && !util.IsExpired(newApp) && !util.ShouldRetry(newApp) {
+	// On a no-op resync (same ResourceVersion), only re-admit the event when the
+	// application still needs action: it is expired (needs deletion) or should
+	// retry. Expiry uses the effective TTL so that an app expired via the
+	// operator default TTL is reconciled for deletion, consistent with the
+	// controller's own cleanup decision.
+	effectiveTTLSeconds, _ := util.EffectiveTimeToLiveSeconds(newApp, f.defaultTimeToLiveSeconds)
+	if oldApp.ResourceVersion == newApp.ResourceVersion && !util.IsExpiredWithTTL(newApp, effectiveTTLSeconds) && !util.ShouldRetry(newApp) {
 		return false
 	}
 

--- a/internal/controller/sparkapplication/event_filter.go
+++ b/internal/controller/sparkapplication/event_filter.go
@@ -179,7 +179,7 @@ func (f *EventFilter) Update(e event.UpdateEvent) bool {
 	// operator default TTL is reconciled for deletion, consistent with the
 	// controller's own cleanup decision.
 	effectiveTTLSeconds, _ := util.EffectiveTimeToLiveSeconds(newApp, f.defaultTimeToLiveSeconds)
-	if oldApp.ResourceVersion == newApp.ResourceVersion && !util.IsExpiredWithTTL(newApp, effectiveTTLSeconds) && !util.ShouldRetry(newApp) {
+	if oldApp.ResourceVersion == newApp.ResourceVersion && !util.IsExpired(newApp, effectiveTTLSeconds) && !util.ShouldRetry(newApp) {
 		return false
 	}
 

--- a/internal/controller/sparkapplication/event_filter_test.go
+++ b/internal/controller/sparkapplication/event_filter_test.go
@@ -18,6 +18,7 @@ package sparkapplication
 
 import (
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/features"
 )
 
 func TestIsWebhookPatchedFieldsOnlyChange(t *testing.T) {
@@ -939,7 +941,7 @@ func TestNewSparkApplicationEventFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector, 0)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("NewSparkApplicationEventFilter() expected error, got nil")
@@ -1046,7 +1048,7 @@ func TestSparkApplicationEventFilter_Create(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector, 0)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1073,7 +1075,7 @@ func TestSparkApplicationEventFilter_Create_NonSparkApplication(t *testing.T) {
 	_ = v1beta2.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	filter, _ := NewSparkApplicationEventFilter(fakeClient, nil, []string{"default"}, "")
+	filter, _ := NewSparkApplicationEventFilter(fakeClient, nil, []string{"default"}, "", 0)
 
 	// Test with a Pod instead of SparkApplication
 	pod := &corev1.Pod{
@@ -1120,7 +1122,7 @@ func TestSparkApplicationEventFilter_Update_TimeToLiveSecondsDoesNotInvalidate(t
 		WithStatusSubresource(&v1beta2.SparkApplication{}).
 		WithObjects(newApp.DeepCopy()).
 		Build()
-	filter, err := NewSparkApplicationEventFilter(fakeClient, events.NewFakeRecorder(10), []string{"default"}, "")
+	filter, err := NewSparkApplicationEventFilter(fakeClient, events.NewFakeRecorder(10), []string{"default"}, "", 0)
 	if err != nil {
 		t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 	}
@@ -1132,6 +1134,85 @@ func TestSparkApplicationEventFilter_Update_TimeToLiveSecondsDoesNotInvalidate(t
 	}
 	if newApp.Status.AppState.State == v1beta2.ApplicationStateInvalidating {
 		t.Errorf("Update() moved application to %s for TimeToLiveSeconds-only change", v1beta2.ApplicationStateInvalidating)
+	}
+}
+
+func TestSparkApplicationEventFilter_Update_ResyncReadmitsDefaultTTLExpired(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1beta2.AddToScheme(scheme)
+
+	// A terminated app with no spec TTL, terminated well in the past.
+	newApp := func() *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-app",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Spec: v1beta2.SparkApplicationSpec{
+				Type:         v1beta2.SparkApplicationTypeScala,
+				SparkVersion: "3.5.0",
+			},
+			Status: v1beta2.SparkApplicationStatus{
+				AppState: v1beta2.ApplicationState{
+					State: v1beta2.ApplicationStateCompleted,
+				},
+				TerminationTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+			},
+		}
+	}
+
+	tests := []struct {
+		name                     string
+		gateEnabled              bool
+		defaultTimeToLiveSeconds int64
+		expected                 bool
+	}{
+		{
+			// Without the operator default, a same-ResourceVersion resync of a
+			// terminated app with no spec TTL is dropped (unchanged legacy behavior).
+			name:                     "resync dropped when no operator default applies",
+			gateEnabled:              false,
+			defaultTimeToLiveSeconds: 3600,
+			expected:                 false,
+		},
+		{
+			// With the operator default enabled and the app past that TTL, the
+			// resync is re-admitted so the controller can delete it.
+			name:                     "resync re-admitted when expired via operator default",
+			gateEnabled:              true,
+			defaultTimeToLiveSeconds: 3600,
+			expected:                 true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := features.SetEnable(features.DefaultTimeToLive, tt.gateEnabled); err != nil {
+				t.Fatalf("features.SetEnable() unexpected error: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = features.SetEnable(features.DefaultTimeToLive, false)
+			})
+
+			app := newApp()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&v1beta2.SparkApplication{}).
+				WithObjects(app.DeepCopy()).
+				Build()
+			filter, err := NewSparkApplicationEventFilter(fakeClient, events.NewFakeRecorder(10), []string{"default"}, "", tt.defaultTimeToLiveSeconds)
+			if err != nil {
+				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
+			}
+
+			// Same ResourceVersion on both sides simulates a no-op resync.
+			result := filter.Update(event.UpdateEvent{ObjectOld: app.DeepCopy(), ObjectNew: app.DeepCopy()})
+			if result != tt.expected {
+				t.Errorf("Update() = %v, expected %v", result, tt.expected)
+			}
+		})
 	}
 }
 
@@ -1185,7 +1266,7 @@ func TestSparkApplicationEventFilter_Delete(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector, 0)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1256,7 +1337,7 @@ func TestSparkApplicationEventFilter_Generic(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, tt.namespaces, tt.namespaceSelector, 0)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1339,7 +1420,7 @@ func TestSparkApplicationEventFilter_MultipleLabelsSelector(t *testing.T) {
 				WithObjects(ns).
 				Build()
 
-			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, []string{}, tt.selector)
+			filter, err := NewSparkApplicationEventFilter(fakeClient, nil, []string{}, tt.selector, 0)
 			if err != nil {
 				t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 			}
@@ -1367,7 +1448,7 @@ func TestSparkApplicationEventFilter_NamespaceAll(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	// Empty namespaces list means watch all namespaces
-	filter, err := NewSparkApplicationEventFilter(fakeClient, nil, []string{}, "")
+	filter, err := NewSparkApplicationEventFilter(fakeClient, nil, []string{}, "", 0)
 	if err != nil {
 		t.Fatalf("NewSparkApplicationEventFilter() unexpected error: %v", err)
 	}

--- a/internal/controller/sparkapplication/event_filter_test.go
+++ b/internal/controller/sparkapplication/event_filter_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
-	"github.com/kubeflow/spark-operator/v2/pkg/features"
 )
 
 func TestIsWebhookPatchedFieldsOnlyChange(t *testing.T) {
@@ -1165,23 +1164,20 @@ func TestSparkApplicationEventFilter_Update_ResyncReadmitsDefaultTTLExpired(t *t
 
 	tests := []struct {
 		name                     string
-		gateEnabled              bool
 		defaultTimeToLiveSeconds int64
 		expected                 bool
 	}{
 		{
 			// Without the operator default, a same-ResourceVersion resync of a
 			// terminated app with no spec TTL is dropped (unchanged legacy behavior).
-			name:                     "resync dropped when no operator default applies",
-			gateEnabled:              false,
-			defaultTimeToLiveSeconds: 3600,
+			name:                     "resync dropped when normalized operator default is disabled",
+			defaultTimeToLiveSeconds: 0,
 			expected:                 false,
 		},
 		{
-			// With the operator default enabled and the app past that TTL, the
+			// With a normalized operator default and the app past that TTL, the
 			// resync is re-admitted so the controller can delete it.
 			name:                     "resync re-admitted when expired via operator default",
-			gateEnabled:              true,
 			defaultTimeToLiveSeconds: 3600,
 			expected:                 true,
 		},
@@ -1189,13 +1185,6 @@ func TestSparkApplicationEventFilter_Update_ResyncReadmitsDefaultTTLExpired(t *t
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := features.SetEnable(features.DefaultTimeToLive, tt.gateEnabled); err != nil {
-				t.Fatalf("features.SetEnable() unexpected error: %v", err)
-			}
-			t.Cleanup(func() {
-				_ = features.SetEnable(features.DefaultTimeToLive, false)
-			})
-
 			app := newApp()
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -49,6 +49,15 @@ const (
 	// owner: @venkomirisetti
 	// alpha: v2.6.0
 	RestSubmitter featuregate.Feature = "RestSubmitter"
+
+	// DefaultTimeToLive enables applying an operator-configured default TTL to
+	// terminated SparkApplications that do not set spec.timeToLiveSeconds. The
+	// value is used only for the cleanup decision (a runtime fallback) and never
+	// mutates the object.
+	//
+	// owner: @dineshkumar181094
+	// alpha: v2.6.0
+	DefaultTimeToLive featuregate.Feature = "DefaultTimeToLive"
 )
 
 // To add a new feature gate, follow these steps:
@@ -91,6 +100,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	LoadSparkDefaults: {Default: false, PreRelease: featuregate.Alpha},
 
 	RestSubmitter: {Default: false, PreRelease: featuregate.Alpha},
+
+	DefaultTimeToLive: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest sets the specified feature gate to the specified value during a test.

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -61,6 +61,14 @@ func TestSetEnableWithRegisteredFeature(t *testing.T) {
 	assert.False(t, Enabled(testFeature))
 }
 
+func TestDefaultTimeToLiveGateRegisteredAndOffByDefault(t *testing.T) {
+	// The gate must be registered (init ran) and default to disabled.
+	assert.False(t, Enabled(DefaultTimeToLive))
+
+	SetFeatureGateDuringTest(t, DefaultTimeToLive, true)
+	assert.True(t, Enabled(DefaultTimeToLive))
+}
+
 func TestSetFeatureGateDuringTestHelper(t *testing.T) {
 	// Register a test feature for this test
 	testFeature := featuregate.Feature("TestFeatureForDuringTest")

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/features"
 )
 
 // GetDriverPodName returns name of the driver pod of the given spark application.
@@ -74,6 +75,28 @@ func IsExpired(app *v1beta2.SparkApplication) bool {
 	}
 
 	return false
+}
+
+// EffectiveTimeToLiveSeconds returns the TTL (in seconds) that should govern cleanup
+// of the given SparkApplication, and whether the operator default (rather than the
+// user spec) was the source.
+//
+// Resolution order:
+//   - the user's spec.timeToLiveSeconds when set and > 0, else
+//   - the operator default when the DefaultTimeToLive feature gate is enabled and
+//     defaultSeconds > 0, else
+//   - nil, meaning "never expire".
+//
+// It never mutates the SparkApplication.
+func EffectiveTimeToLiveSeconds(app *v1beta2.SparkApplication, defaultSeconds int64) (*int64, bool) {
+	if app.Spec.TimeToLiveSeconds != nil && *app.Spec.TimeToLiveSeconds > 0 {
+		return app.Spec.TimeToLiveSeconds, false
+	}
+	if features.Enabled(features.DefaultTimeToLive) && defaultSeconds > 0 {
+		seconds := defaultSeconds
+		return &seconds, true
+	}
+	return nil, false
 }
 
 // IsDriverRunning returns whether the driver pod of the given SparkApplication is running.

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -61,14 +61,26 @@ func IsTerminated(app *v1beta2.SparkApplication) bool {
 		app.Status.AppState.State == v1beta2.ApplicationStateFailed
 }
 
-// IsExpired returns whether the given SparkApplication is expired.
+// IsExpired returns whether the given SparkApplication is expired according to its
+// own spec.timeToLiveSeconds.
 func IsExpired(app *v1beta2.SparkApplication) bool {
+	return IsExpiredWithTTL(app, app.Spec.TimeToLiveSeconds)
+}
+
+// IsExpiredWithTTL returns whether the given terminated SparkApplication has outlived
+// the provided TTL. The TTL may originate from the user's spec or from an
+// operator-configured default (see EffectiveTimeToLiveSeconds).
+//
+//   - A nil ttlSeconds means no TTL is defined: the application never expires.
+//   - A non-nil ttlSeconds that is <= 0 means the application expires immediately
+//     once it has a termination time.
+func IsExpiredWithTTL(app *v1beta2.SparkApplication, ttlSeconds *int64) bool {
 	// The application has no TTL defined and will never expire.
-	if app.Spec.TimeToLiveSeconds == nil {
+	if ttlSeconds == nil {
 		return false
 	}
 
-	ttl := time.Duration(*app.Spec.TimeToLiveSeconds) * time.Second
+	ttl := time.Duration(*ttlSeconds) * time.Second
 	now := time.Now()
 	if !app.Status.TerminationTime.IsZero() && now.Sub(app.Status.TerminationTime.Time) > ttl {
 		return true
@@ -82,14 +94,15 @@ func IsExpired(app *v1beta2.SparkApplication) bool {
 // user spec) was the source.
 //
 // Resolution order:
-//   - the user's spec.timeToLiveSeconds when set and > 0, else
+//   - the user's spec.timeToLiveSeconds whenever it is set (a value <= 0 is an
+//     explicit request to expire immediately and still wins), else
 //   - the operator default when the DefaultTimeToLive feature gate is enabled and
 //     defaultSeconds > 0, else
 //   - nil, meaning "never expire".
 //
 // It never mutates the SparkApplication.
 func EffectiveTimeToLiveSeconds(app *v1beta2.SparkApplication, defaultSeconds int64) (*int64, bool) {
-	if app.Spec.TimeToLiveSeconds != nil && *app.Spec.TimeToLiveSeconds > 0 {
+	if app.Spec.TimeToLiveSeconds != nil {
 		return app.Spec.TimeToLiveSeconds, false
 	}
 	if features.Enabled(features.DefaultTimeToLive) && defaultSeconds > 0 {

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
-	"github.com/kubeflow/spark-operator/v2/pkg/features"
 )
 
 // GetDriverPodName returns name of the driver pod of the given spark application.
@@ -61,20 +60,14 @@ func IsTerminated(app *v1beta2.SparkApplication) bool {
 		app.Status.AppState.State == v1beta2.ApplicationStateFailed
 }
 
-// IsExpired returns whether the given SparkApplication is expired according to its
-// own spec.timeToLiveSeconds.
-func IsExpired(app *v1beta2.SparkApplication) bool {
-	return IsExpiredWithTTL(app, app.Spec.TimeToLiveSeconds)
-}
-
-// IsExpiredWithTTL returns whether the given terminated SparkApplication has outlived
+// IsExpired returns whether the given terminated SparkApplication has outlived
 // the provided TTL. The TTL may originate from the user's spec or from an
 // operator-configured default (see EffectiveTimeToLiveSeconds).
 //
 //   - A nil ttlSeconds means no TTL is defined: the application never expires.
 //   - A non-nil ttlSeconds that is <= 0 means the application expires immediately
 //     once it has a termination time.
-func IsExpiredWithTTL(app *v1beta2.SparkApplication, ttlSeconds *int64) bool {
+func IsExpired(app *v1beta2.SparkApplication, ttlSeconds *int64) bool {
 	// The application has no TTL defined and will never expire.
 	if ttlSeconds == nil {
 		return false
@@ -96,8 +89,7 @@ func IsExpiredWithTTL(app *v1beta2.SparkApplication, ttlSeconds *int64) bool {
 // Resolution order:
 //   - the user's spec.timeToLiveSeconds whenever it is set (a value <= 0 is an
 //     explicit request to expire immediately and still wins), else
-//   - the operator default when the DefaultTimeToLive feature gate is enabled and
-//     defaultSeconds > 0, else
+//   - the operator default when defaultSeconds > 0, else
 //   - nil, meaning "never expire".
 //
 // It never mutates the SparkApplication.
@@ -105,7 +97,7 @@ func EffectiveTimeToLiveSeconds(app *v1beta2.SparkApplication, defaultSeconds in
 	if app.Spec.TimeToLiveSeconds != nil {
 		return app.Spec.TimeToLiveSeconds, false
 	}
-	if features.Enabled(features.DefaultTimeToLive) && defaultSeconds > 0 {
+	if defaultSeconds > 0 {
 		seconds := defaultSeconds
 		return &seconds, true
 	}

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/features"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -190,6 +191,66 @@ var _ = Describe("IsExpired", func() {
 
 		It("Should return true", func() {
 			Expect(util.IsExpired(app)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("EffectiveTimeToLiveSeconds", func() {
+	appWithTTL := func(ttl *int64) *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			Spec: v1beta2.SparkApplicationSpec{TimeToLiveSeconds: ttl},
+		}
+	}
+
+	Context("when the user sets spec.timeToLiveSeconds > 0", func() {
+		It("returns the user value regardless of the default or gate", func() {
+			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](3600)), 60)
+			Expect(ttl).NotTo(BeNil())
+			Expect(*ttl).To(Equal(int64(3600)))
+			Expect(usedDefault).To(BeFalse())
+		})
+	})
+
+	// enableGate toggles the DefaultTimeToLive feature gate for a single spec and
+	// restores it to disabled afterwards, keeping specs independent.
+	enableGate := func(enabled bool) {
+		Expect(features.SetEnable(features.DefaultTimeToLive, enabled)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
+		})
+	}
+
+	Context("when the gate is disabled", func() {
+		It("returns nil even though a positive default is configured", func() {
+			enableGate(false)
+			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 60)
+			Expect(ttl).To(BeNil())
+			Expect(usedDefault).To(BeFalse())
+		})
+	})
+
+	Context("when the gate is enabled and no user TTL is set", func() {
+		It("returns the default and reports usedDefault=true", func() {
+			enableGate(true)
+			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 60)
+			Expect(ttl).NotTo(BeNil())
+			Expect(*ttl).To(Equal(int64(60)))
+			Expect(usedDefault).To(BeTrue())
+		})
+
+		It("returns nil when the default is not positive", func() {
+			enableGate(true)
+			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 0)
+			Expect(ttl).To(BeNil())
+			Expect(usedDefault).To(BeFalse())
+		})
+
+		It("falls through to the default when the user value is not positive", func() {
+			enableGate(true)
+			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](0)), 60)
+			Expect(ttl).NotTo(BeNil())
+			Expect(*ttl).To(Equal(int64(60)))
+			Expect(usedDefault).To(BeTrue())
 		})
 	})
 })

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -195,6 +195,49 @@ var _ = Describe("IsExpired", func() {
 	})
 })
 
+var _ = Describe("IsExpiredWithTTL", func() {
+	terminatedApp := func(sinceTermination time.Duration) *v1beta2.SparkApplication {
+		return &v1beta2.SparkApplication{
+			Status: v1beta2.SparkApplicationStatus{
+				TerminationTime: metav1.NewTime(time.Now().Add(-sinceTermination)),
+			},
+		}
+	}
+
+	Context("with a nil TTL", func() {
+		It("never expires", func() {
+			Expect(util.IsExpiredWithTTL(terminatedApp(time.Hour), nil)).To(BeFalse())
+		})
+	})
+
+	Context("with a positive TTL", func() {
+		It("returns false before the TTL elapses", func() {
+			Expect(util.IsExpiredWithTTL(terminatedApp(30*time.Minute), ptr.To[int64](3600))).To(BeFalse())
+		})
+
+		It("returns true after the TTL elapses", func() {
+			Expect(util.IsExpiredWithTTL(terminatedApp(2*time.Hour), ptr.To[int64](3600))).To(BeTrue())
+		})
+	})
+
+	Context("with a non-positive TTL on a terminated app", func() {
+		It("expires immediately for a zero TTL", func() {
+			Expect(util.IsExpiredWithTTL(terminatedApp(time.Second), ptr.To[int64](0))).To(BeTrue())
+		})
+
+		It("expires immediately for a negative TTL", func() {
+			Expect(util.IsExpiredWithTTL(terminatedApp(time.Second), ptr.To[int64](-5))).To(BeTrue())
+		})
+	})
+
+	Context("with no termination time", func() {
+		It("does not expire even for a zero TTL", func() {
+			app := &v1beta2.SparkApplication{}
+			Expect(util.IsExpiredWithTTL(app, ptr.To[int64](0))).To(BeFalse())
+		})
+	})
+})
+
 var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 	appWithTTL := func(ttl *int64) *v1beta2.SparkApplication {
 		return &v1beta2.SparkApplication{
@@ -207,6 +250,25 @@ var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](3600)), 60)
 			Expect(ttl).NotTo(BeNil())
 			Expect(*ttl).To(Equal(int64(3600)))
+			Expect(usedDefault).To(BeFalse())
+		})
+	})
+
+	Context("when the user sets a non-positive spec.timeToLiveSeconds", func() {
+		It("returns the user value as-is (explicit immediate expiry wins over the default)", func() {
+			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
+			})
+
+			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](0)), 60)
+			Expect(ttl).NotTo(BeNil())
+			Expect(*ttl).To(Equal(int64(0)))
+			Expect(usedDefault).To(BeFalse())
+
+			ttl, usedDefault = util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](-5)), 60)
+			Expect(ttl).NotTo(BeNil())
+			Expect(*ttl).To(Equal(int64(-5)))
 			Expect(usedDefault).To(BeFalse())
 		})
 	})
@@ -243,14 +305,6 @@ var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 0)
 			Expect(ttl).To(BeNil())
 			Expect(usedDefault).To(BeFalse())
-		})
-
-		It("falls through to the default when the user value is not positive", func() {
-			enableGate(true)
-			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](0)), 60)
-			Expect(ttl).NotTo(BeNil())
-			Expect(*ttl).To(Equal(int64(60)))
-			Expect(usedDefault).To(BeTrue())
 		})
 	})
 })

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
-	"github.com/kubeflow/spark-operator/v2/pkg/features"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -125,77 +124,6 @@ var _ = Describe("GetApplicationState", func() {
 })
 
 var _ = Describe("IsExpired", func() {
-	Context("SparkApplication without TTL", func() {
-		app := &v1beta2.SparkApplication{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-app",
-				Namespace: "test-namespace",
-			},
-		}
-
-		It("Should return false", func() {
-			Expect(util.IsExpired(app)).To(BeFalse())
-		})
-	})
-
-	Context("SparkApplication not terminated with TTL", func() {
-		app := &v1beta2.SparkApplication{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-app",
-				Namespace: "test-namespace",
-			},
-			Spec: v1beta2.SparkApplicationSpec{
-				TimeToLiveSeconds: ptr.To[int64](3600),
-			},
-		}
-
-		It("Should return false", func() {
-			Expect(util.IsExpired(app)).To(BeFalse())
-		})
-	})
-
-	Context("SparkApplication terminated with TTL not expired", func() {
-		now := time.Now()
-		app := &v1beta2.SparkApplication{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-app",
-				Namespace: "test-namespace",
-			},
-			Spec: v1beta2.SparkApplicationSpec{
-				TimeToLiveSeconds: ptr.To[int64](3600),
-			},
-			Status: v1beta2.SparkApplicationStatus{
-				TerminationTime: metav1.NewTime(now.Add(-30 * time.Minute)),
-			},
-		}
-
-		It("Should return false", func() {
-			Expect(util.IsExpired(app)).To(BeFalse())
-		})
-	})
-
-	Context("SparkApplication terminated with TTL expired", func() {
-		now := time.Now()
-		app := &v1beta2.SparkApplication{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-app",
-				Namespace: "test-namespace",
-			},
-			Spec: v1beta2.SparkApplicationSpec{
-				TimeToLiveSeconds: ptr.To[int64](3600),
-			},
-			Status: v1beta2.SparkApplicationStatus{
-				TerminationTime: metav1.NewTime(now.Add(-2 * time.Hour)),
-			},
-		}
-
-		It("Should return true", func() {
-			Expect(util.IsExpired(app)).To(BeTrue())
-		})
-	})
-})
-
-var _ = Describe("IsExpiredWithTTL", func() {
 	terminatedApp := func(sinceTermination time.Duration) *v1beta2.SparkApplication {
 		return &v1beta2.SparkApplication{
 			Status: v1beta2.SparkApplicationStatus{
@@ -206,34 +134,34 @@ var _ = Describe("IsExpiredWithTTL", func() {
 
 	Context("with a nil TTL", func() {
 		It("never expires", func() {
-			Expect(util.IsExpiredWithTTL(terminatedApp(time.Hour), nil)).To(BeFalse())
+			Expect(util.IsExpired(terminatedApp(time.Hour), nil)).To(BeFalse())
 		})
 	})
 
 	Context("with a positive TTL", func() {
 		It("returns false before the TTL elapses", func() {
-			Expect(util.IsExpiredWithTTL(terminatedApp(30*time.Minute), ptr.To[int64](3600))).To(BeFalse())
+			Expect(util.IsExpired(terminatedApp(30*time.Minute), ptr.To[int64](3600))).To(BeFalse())
 		})
 
 		It("returns true after the TTL elapses", func() {
-			Expect(util.IsExpiredWithTTL(terminatedApp(2*time.Hour), ptr.To[int64](3600))).To(BeTrue())
+			Expect(util.IsExpired(terminatedApp(2*time.Hour), ptr.To[int64](3600))).To(BeTrue())
 		})
 	})
 
 	Context("with a non-positive TTL on a terminated app", func() {
 		It("expires immediately for a zero TTL", func() {
-			Expect(util.IsExpiredWithTTL(terminatedApp(time.Second), ptr.To[int64](0))).To(BeTrue())
+			Expect(util.IsExpired(terminatedApp(time.Second), ptr.To[int64](0))).To(BeTrue())
 		})
 
 		It("expires immediately for a negative TTL", func() {
-			Expect(util.IsExpiredWithTTL(terminatedApp(time.Second), ptr.To[int64](-5))).To(BeTrue())
+			Expect(util.IsExpired(terminatedApp(time.Second), ptr.To[int64](-5))).To(BeTrue())
 		})
 	})
 
 	Context("with no termination time", func() {
 		It("does not expire even for a zero TTL", func() {
 			app := &v1beta2.SparkApplication{}
-			Expect(util.IsExpiredWithTTL(app, ptr.To[int64](0))).To(BeFalse())
+			Expect(util.IsExpired(app, ptr.To[int64](0))).To(BeFalse())
 		})
 	})
 })
@@ -246,7 +174,7 @@ var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 	}
 
 	Context("when the user sets spec.timeToLiveSeconds > 0", func() {
-		It("returns the user value regardless of the default or gate", func() {
+		It("returns the user value regardless of the default", func() {
 			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](3600)), 60)
 			Expect(ttl).NotTo(BeNil())
 			Expect(*ttl).To(Equal(int64(3600)))
@@ -256,11 +184,6 @@ var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 
 	Context("when the user sets a non-positive spec.timeToLiveSeconds", func() {
 		It("returns the user value as-is (explicit immediate expiry wins over the default)", func() {
-			Expect(features.SetEnable(features.DefaultTimeToLive, true)).To(Succeed())
-			DeferCleanup(func() {
-				Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
-			})
-
 			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(ptr.To[int64](0)), 60)
 			Expect(ttl).NotTo(BeNil())
 			Expect(*ttl).To(Equal(int64(0)))
@@ -273,27 +196,8 @@ var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 		})
 	})
 
-	// enableGate toggles the DefaultTimeToLive feature gate for a single spec and
-	// restores it to disabled afterwards, keeping specs independent.
-	enableGate := func(enabled bool) {
-		Expect(features.SetEnable(features.DefaultTimeToLive, enabled)).To(Succeed())
-		DeferCleanup(func() {
-			Expect(features.SetEnable(features.DefaultTimeToLive, false)).To(Succeed())
-		})
-	}
-
-	Context("when the gate is disabled", func() {
-		It("returns nil even though a positive default is configured", func() {
-			enableGate(false)
-			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 60)
-			Expect(ttl).To(BeNil())
-			Expect(usedDefault).To(BeFalse())
-		})
-	})
-
-	Context("when the gate is enabled and no user TTL is set", func() {
+	Context("when no user TTL is set", func() {
 		It("returns the default and reports usedDefault=true", func() {
-			enableGate(true)
 			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 60)
 			Expect(ttl).NotTo(BeNil())
 			Expect(*ttl).To(Equal(int64(60)))
@@ -301,7 +205,6 @@ var _ = Describe("EffectiveTimeToLiveSeconds", func() {
 		})
 
 		It("returns nil when the default is not positive", func() {
-			enableGate(true)
 			ttl, usedDefault := util.EffectiveTimeToLiveSeconds(appWithTTL(nil), 0)
 			Expect(ttl).To(BeNil())
 			Expect(usedDefault).To(BeFalse())


### PR DESCRIPTION
## Purpose of this PR

Terminated `SparkApplication` objects (`COMPLETED`/`FAILED`) are only garbage-collected when the user sets `spec.timeToLiveSeconds`. When that field is unset, the object — and its driver pod could — linger indefinitely. This is a real hazard when driver pods carry sidecars (logging agents, service-mesh proxies) that do not reliably exit after the primary Spark container finishes: at scale the lingering pods cause pod-IP exhaustion and resource crunch.

This PR adds an operator-configurable **default TTL** that is applied to terminated SparkApplications **only when the user has not set their own** `timeToLiveSeconds`. It is applied purely as a runtime fallback for the cleanup decision — the user's object is never mutated — and it is off by default, gated behind a new alpha feature gate.

**Proposed changes:**

- Add a new alpha feature gate `DefaultTimeToLive` (default `false`).
- Add a `--default-time-to-live-seconds` controller flag (default `0` = disabled) plumbed through to the reconciler `Options`.
- Add `util.EffectiveTimeToLiveSeconds`, which resolves the TTL governing cleanup: user spec wins; else the operator default when the gate is enabled and the value is `> 0`; else `nil` ("never expire"). The pure `util.IsExpired` is left unchanged.
- Use the resolved effective TTL in `reconcileTerminatedSparkApplication` (applies to both `COMPLETED` and `FAILED`), with an info log emitted when the operator default is the source.
- Expose the setting via the Helm chart: `controller.defaultTimeToLiveSeconds` value, a `DefaultTimeToLive` entry in `controller.featureGates`, the rendered flag in the controller deployment, chart unit tests, and regenerated chart docs.

## Change Category

- [x] Feature (non-breaking change which adds functionality)
- [x] Documentation update

### Rationale

The behavior is opt-in and non-destructive: an explicit user TTL always wins, the object's spec is never rewritten, and two independent guards (feature gate enabled **and** a positive value) must both hold for the fallback to activate. This makes the upgrade path a no-op for existing clusters while giving operators a cluster-wide safety net against resource exhaustion.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

- The feature gate follows the repo's existing alpha→beta→GA promotion model in `pkg/features`.
- Tests: unit coverage for `EffectiveTimeToLiveSeconds`, a controller integration test verifying deletion of a terminated app past the default TTL (gate on, no spec TTL), and Helm chart tests asserting the flag renders only when the value is set.
