### PR TITLE
fix: preserve shell-sensitive Spark Connect configuration values

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -121,10 +121,14 @@ func sparkConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 	for key, value := range conn.Spec.SparkConf {
 		// Configuration property for the driver pod name has already been set.
 		if key != common.SparkKubernetesDriverPodName {
-			args = append(args, "--conf", fmt.Sprintf("%s=%s", key, value))
+			args = append(args, "--conf", shellQuoteSparkConfig(key, value))
 		}
 	}
 	return args, nil
+}
+
+func shellQuoteSparkConfig(key, value string) string {
+	return "'" + strings.ReplaceAll(key+"="+value, "'", "'\"'\"'") + "'"
 }
 
 func hadoopConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
@@ -135,11 +139,11 @@ func hadoopConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 	// Add Hadoop configuration properties.
 	for key, value := range conn.Spec.HadoopConf {
 		if strings.HasPrefix(key, common.SparkHadoopPropertiesPrefix) {
-			args = append(args, "--conf", fmt.Sprintf("%s=%s", key, value))
+			args = append(args, "--conf", shellQuoteSparkConfig(key, value))
 		} else {
 			// Add prefix to the configuration key if it does not start with `spark.hadoop.`.
 			// Users will be able to use the configuration key with or without prefix.
-			args = append(args, "--conf", fmt.Sprintf("%s%s=%s", common.SparkHadoopPropertiesPrefix, key, value))
+			args = append(args, "--conf", shellQuoteSparkConfig(common.SparkHadoopPropertiesPrefix+key, value))
 		}
 	}
 	return args, nil

--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -128,7 +128,8 @@ func sparkConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 }
 
 func shellQuoteSparkConfig(key, value string) string {
-	return "'" + strings.ReplaceAll(key+"="+value, "'", "'\"'\"'") + "'"
+	config := fmt.Sprintf("%s=%s", key, value)
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(config, "'", `'"'"'`))
 }
 
 func hadoopConfOption(conn *v1alpha1.SparkConnect) ([]string, error) {

--- a/internal/controller/sparkconnect/options_test.go
+++ b/internal/controller/sparkconnect/options_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package sparkconnect
 
 import (
+	"bytes"
+	"os/exec"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -57,4 +61,62 @@ var _ = Describe("Options functions", func() {
 			))
 		})
 	})
+
+	Context("sparkConfOption", func() {
+		It("preserves shell-sensitive Spark configuration values", func() {
+			config := map[string]string{
+				"spark.redaction.regex":          "(?i)secret|password|token|access[.]key|account[.]key",
+				"spark.driver.extraJavaOptions":  `-Dmessage="hello world" -Dquote='value'`,
+				"spark.example.shell_expression": "$HOME $(printf injected) `printf injected` ; & |",
+				"spark.example.multiline":        "first line\nsecond line",
+				"spark.example.empty":            "",
+			}
+			conn := &v1alpha1.SparkConnect{
+				Spec: v1alpha1.SparkConnectSpec{SparkConf: config},
+			}
+
+			args, err := sparkConfOption(conn)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shellParsedSparkConfig(args)).To(Equal(config))
+		})
+	})
+
+	Context("hadoopConfOption", func() {
+		It("preserves shell-sensitive Hadoop configuration values", func() {
+			conn := &v1alpha1.SparkConnect{
+				Spec: v1alpha1.SparkConnectSpec{
+					HadoopConf: map[string]string{
+						"fs.example.regex":              "(?i)secret|password",
+						"spark.hadoop.fs.example.value": "literal '$HOME' $(printf injected)",
+					},
+				},
+			}
+
+			args, err := hadoopConfOption(conn)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shellParsedSparkConfig(args)).To(Equal(map[string]string{
+				"spark.hadoop.fs.example.regex": "(?i)secret|password",
+				"spark.hadoop.fs.example.value": "literal '$HOME' $(printf injected)",
+			}))
+		})
+	})
 })
+
+func shellParsedSparkConfig(args []string) map[string]string {
+	GinkgoHelper()
+
+	output, err := exec.Command("bash", "-c", "printf '%s\\0' "+strings.Join(args, " ")).Output()
+	Expect(err).NotTo(HaveOccurred())
+
+	fields := bytes.Split(bytes.TrimSuffix(output, []byte{0}), []byte{0})
+	Expect(len(fields) % 2).To(Equal(0))
+
+	config := make(map[string]string, len(fields)/2)
+	for index := 0; index < len(fields); index += 2 {
+		Expect(string(fields[index])).To(Equal("--conf"))
+		key, value, found := strings.Cut(string(fields[index+1]), "=")
+		Expect(found).To(BeTrue())
+		config[key] = value
+	}
+	return config
+}


### PR DESCRIPTION
## Purpose of this PR

Spark Connect constructs its server startup command with `bash -c`, so Spark and Hadoop configuration values containing shell metacharacters are currently interpreted by the shell instead of being passed literally.

For example, setting `spark.redaction.regex=(?i)secret|password|token` can prevent a Spark Connect server from starting.

**Proposed changes:**

- Shell-quote user-supplied Spark and Hadoop configuration arguments before adding them to the server startup command.
- Preserve embedded single quotes, whitespace, regular-expression metacharacters, command-like text, newlines, and empty values.
- Add focused regression coverage to the existing Spark Connect Ginkgo suite.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Spark and Hadoop configuration values should reach the Spark Connect server unchanged, regardless of characters that have special meaning to the shell.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have added tests that prove my changes are effective.
- [x] Existing unit tests pass locally with my changes.

### Validation

- `go test ./internal/controller/sparkconnect -ginkgo.focus='preserves shell-sensitive'`
- `go test ./internal/controller/sparkconnect/...`
- `go test -race ./internal/controller/sparkconnect/...`
- `go vet ./internal/controller/sparkconnect/...`