### PR TITLE
fix(webhook): fall back to admission request namespace when pod namespace is empty (Kubernetes 1.22 compatibility)

### DIFF
--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -76,6 +76,16 @@ func (d *SparkPodDefaulter) Default(ctx context.Context, pod *corev1.Pod) error 
 
 	logger := log.FromContext(ctx)
 	namespace := pod.Namespace
+	if namespace == "" {
+		// On older API servers (verified on Kubernetes 1.22), the object sent to
+		// admission webhooks does not have metadata.namespace populated when the
+		// client omitted it from the request body, which is the case for driver
+		// and executor pods created by spark-submit (fabric8 client). Fall back
+		// to the namespace of the admission request itself.
+		if req, err := admission.RequestFromContext(ctx); err == nil {
+			namespace = req.Namespace
+		}
+	}
 	if !d.isSparkJobNamespace(namespace) {
 		return nil
 	}

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -24,9 +25,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
@@ -2348,4 +2353,72 @@ func TestPatchSparkPod_MemoryLimit(t *testing.T) {
 	assert.Equal(t, "10Gi", expectedExecutorMemoryLimit.String())
 	assert.NotEqual(t, expectedExecutorMemoryRequest.String(), expectedExecutorMemoryLimit.String())
 
+}
+
+func TestSparkPodDefaulter_Default_NamespaceFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, v1beta2.AddToScheme(scheme))
+
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spark-test",
+			Namespace: "test-ns",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "team",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "de",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	defaulter := NewSparkPodDefaulter(fakeClient, []string{"test-ns"})
+
+	newPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "spark-test-driver",
+				// Namespace is intentionally left empty: on older API servers
+				// (verified on Kubernetes 1.22), the object in the admission
+				// request does not have metadata.namespace populated when the
+				// client omitted it from the request body, which is the case
+				// for pods created by spark-submit.
+				Labels: map[string]string{
+					common.LabelSparkRole:               common.SparkRoleDriver,
+					common.LabelLaunchedBySparkOperator: "true",
+					common.LabelSparkAppName:            "spark-test",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  common.SparkDriverContainerName,
+						Image: "spark-driver:latest",
+					},
+				},
+			},
+		}
+	}
+
+	// The namespace of the admission request must be used as a fallback and
+	// the pod must be mutated.
+	req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "test-ns"}}
+	pod := newPod()
+	assert.NoError(t, defaulter.Default(admission.NewContextWithRequest(context.Background(), req), pod))
+	assert.Equal(t, app.Spec.Driver.Tolerations, pod.Spec.Tolerations)
+
+	// A request from a namespace not watched by the operator must still be
+	// skipped without mutation.
+	req = admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "other-ns"}}
+	pod = newPod()
+	assert.NoError(t, defaulter.Default(admission.NewContextWithRequest(context.Background(), req), pod))
+	assert.Empty(t, pod.Spec.Tolerations)
 }


### PR DESCRIPTION
## Purpose of this PR

Fixes silent no-op of the pod mutating webhook on older Kubernetes API servers (verified on 1.22): driver/executor pods created by spark-submit are admitted without any mutation (no volumes, tolerations, initContainers, etc. from the SparkApplication spec), with no error and no log line.

**Root cause**

`SparkPodDefaulter.Default()` filters pods by `pod.Namespace`:

```go
namespace := pod.Namespace
if !d.isSparkJobNamespace(namespace) {
    return nil
}
```

spark-submit (fabric8 client) POSTs pods without `metadata.namespace` in the request body (the namespace is only in the URL path). On Kubernetes 1.22, the API server does not populate `metadata.namespace` on the object sent to admission webhooks in this case, so `pod.Namespace` is an empty string inside the webhook, `isSparkJobNamespace("")` returns false, and the defaulter returns without mutating. Newer API servers populate the namespace before calling webhooks, which is why this does not reproduce there.

The result is hard to diagnose: the webhook is called (`controller_runtime_webhook_requests_total{webhook="/mutate--v1-pod",code="200"}` increments, `code="500"` stays 0), `failurePolicy: Fail` does not trigger, and nothing is logged.

**Proposed changes:**

- `SparkPodDefaulter.Default()`: when `pod.Namespace` is empty, fall back to the namespace of the admission request (`admission.RequestFromContext`), which is always populated by the API server from the request URL.
- Unit test covering the fallback (empty pod namespace + request namespace in watched/unwatched namespaces).

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)

### Rationale

Environment where this was hit:

- Kubernetes v1.22.9 (on-premises), 3 API servers
- spark-operator 2.4.0 (`ghcr.io/kubeflow/spark-operator/controller:2.4.0`, digest `sha256:067ee917...`), Helm chart 2.4.0, webhook enabled, `spark.jobNamespaces` set to an explicit list. Also reproduced on 2.5.1.
- The same image digest on EKS v1.35.6 (`v1.35.6-eks-8f14419`) mutates the same SparkApplication correctly.

Observed behavior on 1.22:

- Webhook log over 4 days contains 9037 `Defaulting SparkApplication` lines and 0 `Mutating Spark pod` lines, while `/mutate--v1-pod` served 30k+ requests, all HTTP 200, zero 500.
- Driver pod is created with all operator labels present at creation time (single `fabric8-kubernetes-client` entry in `managedFields` containing `sparkoperator.k8s.io/app-name`, `.../launched-by-spark-operator`), scheduled, and runs — but without the tolerations/volumes/initContainers declared in `spec.driver`.
- Re-creating the same driver pod manifest with `kubectl create` (which puts `metadata.namespace` into the body) is mutated correctly by the same webhook instance, on the same cluster, in the same namespace.

Minimal reproduction independent of Spark, against a 1.22 API server with the webhook watching `spark-test`:

```console
# metadata.namespace omitted from the body (as fabric8 does) — silently accepted, no mutation:
$ kubectl create --raw "/api/v1/namespaces/spark-test/pods?dryRun=All" -f pod-without-namespace.json
{"kind":"Pod", ...}

# identical pod with metadata.namespace in the body — webhook processes it
# (denied here because the referenced SparkApplication does not exist):
$ kubectl create --raw "/api/v1/namespaces/spark-test/pods?dryRun=All" -f pod-with-namespace.json
Error from server (Forbidden): admission webhook "mutate--v1-pod.sparkoperator.k8s.io" denied the request:
failed to get SparkApplication spark-test/nonexistent: SparkApplication.sparkoperator.k8s.io "nonexistent" not found
```

Note that setting `spark.jobNamespaces` to include the empty string is not a workaround: `isSparkJobNamespace("")` would pass, but the subsequent `client.Get` with an empty namespace fails and, with `failurePolicy: Fail`, rejects every matching pod.

Current workaround in our cluster until this is fixed: we keep the legacy 1.x operator (chart 1.4.6, image `v1beta2-1.6.2-3.5.0`) running purely as the pod mutation engine — its webhook uses a label-based `namespaceSelector` and no in-process namespace re-check, so it is not affected — while the 2.x operator handles reconciliation. This "2.x controller + 1.x webhook" split works but blocks retiring the 1.x deployment.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly (code comment).
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
