### PR TITLE
Make webhook leader election timings configurable

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -161,6 +161,9 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.replicas | int | `1` | Number of replicas of webhook server. |
 | webhook.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | webhook.leaderElection.enable | bool | `true` | Specifies whether to enable leader election for webhook. |
+| webhook.leaderElection.leaseDuration | string | `"15s"` | Leader election lease duration. |
+| webhook.leaderElection.renewDeadline | string | `"10s"` | Leader election renew deadline. |
+| webhook.leaderElection.retryPeriod | string | `"2s"` | Leader election retry period. |
 | webhook.logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |
 | webhook.logEncoder | string | `"console"` | Configure the encoder of logging, can be one of `console` or `json`. |
 | webhook.port | int | `9443` | Specifies webhook port. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -163,6 +163,9 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.replicas | int | `1` | Number of replicas of webhook server. |
 | webhook.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | webhook.leaderElection.enable | bool | `true` | Specifies whether to enable leader election for webhook. |
+| webhook.leaderElection.leaseDuration | string | `"15s"` | Leader election lease duration. |
+| webhook.leaderElection.renewDeadline | string | `"10s"` | Leader election renew deadline. |
+| webhook.leaderElection.retryPeriod | string | `"2s"` | Leader election retry period. |
 | webhook.logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |
 | webhook.logEncoder | string | `"console"` | Configure the encoder of logging, can be one of `console` or `json`. |
 | webhook.port | int | `9443` | Specifies webhook port. |

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -95,6 +95,9 @@ spec:
         - --leader-election=true
         - --leader-election-lock-name={{ include "spark-operator.webhook.leaderElectionName" . }}
         - --leader-election-lock-namespace={{ .Release.Namespace }}
+        - --leader-election-lease-duration={{ .Values.webhook.leaderElection.leaseDuration }}
+        - --leader-election-renew-deadline={{ .Values.webhook.leaderElection.renewDeadline }}
+        - --leader-election-retry-period={{ .Values.webhook.leaderElection.retryPeriod }}
         {{- else -}}
         - --leader-election=false
         {{- end }}

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -212,6 +212,25 @@ tests:
           path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
           content: --leader-election=false
 
+  - it: Should add leader election parameters if `webhook.leaderElection.leaseDuration`, `webhook.leaderElection.renewDeadline` and `webhook.leaderElection.retryPeriod` are set.
+    set:
+      webhook:
+        leaderElection:
+          enable: true
+          leaseDuration: 120s
+          renewDeadline: 30s
+          retryPeriod: 15s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-lease-duration=120s
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-renew-deadline=30s
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-retry-period=15s
+
   - it: Should add webhook port
     set:
       webhook:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -359,6 +359,12 @@ webhook:
   leaderElection:
     # -- Specifies whether to enable leader election for webhook.
     enable: true
+    # -- Leader election lease duration.
+    leaseDuration: 15s
+    # -- Leader election renew deadline.
+    renewDeadline: 10s
+    # -- Leader election retry period.
+    retryPeriod: 2s
 
   # -- Configure the verbosity of logging, can be one of `debug`, `info`, `error`.
   logLevel: info

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -374,6 +374,12 @@ webhook:
   leaderElection:
     # -- Specifies whether to enable leader election for webhook.
     enable: true
+    # -- Leader election lease duration.
+    leaseDuration: 15s
+    # -- Leader election renew deadline.
+    renewDeadline: 10s
+    # -- Leader election retry period.
+    retryPeriod: 2s
 
   # -- Configure the verbosity of logging, can be one of `debug`, `info`, `error`.
   logLevel: info

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -227,6 +227,9 @@ func start() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        leaderElectionLockName,
 		LeaderElectionNamespace: leaderElectionLockNamespace,
+		LeaseDuration:           &leaderElectionLeaseDuration,
+		RenewDeadline:           &leaderElectionRenewDeadline,
+		RetryPeriod:             &leaderElectionRetryPeriod,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -159,8 +159,8 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&leaderElectionLockName, "leader-election-lock-name", "spark-operator-lock", "Name of the ConfigMap for leader election.")
 	command.Flags().StringVar(&leaderElectionLockNamespace, "leader-election-lock-namespace", "spark-operator", "Namespace in which to create the ConfigMap for leader election.")
 	command.Flags().DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "Leader election lease duration.")
-	command.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 14*time.Second, "Leader election renew deadline.")
-	command.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 4*time.Second, "Leader election retry period.")
+	command.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second, "Leader election renew deadline.")
+	command.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second, "Leader election retry period.")
 
 	// Prometheus metrics
 	command.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics.")

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -57,6 +57,9 @@ spec:
             - --leader-election=true
             - --leader-election-lock-name=spark-operator-webhook-lock
             - --leader-election-lock-namespace=$(WEBHOOK_NAMESPACE)
+            - --leader-election-lease-duration=15s
+            - --leader-election-renew-deadline=10s
+            - --leader-election-retry-period=2s
           env:
             - name: WEBHOOK_NAMESPACE
               valueFrom:


### PR DESCRIPTION
## Purpose of this PR

This PR exposes the webhook leader election timing parameters (`leaseDuration`, `renewDeadline`, and `retryPeriod`) through the Helm chart.

In Kubernetes environments where API server requests experience higher latency or temporary delays, the default leader election timings may not be sufficient, potentially resulting in leader election loss and webhook shutdown.

This change allows users to tune these parameters while preserving the existing default behavior.

**Proposed changes:**
- Fixes #3068.
- Add configurable Helm values for `leaseDuration`, `renewDeadline`, and `retryPeriod`.
- Pass the configured values to the webhook manager.
- Update the Helm chart documentation.
- Add Helm chart tests for the new configuration.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

During testing, the webhook successfully acquired the leader lease, but subsequent lease renewal requests timed out due to slow API server responses. As a result, the webhook lost leadership and shut down.

Making the leader election timing parameters configurable allows operators to tune them for clusters with higher API server latency while preserving the existing default behavior.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

The default leader election timing values remain unchanged. Existing deployments are unaffected unless users explicitly override these values.