### PR TITLE
test(e2e): add Prometheus metrics and Spark UI e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -96,11 +97,13 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -97,13 +96,11 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/common v0.66.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
@@ -108,7 +109,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -138,6 +140,8 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
@@ -204,6 +208,8 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -216,6 +222,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -140,8 +138,6 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
@@ -208,8 +204,6 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
-github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -222,8 +216,6 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
-github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -18,8 +18,6 @@ package e2e_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,31 +25,12 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
-
-// loadSparkPi parses the canonical spark-pi example and gives the caller a
-// fresh copy. We rename it per-test so two tests can run in the same
-// namespace without colliding.
-func loadSparkPi(name string) *v1beta2.SparkApplication {
-	app := &v1beta2.SparkApplication{}
-	path := filepath.Join("..", "..", "examples", "spark-pi.yaml")
-	file, err := os.Open(path)
-	Expect(err).NotTo(HaveOccurred())
-	defer func() {
-		_ = file.Close()
-	}()
-	Expect(yaml.NewYAMLOrJSONDecoder(file, 100).Decode(app)).NotTo(HaveOccurred())
-	app.Name = name
-	app.ResourceVersion = ""
-	app.UID = ""
-	return app
-}
 
 func driverPDBKey(app *v1beta2.SparkApplication) types.NamespacedName {
 	return types.NamespacedName{Name: util.GetDriverPodName(app), Namespace: app.Namespace}

--- a/test/e2e/prometheus_metrics_test.go
+++ b/test/e2e/prometheus_metrics_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+var _ = Describe("Prometheus Metrics", func() {
+	Context("Controller metrics endpoint", func() {
+		ctx := context.Background()
+		path := filepath.Join("..", "..", "examples", "spark-pi.yaml")
+
+		var app *v1beta2.SparkApplication
+
+		BeforeEach(func() {
+			By("Parsing SparkApplication from file")
+			file, err := os.Open(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).NotTo(BeNil())
+			defer func() { Expect(file.Close()).To(Succeed()) }()
+
+			decoder := yaml.NewYAMLOrJSONDecoder(file, 100)
+			Expect(decoder).NotTo(BeNil())
+
+			app = &v1beta2.SparkApplication{}
+			Expect(decoder.Decode(app)).NotTo(HaveOccurred())
+			app.Name = "spark-pi-metrics-test"
+		})
+
+		AfterEach(func() {
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			if err := k8sClient.Get(ctx, key, app); err == nil {
+				By("Deleting SparkApplication")
+				Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+			}
+		})
+
+		It("Should serve Prometheus metrics including Spark application metrics", func() {
+			By("Finding the controller pod")
+			pods := &corev1.PodList{}
+			Expect(k8sClient.List(ctx, pods,
+				client.InNamespace(ReleaseNamespace),
+				client.MatchingLabels{
+					"app.kubernetes.io/name":      "spark-operator",
+					"app.kubernetes.io/component": "controller",
+				},
+			)).To(Succeed())
+			Expect(pods.Items).NotTo(BeEmpty(), "controller pod not found")
+
+			By("Identifying the leader controller pod via Lease")
+			controllerPod := pods.Items[0]
+			lease := &coordinationv1.Lease{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: ReleaseNamespace,
+				Name:      "spark-operator-controller-lock",
+			}, lease); err == nil && lease.Spec.HolderIdentity != nil {
+				for _, pod := range pods.Items {
+					if pod.Name == *lease.Spec.HolderIdentity {
+						controllerPod = pod
+						break
+					}
+				}
+			}
+
+			By("Detecting metrics scheme and port from controller deployment")
+			deploy := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: ReleaseNamespace,
+				Name:      "spark-operator-controller",
+			}, deploy)).To(Succeed())
+
+			metricsScheme := "http"
+			metricsPort := "8080"
+			for _, arg := range deploy.Spec.Template.Spec.Containers[0].Args {
+				if arg == "--secure-metrics" || arg == "--secure-metrics=true" {
+					metricsScheme = "https"
+				}
+				if strings.HasPrefix(arg, "--metrics-bind-address=") {
+					addr := strings.TrimPrefix(arg, "--metrics-bind-address=")
+					if _, port, err := net.SplitHostPort(addr); err == nil && port != "" {
+						metricsPort = port
+					}
+				}
+			}
+
+			By("Verifying the metrics endpoint serves Prometheus-formatted data")
+			data, err := clientset.CoreV1().Pods(ReleaseNamespace).
+				ProxyGet(metricsScheme, controllerPod.Name, metricsPort, "metrics", nil).
+				DoRaw(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to proxy GET /metrics from controller pod")
+
+			metricsOutput := string(data)
+			Expect(metricsOutput).To(ContainSubstring("# HELP"))
+			Expect(metricsOutput).To(ContainSubstring("# TYPE"))
+			Expect(metricsOutput).To(ContainSubstring("go_goroutines"))
+			Expect(metricsOutput).To(ContainSubstring("process_cpu_seconds_total"))
+
+			By("Creating SparkApplication to exercise the metrics pipeline")
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("Waiting for SparkApplication to complete")
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			Expect(waitForSparkApplicationCompleted(ctx, key)).NotTo(HaveOccurred())
+
+			By("Verifying Spark application metrics are present after app completion")
+			Eventually(func() string {
+				data, err := clientset.CoreV1().Pods(ReleaseNamespace).
+					ProxyGet(metricsScheme, controllerPod.Name, metricsPort, "metrics", nil).
+					DoRaw(ctx)
+				if err != nil {
+					return ""
+				}
+				return string(data)
+			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(And(
+				ContainSubstring("spark_application_count"),
+				ContainSubstring("spark_application_submit_count"),
+				ContainSubstring("spark_application_success_count"),
+			))
+		})
+	})
+})

--- a/test/e2e/prometheus_metrics_test.go
+++ b/test/e2e/prometheus_metrics_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package e2e_test
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,6 +38,29 @@ import (
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 )
+
+// sumMetricValues parses Prometheus text-exposition output and returns the
+// sum of all sample values for the given metric name, across all label combinations.
+func sumMetricValues(metricsText, name string) float64 {
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `(\{[^}]*\})?\s+(\S+)$`)
+
+	var total float64
+	scanner := bufio.NewScanner(strings.NewReader(metricsText))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		matches := pattern.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		if value, err := strconv.ParseFloat(matches[2], 64); err == nil {
+			total += value
+		}
+	}
+	return total
+}
 
 var _ = Describe("Prometheus Metrics", func() {
 	Context("Controller metrics endpoint", func() {
@@ -54,7 +81,7 @@ var _ = Describe("Prometheus Metrics", func() {
 
 			app = &v1beta2.SparkApplication{}
 			Expect(decoder.Decode(app)).NotTo(HaveOccurred())
-			app.Name = "spark-pi-metrics-test"
+			app.Name = fmt.Sprintf("spark-pi-metrics-test-%d", GinkgoRandomSeed())
 		})
 
 		AfterEach(func() {
@@ -84,12 +111,16 @@ var _ = Describe("Prometheus Metrics", func() {
 				Namespace: ReleaseNamespace,
 				Name:      "spark-operator-controller-lock",
 			}, lease); err == nil && lease.Spec.HolderIdentity != nil {
+				// controller-runtime sets the lease holder identity to "<pod-name>_<uuid>".
+				matched := false
 				for _, pod := range pods.Items {
-					if pod.Name == *lease.Spec.HolderIdentity {
+					if strings.HasPrefix(*lease.Spec.HolderIdentity, pod.Name+"_") {
 						controllerPod = pod
+						matched = true
 						break
 					}
 				}
+				Expect(matched).To(BeTrue(), "no controller pod matches lease holder identity %q", *lease.Spec.HolderIdentity)
 			}
 
 			By("Detecting metrics scheme and port from controller deployment")
@@ -125,6 +156,12 @@ var _ = Describe("Prometheus Metrics", func() {
 			Expect(metricsOutput).To(ContainSubstring("go_goroutines"))
 			Expect(metricsOutput).To(ContainSubstring("process_cpu_seconds_total"))
 
+			// Other specs may run concurrently and share these process-global counters,
+			// so capture a baseline and assert on the delta rather than mere presence.
+			countBefore := sumMetricValues(metricsOutput, "spark_application_count")
+			submitCountBefore := sumMetricValues(metricsOutput, "spark_application_submit_count")
+			successCountBefore := sumMetricValues(metricsOutput, "spark_application_success_count")
+
 			By("Creating SparkApplication to exercise the metrics pipeline")
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
 
@@ -132,20 +169,19 @@ var _ = Describe("Prometheus Metrics", func() {
 			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
 			Expect(waitForSparkApplicationCompleted(ctx, key)).NotTo(HaveOccurred())
 
-			By("Verifying Spark application metrics are present after app completion")
-			Eventually(func() string {
+			By("Verifying Spark application metrics incremented after app completion")
+			Eventually(func() (bool, error) {
 				data, err := clientset.CoreV1().Pods(ReleaseNamespace).
 					ProxyGet(metricsScheme, controllerPod.Name, metricsPort, "metrics", nil).
 					DoRaw(ctx)
 				if err != nil {
-					return ""
+					return false, err
 				}
-				return string(data)
-			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(And(
-				ContainSubstring("spark_application_count"),
-				ContainSubstring("spark_application_submit_count"),
-				ContainSubstring("spark_application_success_count"),
-			))
+				metricsOutput := string(data)
+				return sumMetricValues(metricsOutput, "spark_application_count") > countBefore &&
+					sumMetricValues(metricsOutput, "spark_application_submit_count") > submitCountBefore &&
+					sumMetricValues(metricsOutput, "spark_application_success_count") > successCountBefore, nil
+			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
 		})
 	})
 })

--- a/test/e2e/prometheus_metrics_test.go
+++ b/test/e2e/prometheus_metrics_test.go
@@ -17,15 +17,14 @@ limitations under the License.
 package e2e_test
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,25 +36,30 @@ import (
 
 // sumMetricValues parses Prometheus text-exposition output and returns the
 // sum of all sample values for the given metric name, across all label combinations.
-func sumMetricValues(metricsText, name string) float64 {
-	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `(\{[^}]*\})?\s+(\S+)$`)
+func sumMetricValues(metricsText, name string) (float64, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(metricsText))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse Prometheus metrics: %w", err)
+	}
+
+	family, ok := families[name]
+	if !ok {
+		return 0, nil
+	}
 
 	var total float64
-	scanner := bufio.NewScanner(strings.NewReader(metricsText))
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		matches := pattern.FindStringSubmatch(line)
-		if matches == nil {
-			continue
-		}
-		if value, err := strconv.ParseFloat(matches[2], 64); err == nil {
-			total += value
+	for _, metric := range family.GetMetric() {
+		switch {
+		case metric.GetCounter() != nil:
+			total += metric.GetCounter().GetValue()
+		case metric.GetGauge() != nil:
+			total += metric.GetGauge().GetValue()
+		case metric.GetUntyped() != nil:
+			total += metric.GetUntyped().GetValue()
 		}
 	}
-	return total
+	return total, nil
 }
 
 var _ = Describe("Prometheus Metrics", func() {
@@ -136,9 +140,12 @@ var _ = Describe("Prometheus Metrics", func() {
 
 			// Other specs may run concurrently and share these process-global counters,
 			// so capture a baseline and assert on the delta rather than mere presence.
-			countBefore := sumMetricValues(metricsOutput, common.MetricSparkApplicationCount)
-			submitCountBefore := sumMetricValues(metricsOutput, common.MetricSparkApplicationSubmitCount)
-			successCountBefore := sumMetricValues(metricsOutput, common.MetricSparkApplicationSuccessCount)
+			countBefore, err := sumMetricValues(metricsOutput, common.MetricSparkApplicationCount)
+			Expect(err).NotTo(HaveOccurred())
+			submitCountBefore, err := sumMetricValues(metricsOutput, common.MetricSparkApplicationSubmitCount)
+			Expect(err).NotTo(HaveOccurred())
+			successCountBefore, err := sumMetricValues(metricsOutput, common.MetricSparkApplicationSuccessCount)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating SparkApplication to exercise the metrics pipeline")
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
@@ -148,18 +155,24 @@ var _ = Describe("Prometheus Metrics", func() {
 			Expect(waitForSparkApplicationCompleted(ctx, key)).NotTo(HaveOccurred())
 
 			By("Verifying Spark application metrics incremented after app completion")
-			Eventually(func() (bool, error) {
+			Eventually(func(g Gomega) {
 				data, err := clientset.CoreV1().Pods(ReleaseNamespace).
 					ProxyGet(metricsScheme, controllerPod.Name, metricsPort, metricsPath, nil).
 					DoRaw(ctx)
-				if err != nil {
-					return false, err
-				}
+				g.Expect(err).NotTo(HaveOccurred(), "failed to proxy GET /metrics from controller pod")
+
 				metricsOutput := string(data)
-				return sumMetricValues(metricsOutput, common.MetricSparkApplicationCount) > countBefore &&
-					sumMetricValues(metricsOutput, common.MetricSparkApplicationSubmitCount) > submitCountBefore &&
-					sumMetricValues(metricsOutput, common.MetricSparkApplicationSuccessCount) > successCountBefore, nil
-			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
+				countAfter, err := sumMetricValues(metricsOutput, common.MetricSparkApplicationCount)
+				g.Expect(err).NotTo(HaveOccurred())
+				submitCountAfter, err := sumMetricValues(metricsOutput, common.MetricSparkApplicationSubmitCount)
+				g.Expect(err).NotTo(HaveOccurred())
+				successCountAfter, err := sumMetricValues(metricsOutput, common.MetricSparkApplicationSuccessCount)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(countAfter).To(BeNumerically(">", countBefore))
+				g.Expect(submitCountAfter).To(BeNumerically(">", submitCountBefore))
+				g.Expect(successCountAfter).To(BeNumerically(">", successCountBefore))
+			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/prometheus_metrics_test.go
+++ b/test/e2e/prometheus_metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubeflow authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,23 +20,19 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"net"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
 
 // sumMetricValues parses Prometheus text-exposition output and returns the
@@ -65,23 +61,11 @@ func sumMetricValues(metricsText, name string) float64 {
 var _ = Describe("Prometheus Metrics", func() {
 	Context("Controller metrics endpoint", func() {
 		ctx := context.Background()
-		path := filepath.Join("..", "..", "examples", "spark-pi.yaml")
 
 		var app *v1beta2.SparkApplication
 
 		BeforeEach(func() {
-			By("Parsing SparkApplication from file")
-			file, err := os.Open(path)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(file).NotTo(BeNil())
-			defer func() { Expect(file.Close()).To(Succeed()) }()
-
-			decoder := yaml.NewYAMLOrJSONDecoder(file, 100)
-			Expect(decoder).NotTo(BeNil())
-
-			app = &v1beta2.SparkApplication{}
-			Expect(decoder.Decode(app)).NotTo(HaveOccurred())
-			app.Name = fmt.Sprintf("spark-pi-metrics-test-%d", GinkgoRandomSeed())
+			app = loadSparkPi(fmt.Sprintf("spark-pi-metrics-test-%d", GinkgoRandomSeed()))
 		})
 
 		AfterEach(func() {
@@ -123,30 +107,24 @@ var _ = Describe("Prometheus Metrics", func() {
 				Expect(matched).To(BeTrue(), "no controller pod matches lease holder identity %q", *lease.Spec.HolderIdentity)
 			}
 
-			By("Detecting metrics scheme and port from controller deployment")
-			deploy := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: ReleaseNamespace,
-				Name:      "spark-operator-controller",
-			}, deploy)).To(Succeed())
-
+			// The chart stamps the scrape port/path onto the pod as annotations
+			// whenever prometheus.metrics.enable is set, so read config from there
+			// instead of re-deriving it from container args. This suite doesn't
+			// exercise --secure-metrics (it isn't enabled in CI and would require
+			// extra auth setup), so the scheme is always http.
 			metricsScheme := "http"
 			metricsPort := "8080"
-			for _, arg := range deploy.Spec.Template.Spec.Containers[0].Args {
-				if arg == "--secure-metrics" || arg == "--secure-metrics=true" {
-					metricsScheme = "https"
-				}
-				if strings.HasPrefix(arg, "--metrics-bind-address=") {
-					addr := strings.TrimPrefix(arg, "--metrics-bind-address=")
-					if _, port, err := net.SplitHostPort(addr); err == nil && port != "" {
-						metricsPort = port
-					}
-				}
+			metricsPath := "metrics"
+			if port, ok := controllerPod.Annotations[common.PrometheusPortAnnotation]; ok && port != "" {
+				metricsPort = port
+			}
+			if path, ok := controllerPod.Annotations[common.PrometheusPathAnnotation]; ok && path != "" {
+				metricsPath = strings.TrimPrefix(path, "/")
 			}
 
 			By("Verifying the metrics endpoint serves Prometheus-formatted data")
 			data, err := clientset.CoreV1().Pods(ReleaseNamespace).
-				ProxyGet(metricsScheme, controllerPod.Name, metricsPort, "metrics", nil).
+				ProxyGet(metricsScheme, controllerPod.Name, metricsPort, metricsPath, nil).
 				DoRaw(ctx)
 			Expect(err).NotTo(HaveOccurred(), "failed to proxy GET /metrics from controller pod")
 
@@ -158,9 +136,9 @@ var _ = Describe("Prometheus Metrics", func() {
 
 			// Other specs may run concurrently and share these process-global counters,
 			// so capture a baseline and assert on the delta rather than mere presence.
-			countBefore := sumMetricValues(metricsOutput, "spark_application_count")
-			submitCountBefore := sumMetricValues(metricsOutput, "spark_application_submit_count")
-			successCountBefore := sumMetricValues(metricsOutput, "spark_application_success_count")
+			countBefore := sumMetricValues(metricsOutput, common.MetricSparkApplicationCount)
+			submitCountBefore := sumMetricValues(metricsOutput, common.MetricSparkApplicationSubmitCount)
+			successCountBefore := sumMetricValues(metricsOutput, common.MetricSparkApplicationSuccessCount)
 
 			By("Creating SparkApplication to exercise the metrics pipeline")
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
@@ -172,15 +150,15 @@ var _ = Describe("Prometheus Metrics", func() {
 			By("Verifying Spark application metrics incremented after app completion")
 			Eventually(func() (bool, error) {
 				data, err := clientset.CoreV1().Pods(ReleaseNamespace).
-					ProxyGet(metricsScheme, controllerPod.Name, metricsPort, "metrics", nil).
+					ProxyGet(metricsScheme, controllerPod.Name, metricsPort, metricsPath, nil).
 					DoRaw(ctx)
 				if err != nil {
 					return false, err
 				}
 				metricsOutput := string(data)
-				return sumMetricValues(metricsOutput, "spark_application_count") > countBefore &&
-					sumMetricValues(metricsOutput, "spark_application_submit_count") > submitCountBefore &&
-					sumMetricValues(metricsOutput, "spark_application_success_count") > successCountBefore, nil
+				return sumMetricValues(metricsOutput, common.MetricSparkApplicationCount) > countBefore &&
+					sumMetricValues(metricsOutput, common.MetricSparkApplicationSubmitCount) > submitCountBefore &&
+					sumMetricValues(metricsOutput, common.MetricSparkApplicationSuccessCount) > successCountBefore, nil
 			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
 		})
 	})

--- a/test/e2e/spark_ui_test.go
+++ b/test/e2e/spark_ui_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
+)
+
+var _ = Describe("Spark UI", func() {
+	Context("Verify Spark UI is accessible while application is running", func() {
+		ctx := context.Background()
+		path := filepath.Join("..", "..", "examples", "spark-pi.yaml")
+
+		var app *v1beta2.SparkApplication
+
+		BeforeEach(func() {
+			By("Parsing SparkApplication from file")
+			file, err := os.Open(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).NotTo(BeNil())
+			defer func() { Expect(file.Close()).To(Succeed()) }()
+			decoder := yaml.NewYAMLOrJSONDecoder(file, 4096)
+			Expect(decoder).NotTo(BeNil())
+
+			app = &v1beta2.SparkApplication{}
+			Expect(decoder.Decode(app)).NotTo(HaveOccurred())
+
+			// Use a unique name and large partition count so SparkPi runs long enough
+			// for the test to query the UI while it's still in the Running state.
+			app.Name = fmt.Sprintf("spark-pi-ui-test-%d", GinkgoRandomSeed())
+			app.Spec.Arguments = []string{"1000000"}
+
+			By("Creating SparkApplication")
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			if err := k8sClient.Get(ctx, key, app); err == nil {
+				By("Deleting SparkApplication")
+				Expect(k8sClient.Delete(ctx, app)).To(Succeed())
+			}
+		})
+
+		It("Should create a UI service and serve the Spark web UI", func() {
+			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
+			driverPodName := util.GetDriverPodName(app)
+
+			By("Waiting for SparkApplication to reach Running state with UI service populated")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, key, app); err != nil {
+					return false
+				}
+				return app.Status.AppState.State == v1beta2.ApplicationStateRunning &&
+					app.Status.DriverInfo.WebUIServiceName != ""
+			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
+
+			By("Verifying the WebUI status fields are populated")
+			Expect(app.Status.DriverInfo.WebUIPort).To(Equal(int32(4040)))
+			Expect(app.Status.DriverInfo.WebUIAddress).NotTo(BeEmpty())
+
+			By("Verifying the UI service exists with port 4040")
+			uiServiceName := app.Status.DriverInfo.WebUIServiceName
+			svcKey := types.NamespacedName{Namespace: app.Namespace, Name: uiServiceName}
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, svcKey, svc)).To(Succeed())
+			hasUIPort := false
+			for _, port := range svc.Spec.Ports {
+				if port.Port == 4040 {
+					hasUIPort = true
+					break
+				}
+			}
+			Expect(hasUIPort).To(BeTrue(), "UI service should expose port 4040")
+
+			By("Verifying the Spark UI is responding on port 4040")
+			Eventually(func(g Gomega) {
+				transport, upgrader, err := spdy.RoundTripperFor(cfg)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				reqURL := clientset.CoreV1().RESTClient().Post().
+					Resource("pods").
+					Namespace(app.Namespace).
+					Name(driverPodName).
+					SubResource("portforward").
+					URL()
+
+				dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, reqURL)
+
+				stopChan := make(chan struct{})
+				defer close(stopChan)
+				readyChan := make(chan struct{})
+
+				fw, err := portforward.New(dialer, []string{"0:4040"}, stopChan, readyChan, io.Discard, io.Discard)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				errChan := make(chan error, 1)
+				go func() { errChan <- fw.ForwardPorts() }()
+
+				select {
+				case <-readyChan:
+				case err := <-errChan:
+					g.Expect(err).NotTo(HaveOccurred(), "port forward failed to start")
+					return
+				case <-time.After(15 * time.Second):
+					g.Expect(errors.New("timed out waiting for port-forward to become ready")).NotTo(HaveOccurred())
+					return
+				}
+
+				ports, err := fw.GetPorts()
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ports).NotTo(BeEmpty())
+
+				httpClient := &http.Client{Timeout: 15 * time.Second}
+				resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d", ports[0].Local))
+				g.Expect(err).NotTo(HaveOccurred())
+				defer func() { _ = resp.Body.Close() }()
+
+				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(body)).To(ContainSubstring("Spark Jobs"))
+			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/spark_ui_test.go
+++ b/test/e2e/spark_ui_test.go
@@ -57,10 +57,10 @@ var _ = Describe("Spark UI", func() {
 			app = &v1beta2.SparkApplication{}
 			Expect(decoder.Decode(app)).NotTo(HaveOccurred())
 
-			// Use a unique name and large partition count so SparkPi runs long enough
-			// for the test to query the UI while it's still in the Running state.
+			// Use a unique name and a partition count high enough that SparkPi keeps
+			// running for the few seconds it takes the test to query the UI.
 			app.Name = fmt.Sprintf("spark-pi-ui-test-%d", GinkgoRandomSeed())
-			app.Spec.Arguments = []string{"1000000"}
+			app.Spec.Arguments = []string{"50000"}
 
 			By("Creating SparkApplication")
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())

--- a/test/e2e/spark_ui_test.go
+++ b/test/e2e/spark_ui_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubeflow authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,49 +18,72 @@ package e2e_test
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
+	"net"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
+	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
-	"github.com/kubeflow/spark-operator/v2/pkg/util"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 )
+
+// sleepyPiScript computes a trivial result and then sleeps for a fixed,
+// deterministic duration so the driver stays up long enough for the test to
+// query the Spark UI, regardless of cluster/node speed.
+const sleepyPiScript = `
+import time
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.appName("SparkUIKeepAlive").getOrCreate()
+print(spark.sparkContext.parallelize(range(2), 2).sum())
+time.sleep(60)
+spark.stop()
+`
 
 var _ = Describe("Spark UI", func() {
 	Context("Verify Spark UI is accessible while application is running", func() {
 		ctx := context.Background()
-		path := filepath.Join("..", "..", "examples", "spark-pi.yaml")
 
 		var app *v1beta2.SparkApplication
+		var scriptConfigMap *corev1.ConfigMap
 
 		BeforeEach(func() {
-			By("Parsing SparkApplication from file")
-			file, err := os.Open(path)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(file).NotTo(BeNil())
-			defer func() { Expect(file.Close()).To(Succeed()) }()
-			decoder := yaml.NewYAMLOrJSONDecoder(file, 4096)
-			Expect(decoder).NotTo(BeNil())
+			seed := GinkgoRandomSeed()
+			app = loadSparkPiPython(fmt.Sprintf("spark-pi-ui-test-%d", seed))
 
-			app = &v1beta2.SparkApplication{}
-			Expect(decoder.Decode(app)).NotTo(HaveOccurred())
+			By("Creating a ConfigMap with a script that keeps the driver alive")
+			scriptConfigMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("spark-ui-test-script-%d", seed),
+					Namespace: app.Namespace,
+				},
+				Data: map[string]string{
+					"sleepy_pi.py": sleepyPiScript,
+				},
+			}
+			Expect(k8sClient.Create(ctx, scriptConfigMap)).To(Succeed())
 
-			// Use a unique name and a partition count high enough that SparkPi keeps
-			// running for the few seconds it takes the test to query the UI.
-			app.Name = fmt.Sprintf("spark-pi-ui-test-%d", GinkgoRandomSeed())
-			app.Spec.Arguments = []string{"50000"}
+			app.Spec.MainApplicationFile = ptr.To("local:///opt/spark/scripts/sleepy_pi.py")
+			app.Spec.Volumes = append(app.Spec.Volumes, corev1.Volume{
+				Name: "ui-test-script",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: scriptConfigMap.Name},
+					},
+				},
+			})
+			app.Spec.Driver.VolumeMounts = append(app.Spec.Driver.VolumeMounts, corev1.VolumeMount{
+				Name:      "ui-test-script",
+				MountPath: "/opt/spark/scripts",
+			})
 
 			By("Creating SparkApplication")
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
@@ -72,11 +95,12 @@ var _ = Describe("Spark UI", func() {
 				By("Deleting SparkApplication")
 				Expect(k8sClient.Delete(ctx, app)).To(Succeed())
 			}
+			By("Deleting the script ConfigMap")
+			_ = k8sClient.Delete(ctx, scriptConfigMap)
 		})
 
 		It("Should create a UI service and serve the Spark web UI", func() {
 			key := types.NamespacedName{Namespace: app.Namespace, Name: app.Name}
-			driverPodName := util.GetDriverPodName(app)
 
 			By("Waiting for SparkApplication to reach Running state with UI service populated")
 			Eventually(func() bool {
@@ -88,71 +112,38 @@ var _ = Describe("Spark UI", func() {
 			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(BeTrue())
 
 			By("Verifying the WebUI status fields are populated")
-			Expect(app.Status.DriverInfo.WebUIPort).To(Equal(int32(4040)))
-			Expect(app.Status.DriverInfo.WebUIAddress).NotTo(BeEmpty())
+			Expect(app.Status.DriverInfo.WebUIPort).To(Equal(common.DefaultSparkWebUIPort))
+			_, port, err := net.SplitHostPort(app.Status.DriverInfo.WebUIAddress)
+			Expect(err).NotTo(HaveOccurred(), "WebUIAddress should be a valid host:port, got %q", app.Status.DriverInfo.WebUIAddress)
+			Expect(port).To(Equal(strconv.Itoa(int(app.Status.DriverInfo.WebUIPort))))
 
-			By("Verifying the UI service exists with port 4040")
+			By(fmt.Sprintf("Verifying the UI service exists with port %d", common.DefaultSparkWebUIPort))
 			uiServiceName := app.Status.DriverInfo.WebUIServiceName
 			svcKey := types.NamespacedName{Namespace: app.Namespace, Name: uiServiceName}
 			svc := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, svcKey, svc)).To(Succeed())
 			hasUIPort := false
 			for _, port := range svc.Spec.Ports {
-				if port.Port == 4040 {
+				if port.Port == common.DefaultSparkWebUIPort {
 					hasUIPort = true
 					break
 				}
 			}
-			Expect(hasUIPort).To(BeTrue(), "UI service should expose port 4040")
+			Expect(hasUIPort).To(BeTrue(), "UI service should expose port %d", common.DefaultSparkWebUIPort)
 
-			By("Verifying the Spark UI is responding on port 4040")
+			By("Verifying the Spark UI REST API reports the running application via the Service proxy")
 			Eventually(func(g Gomega) {
-				transport, upgrader, err := spdy.RoundTripperFor(cfg)
-				g.Expect(err).NotTo(HaveOccurred())
+				reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+				defer cancel()
 
-				reqURL := clientset.CoreV1().RESTClient().Post().
-					Resource("pods").
-					Namespace(app.Namespace).
-					Name(driverPodName).
-					SubResource("portforward").
-					URL()
+				data, err := clientset.CoreV1().Services(app.Namespace).
+					ProxyGet("http", uiServiceName, common.DefaultSparkWebUIPortName, "api/v1/applications", nil).
+					DoRaw(reqCtx)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to proxy GET /api/v1/applications from UI service")
 
-				dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, reqURL)
-
-				stopChan := make(chan struct{})
-				defer close(stopChan)
-				readyChan := make(chan struct{})
-
-				fw, err := portforward.New(dialer, []string{"0:4040"}, stopChan, readyChan, io.Discard, io.Discard)
-				g.Expect(err).NotTo(HaveOccurred())
-
-				errChan := make(chan error, 1)
-				go func() { errChan <- fw.ForwardPorts() }()
-
-				select {
-				case <-readyChan:
-				case err := <-errChan:
-					g.Expect(err).NotTo(HaveOccurred(), "port forward failed to start")
-					return
-				case <-time.After(15 * time.Second):
-					g.Expect(errors.New("timed out waiting for port-forward to become ready")).NotTo(HaveOccurred())
-					return
-				}
-
-				ports, err := fw.GetPorts()
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(ports).NotTo(BeEmpty())
-
-				httpClient := &http.Client{Timeout: 15 * time.Second}
-				resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d", ports[0].Local))
-				g.Expect(err).NotTo(HaveOccurred())
-				defer func() { _ = resp.Body.Close() }()
-
-				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-
-				body, err := io.ReadAll(resp.Body)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(string(body)).To(ContainSubstring("Spark Jobs"))
+				var runningApps []map[string]any
+				g.Expect(json.Unmarshal(data, &runningApps)).To(Succeed(), "expected valid JSON from Spark UI REST API, got: %s", data)
+				g.Expect(runningApps).NotTo(BeEmpty(), "expected the Spark UI REST API to report at least one application")
 			}).WithPolling(PollInterval).WithTimeout(WaitTimeout).Should(Succeed())
 		})
 	})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -42,6 +42,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -406,4 +407,31 @@ func collectSparkApplicationsUntilTermination(ctx context.Context, key types.Nam
 		return false, nil
 	})
 	return apps, err
+}
+
+// loadSparkApplication parses the SparkApplication example at path and gives
+// the caller a fresh copy. We rename it per-test so two tests can run in the
+// same namespace without colliding.
+func loadSparkApplication(path, name string) *v1beta2.SparkApplication {
+	app := &v1beta2.SparkApplication{}
+	file, err := os.Open(path)
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_ = file.Close()
+	}()
+	Expect(yaml.NewYAMLOrJSONDecoder(file, 4096).Decode(app)).NotTo(HaveOccurred())
+	app.Name = name
+	app.ResourceVersion = ""
+	app.UID = ""
+	return app
+}
+
+// loadSparkPi loads the canonical Scala spark-pi example.
+func loadSparkPi(name string) *v1beta2.SparkApplication {
+	return loadSparkApplication(filepath.Join("..", "..", "examples", "spark-pi.yaml"), name)
+}
+
+// loadSparkPiPython loads the Python spark-pi example.
+func loadSparkPiPython(name string) *v1beta2.SparkApplication {
+	return loadSparkApplication(filepath.Join("..", "..", "examples", "spark-pi-python.yaml"), name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://spark.kubeflow.org/en/latest/contributor-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

Adds two E2E tests covering operator functionality that previously had no coverage - verifying the Prometheus metrics endpoint reports correct data and that the Spark UI is actually reachable while a job runs. Both are fully platform-agnostic, with just Kubernetes primitives. 

**Proposed changes:**

- Add `test/e2e/prometheus_metrics_test.go`which finds the controller pod, verifies `/metrics` serves valid Prometheus-formatted data, then runs a real SparkApplication and confirms that Spark counters increment correctly
- Add `test/e2e/spark_ui_test.go`, which runs a SparkApplication, verifies the operator creates a UI Service on port 4040, then port-forwards directly to the driver pod and makes a real HTTP request to confirm the Spark UI actually renders

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The existing tests check that Kubernetes objects get created, exists, and are Ready; but they don't verify that the features behind them work E2E. Adding these two tests will close that gap for observability via Prometheus metrics and the Spark UI for job monitoring. Neither test requires any new cluster, image, or build setup and should not add much overhead to the CI. 

## Checklist

<!-- Before submitting your PR, please review the following: -->

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

<!-- Include any additional notes or context that could be helpful for the reviewers here. -->
Verified test behavior locally with `make e2e-test`. The Spark UI test's port-forward step includes a bounded timeout on both the connection-ready wait and the HTTP request, so a stalled port-forward fails and retries cleanly within the existing `WaitTimeout` window instead of risking an indefinite hang.
