### PR TITLE
feat(ci): Publish Spark Operator binaries with GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -402,6 +402,78 @@ jobs:
           VERSION=$(cat VERSION)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      # NOTE: this must run before "Package Helm charts". That step writes
+      # *.tgz into the repository root, which is not gitignored, so
+      # `git status --porcelain` becomes non-empty and the Makefile would
+      # stamp the binaries with GIT_TREE_STATE=dirty.
+      - name: Build operator binaries
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            stage="dist/linux_${arch}"
+            mkdir -p "${stage}"
+            echo "Building linux/${arch}..."
+            GOOS=linux GOARCH="${arch}" \
+              make build-operator SPARK_OPERATOR="${PWD}/${stage}/spark-operator"
+            cp LICENSE "${stage}/"
+            tar -czf "dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
+              -C "${stage}" spark-operator LICENSE
+          done
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum spark-operator_*.tar.gz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      # NOTE: this must run before "Package Helm charts". That step writes
+      # *.tgz into the repository root, which is not gitignored, so
+      # `git status --porcelain` becomes non-empty and the Makefile would
+      # stamp the binaries with GIT_TREE_STATE=dirty.
+      - name: Build operator binaries
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            stage="dist/linux_${arch}"
+            mkdir -p "${stage}"
+            echo "Building linux/${arch}..."
+            GOOS=linux GOARCH="${arch}" \
+              make build-operator SPARK_OPERATOR="${PWD}/${stage}/spark-operator"
+            cp LICENSE "${stage}/"
+            tar -czf "dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
+              -C "${stage}" spark-operator LICENSE
+          done
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum spark-operator_*.tar.gz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Verify binaries
+        run: |
+          set -euo pipefail
+          tar -xzf "dist/spark-operator_${VERSION}_linux_amd64.tar.gz" \
+            -C "${RUNNER_TEMP}" spark-operator
+          "${RUNNER_TEMP}/spark-operator" version
+          "${RUNNER_TEMP}/spark-operator" --help > /dev/null
+          tar -xzf "dist/spark-operator_${VERSION}_linux_arm64.tar.gz" \
+            -C "${RUNNER_TEMP}" spark-operator
+          file "${RUNNER_TEMP}/spark-operator" | grep -q "ARM aarch64"
+          file "${RUNNER_TEMP}/spark-operator" | grep -q "statically linked"
+
       - name: Get Helm version
         id: get_helm_version
         run: |
@@ -432,4 +504,7 @@ jobs:
           if [[ "$VERSION" == *rc* ]]; then
             args+=(--prerelease)
           fi
-          gh release create "${args[@]}" *.tgz
+          gh release create "${args[@]}" \
+            *.tgz \
+            dist/spark-operator_*.tar.gz \
+            dist/SHA256SUMS

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -432,36 +432,6 @@ jobs:
           sha256sum spark-operator_*.tar.gz > SHA256SUMS
           cat SHA256SUMS
 
-      - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version-file: go.mod
-
-      # NOTE: this must run before "Package Helm charts". That step writes
-      # *.tgz into the repository root, which is not gitignored, so
-      # `git status --porcelain` becomes non-empty and the Makefile would
-      # stamp the binaries with GIT_TREE_STATE=dirty.
-      - name: Build operator binaries
-        run: |
-          set -euo pipefail
-          for arch in amd64 arm64; do
-            stage="dist/linux_${arch}"
-            mkdir -p "${stage}"
-            echo "Building linux/${arch}..."
-            GOOS=linux GOARCH="${arch}" \
-              make build-operator SPARK_OPERATOR="${PWD}/${stage}/spark-operator"
-            cp LICENSE "${stage}/"
-            tar -czf "dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
-              -C "${stage}" spark-operator LICENSE
-          done
-
-      - name: Generate checksums
-        run: |
-          set -euo pipefail
-          cd dist
-          sha256sum spark-operator_*.tar.gz > SHA256SUMS
-          cat SHA256SUMS
-
       - name: Verify binaries
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -406,6 +406,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       # NOTE: this must run before "Package Helm charts". That step writes
       # *.tgz into the repository root, which is not gitignored, so

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -425,9 +425,9 @@ jobs:
             echo "Building linux/${arch}..."
             GOOS=linux GOARCH="${arch}" \
               make build-operator SPARK_OPERATOR="${stage}/spark-operator"
-            cp LICENSE "${stage}/"
+            cp LICENSE entrypoint.sh "${stage}/"
             tar -czf "${RUNNER_TEMP}/dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
-              -C "${stage}" spark-operator LICENSE
+              -C "${stage}" spark-operator LICENSE entrypoint.sh
           done
 
       - name: Generate checksums

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -415,35 +415,48 @@ jobs:
       - name: Build operator binaries
         run: |
           set -euo pipefail
+          # The Makefile derives GIT_TREE_STATE from `git status --porcelain`,
+          # so fail loudly here rather than silently stamping binaries dirty.
+          test -z "$(git status --porcelain)"
+          mkdir -p "${RUNNER_TEMP}/dist"
           for arch in amd64 arm64; do
-            stage="dist/linux_${arch}"
+            stage="${RUNNER_TEMP}/stage/linux_${arch}"
             mkdir -p "${stage}"
             echo "Building linux/${arch}..."
             GOOS=linux GOARCH="${arch}" \
-              make build-operator SPARK_OPERATOR="${PWD}/${stage}/spark-operator"
+              make build-operator SPARK_OPERATOR="${stage}/spark-operator"
             cp LICENSE "${stage}/"
-            tar -czf "dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
+            tar -czf "${RUNNER_TEMP}/dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
               -C "${stage}" spark-operator LICENSE
           done
 
       - name: Generate checksums
         run: |
           set -euo pipefail
-          cd dist
+          cd "${RUNNER_TEMP}/dist"
           sha256sum spark-operator_*.tar.gz > SHA256SUMS
           cat SHA256SUMS
 
       - name: Verify binaries
         run: |
           set -euo pipefail
-          tar -xzf "dist/spark-operator_${VERSION}_linux_amd64.tar.gz" \
-            -C "${RUNNER_TEMP}" spark-operator
-          "${RUNNER_TEMP}/spark-operator" version
-          "${RUNNER_TEMP}/spark-operator" --help > /dev/null
-          tar -xzf "dist/spark-operator_${VERSION}_linux_arm64.tar.gz" \
-            -C "${RUNNER_TEMP}" spark-operator
-          file "${RUNNER_TEMP}/spark-operator" | grep -q "ARM aarch64"
-          file "${RUNNER_TEMP}/spark-operator" | grep -q "statically linked"
+          (cd "${RUNNER_TEMP}/dist" && sha256sum --check SHA256SUMS)
+
+          verify="${RUNNER_TEMP}/verify"
+          mkdir -p "${verify}"
+
+          tar -xzf "${RUNNER_TEMP}/dist/spark-operator_${VERSION}_linux_amd64.tar.gz" \
+            -C "${verify}" spark-operator
+          "${verify}/spark-operator" version
+          "${verify}/spark-operator" version | grep -qF "Git Version: ${VERSION}"
+          "${verify}/spark-operator" version | grep -qF "Git Tree State: clean"
+          "${verify}/spark-operator" --help > /dev/null
+
+          rm -f "${verify}/spark-operator"
+          tar -xzf "${RUNNER_TEMP}/dist/spark-operator_${VERSION}_linux_arm64.tar.gz" \
+            -C "${verify}" spark-operator
+          file "${verify}/spark-operator" | grep -q "ARM aarch64"
+          file "${verify}/spark-operator" | grep -q "statically linked"
 
       - name: Get Helm version
         id: get_helm_version
@@ -477,5 +490,5 @@ jobs:
           fi
           gh release create "${args[@]}" \
             *.tgz \
-            dist/spark-operator_*.tar.gz \
-            dist/SHA256SUMS
+            "${RUNNER_TEMP}"/dist/spark-operator_*.tar.gz \
+            "${RUNNER_TEMP}/dist/SHA256SUMS"

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -36,7 +36,7 @@ Below are the adopters of project Spark Operator. If you are using Spark Operato
 | [Ninja Van](https://tech.ninjavan.co/) | @hongshaoyang | Production | Data Infrastructure |
 | [PUBG](https://careers.pubg.com/#/en/) | @jacobhjkim | Production | ML & Data Infrastructure |
 | [Qualytics](https://www.qualytics.co/) | @josecsotomorales | Production | Data Quality Platform |
-| [RAICS.AI](https://raics.ai)| @vikas-saxena02 | Production | ML and AI patform |
+| [RAICS.AI](https://raics.ai)| @vikas-saxena02 | Production | ML and AI platform |
 | Riskified | @henbh | Evaluation | Analytics Data Platform |
 | [Roblox](https://www.roblox.com/) | @matschaffer-roblox | Evaluation | Data Infrastructure |
 | [Rokt](https://www.rokt.com) | @jacobsalway | Production | Data Infrastructure |

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # Version information.
-VERSION ?= $(shell cat VERSION | sed "s/^v//")
+VERSION := $(shell cat VERSION | sed "s/^v//")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%S%:z")
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_TAG := $(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)

--- a/docs/website/user-guide/building-custom-images.md
+++ b/docs/website/user-guide/building-custom-images.md
@@ -1,0 +1,112 @@
+# Building Custom Operator Images
+
+The official controller images published to `ghcr.io/kubeflow/spark-operator/controller`
+are the recommended way to run Spark Operator. Some organizations, however, need to
+build their own image: to use an approved base image, apply internal hardening, embed a
+corporate CA bundle, or satisfy private registry conventions.
+
+Every release attaches prebuilt `spark-operator` binaries so you can do this without
+installing a Go toolchain or reproducing the project build.
+
+## Release artifacts
+
+Each GitHub release includes:
+
+| Artifact | Contents |
+| --- | --- |
+| `spark-operator_<version>_linux_amd64.tar.gz` | `spark-operator` binary and `LICENSE` |
+| `spark-operator_<version>_linux_arm64.tar.gz` | `spark-operator` binary and `LICENSE` |
+| `SHA256SUMS` | SHA-256 checksums for the archives above |
+
+The binaries are statically linked and carry the same version metadata as the official
+images, so `spark-operator version` reports the released version, commit and build date.
+
+## Downloading and verifying
+
+```bash
+VERSION=v2.5.1
+ARCH=amd64
+
+curl -fsSLO "https://github.com/kubeflow/spark-operator/releases/download/${VERSION}/spark-operator_${VERSION}_linux_${ARCH}.tar.gz"
+curl -fsSLO "https://github.com/kubeflow/spark-operator/releases/download/${VERSION}/SHA256SUMS"
+
+# Verify before use.
+sha256sum --ignore-missing --check SHA256SUMS
+
+tar -xzf "spark-operator_${VERSION}_linux_${ARCH}.tar.gz"
+./spark-operator version
+```
+
+## Building a custom image
+
+The operator invokes `${SPARK_HOME}/bin/spark-submit` as a subprocess, so the runtime
+image must contain a Spark distribution and a JVM. The example below layers the released
+binary onto the official Spark image; substitute your own approved base as needed.
+
+```dockerfile
+ARG SPARK_IMAGE=docker.io/apache/spark:4.0.4
+FROM ${SPARK_IMAGE}
+
+ARG SPARK_UID=185
+ARG SPARK_GID=185
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends catatonit \
+    && rm -rf /var/lib/apt/lists/*
+
+# The webhook Deployment runs this same image and mounts serving certs here.
+RUN mkdir -p /etc/k8s-webhook-server/serving-certs /home/spark \
+    && chmod -R g+rw /etc/k8s-webhook-server/serving-certs \
+    && chown -R "${SPARK_UID}:${SPARK_GID}" /etc/k8s-webhook-server/serving-certs /home/spark
+
+COPY spark-operator /usr/bin/spark-operator
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+USER ${SPARK_UID}:${SPARK_GID}
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+```
+
+Build it alongside the extracted binary and `entrypoint.sh` from the release tag:
+
+```bash
+docker build -t my-registry.example.com/spark-operator:${VERSION} .
+```
+
+### Requirements for a custom base image
+
+If you replace the Spark base image, the resulting image must still provide:
+
+- `SPARK_HOME` set, with a working `bin/spark-submit` and a JVM. The operator fails at
+  startup if `SPARK_HOME` is unset.
+- `bash`, since `entrypoint.sh` and `spark-submit` are Bash scripts.
+- `catatonit` on `PATH`. `spark-submit` forks child JVMs, and without a PID 1 reaper the
+  controller pod accumulates zombie processes.
+- `libnss_wrapper.so`, if you run on OpenShift. `entrypoint.sh` uses it to synthesize a
+  passwd entry under an arbitrary UID.
+- A writable, group-readable `/etc/k8s-webhook-server/serving-certs`, used by the webhook
+  Deployment.
+
+Changing the default UID/GID away from `185:185` may break existing Pod Security
+Admission policies and `securityContext` overrides, so keep it unless you have a reason
+not to.
+
+## Using the image
+
+Point the Helm chart at your registry:
+
+```yaml
+image:
+  registry: my-registry.example.com
+  repository: spark-operator
+  tag: v2.5.1
+```
+
+```bash
+helm upgrade --install spark-operator spark-operator/spark-operator \
+    --namespace spark-operator \
+    --create-namespace \
+    -f values.yaml
+```

--- a/docs/website/user-guide/building-custom-images.md
+++ b/docs/website/user-guide/building-custom-images.md
@@ -14,8 +14,8 @@ Each GitHub release includes:
 
 | Artifact | Contents |
 | --- | --- |
-| `spark-operator_<version>_linux_amd64.tar.gz` | `spark-operator` binary and `LICENSE` |
-| `spark-operator_<version>_linux_arm64.tar.gz` | `spark-operator` binary and `LICENSE` |
+| `spark-operator_<version>_linux_amd64.tar.gz` | `spark-operator` binary `entrypoint.sh` and `LICENSE` |
+| `spark-operator_<version>_linux_arm64.tar.gz` | `spark-operator` binary `entrypoint.sh` and `LICENSE` |
 | `SHA256SUMS` | SHA-256 checksums for the archives above |
 
 The binaries are statically linked and carry the same version metadata as the official
@@ -69,11 +69,12 @@ USER ${SPARK_UID}:${SPARK_GID}
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 ```
+
 Override `SPARK_VERSION` to target a different Spark line, or `SPARK_IMAGE` to point at an
 approved internal base image. Pinning `SPARK_IMAGE` by digest, as the project's own
 `Dockerfile` does, is recommended for reproducible builds.
 
-Build it alongside the extracted binary and `entrypoint.sh` from the release tag:
+Save this as `Dockerfile` next to the extracted `spark-operator` and `entrypoint.sh`, then:
 
 ```bash
 docker build -t my-registry.example.com/spark-operator:${VERSION} .

--- a/docs/website/user-guide/building-custom-images.md
+++ b/docs/website/user-guide/building-custom-images.md
@@ -44,7 +44,8 @@ image must contain a Spark distribution and a JVM. The example below layers the 
 binary onto the official Spark image; substitute your own approved base as needed.
 
 ```dockerfile
-ARG SPARK_IMAGE=docker.io/apache/spark:4.0.4
+ARG SPARK_VERSION=4.0.4
+ARG SPARK_IMAGE=docker.io/apache/spark:${SPARK_VERSION}
 FROM ${SPARK_IMAGE}
 
 ARG SPARK_UID=185
@@ -68,6 +69,9 @@ USER ${SPARK_UID}:${SPARK_GID}
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 ```
+Override `SPARK_VERSION` to target a different Spark line, or `SPARK_IMAGE` to point at an
+approved internal base image. Pinning `SPARK_IMAGE` by digest, as the project's own
+`Dockerfile` does, is recommended for reproducible builds.
 
 Build it alongside the extracted binary and `entrypoint.sh` from the release tag:
 

--- a/docs/website/user-guide/index.md
+++ b/docs/website/user-guide/index.md
@@ -51,6 +51,13 @@ Use `ScheduledSparkApplication` to run Spark jobs on a cron schedule
 Tune operator behavior, flags, and Helm chart values
 ::::
 
+::::{grid-item-card} Building Custom Operator Images
+:link: building-custom-images
+:link-type: doc
+
+Build your own operator image from the released binaries
+::::
+
 ::::{grid-item-card} Enabling Leader Election
 :link: leader-election
 :link-type: doc
@@ -134,6 +141,7 @@ writing-sparkapplication
 working-with-sparkapplication
 running-sparkapplication-on-schedule
 customizing-spark-operator
+building-custom-images
 leader-election
 running-multiple-instances-of-the-operator
 resource-quota-enforcement


### PR DESCRIPTION
## Purpose of this PR

Closes #3073

Releases currently publish Helm charts and container images but not the operator
executable. Organizations that need a custom base image, internal hardening, an approved
CA bundle, or private registry conventions must install a Go toolchain and reproduce the
project build, taking on responsibility for matching release version metadata themselves.

**Proposed changes:**

- Cross-build `spark-operator` for `linux/amd64` and `linux/arm64` in the `draft_release` job via the existing `make build-operator` path
- Package each architecture as `spark-operator_<version>_linux_<arch>.tar.gz` containing the binary and `LICENSE`
- Generate a `SHA256SUMS` file covering both archives
- Smoke-test the artifacts before publication
- Attach archives and checksums to the draft release alongside the Helm chart packages
- Document building a custom operator image from the released binary

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

Building through `make build-operator` means the published binaries carry the same
`LDFLAGS` as the official controller images, so `spark-operator version` reports
identical version, commit, tree state and build date.

**Step ordering is load-bearing.** The binary build runs before `Package Helm charts`.
That step writes `*.tgz` into the repository root, which is not gitignored, so
`git status --porcelain` becomes non-empty and the Makefile would stamp
`GIT_TREE_STATE=dirty` into every published binary. There is a comment in the workflow to
prevent this being reordered later.

**Verification is asymmetric.** The amd64 binary runs natively on the runner and is
exercised with `spark-operator version` and `--help`. arm64 cannot execute on an x86
runner without emulation, so it is checked with `file` for the correct target
architecture and static linking. Happy to add a QEMU step if reviewers would prefer a
real arm64 execution test, though it adds runner time to every release.

**Single job, no artifact passing.** Cross-compiling two `CGO_ENABLED=0` binaries takes
well under a minute, so this stays inside `draft_release` rather than adding a matrix job
plus an upload/download-artifact round trip. Happy to split it out if maintainers prefer.

**Scoped out:** the issue also asks for provenance and signatures per Kubeflow
supply-chain standards. The repository has no signing or SBOM tooling in any workflow
today, so adding cosign here would mean deciding keyless vs. keyed signing and OIDC
configuration inside an otherwise mechanical change. Suggest tracking that separately;
happy to follow up.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

The `Release` workflow triggers on pushes to `release-*` that touch `VERSION`, so it
cannot execute on a fork PR. I have validated the packaging and checksum logic locally
and confirmed the step order parses as intended, but the job is untested end to end.
Reviewers may want to dry-run `draft_release` before merge.