### PR TITLE
ci: restore test coverage reporting

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -117,6 +117,12 @@ jobs:
       - name: Run go unit tests
         run: make unit-test
 
+      - name: Coveralls report
+        uses: shogo82148/actions-goveralls@9606dbc5ac5cf888a0e9ef901515c3cd516a2790 # v1
+        continue-on-error: true
+        with:
+          path-to-profile: cover.out
+
       - name: Build Spark operator
         run: make build-operator
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/kubeflow/spark-operator)](https://github.com/kubeflow/spark-operator/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeflow/spark-operator)](https://goreportcard.com/report/github.com/kubeflow/spark-operator)
 [![Integration Test](https://github.com/kubeflow/spark-operator/actions/workflows/integration.yaml/badge.svg)](https://github.com/kubeflow/spark-operator/actions/workflows/integration.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/kubeflow/spark-operator/badge.svg?branch=master)](https://coveralls.io/github/kubeflow/spark-operator?branch=master)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kubeflow/spark-operator)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10524/badge)](https://www.bestpractices.dev/projects/10524)


### PR DESCRIPTION
## What this PR does / why we need it

Spark Operator already generates `cover.out` as part of `make unit-test`, but the coverage profile is currently discarded when CI finishes. This means coverage trends and regressions are not visible during review.

This PR restores coverage reporting following the existing Kubeflow Trainer workflow pattern.

### Changes

* Uploads the existing `cover.out` profile to Coveralls after Go unit tests.
* Uses the same pinned `actions-goveralls` action and configuration as Kubeflow Trainer.
* Adds a Coveralls coverage badge to the README.
* Keeps the existing unit-test coverage collection and package exclusions unchanged.

### Coverage enforcement

This PR intentionally does not hard-code an arbitrary coverage threshold.

The first successful report on `master` should establish the repository baseline. Maintainers can then enable Coveralls status checks and configure the agreed coverage/decrease thresholds in the repository's Coveralls settings, as proposed in #3076.

A local Windows run produced an approximate 34.3% profile, but I am not treating that as the repository baseline because the envtest suites fail during `AfterSuite` teardown on native Windows when stopping `kube-apiserver` and `etcd`. The test specs themselves completed successfully; the authoritative baseline should come from the Linux CI run.

### Validation

* `git diff --check`
* GitHub Actions workflow YAML parses successfully.
* Verified the coverage upload configuration against Kubeflow Trainer's current Go test workflow.
* Locally exercised the existing unit-test coverage path with Kubernetes 1.35 envtest assets; native Windows envtest teardown is unsupported, so the GitHub-hosted Linux run will provide the authoritative full result.

Related to #3076

### Scope and operational prerequisite

This PR restores coverage profile reporting only.

Before uploads and the README badge can become functional, an authorized maintainer must enable `kubeflow/spark-operator` in Coveralls. The badge may display `unknown` until the first successful upload from `master`.

Coverage thresholds and reviewed exclusions for generated or non-testable code will be handled separately after the Linux CI baseline is available.


Coveralls repository enablement is tracked in #3089 