### PR TITLE
feat(ci): publish the operator binary extracted from the released image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,6 +105,16 @@ jobs:
           VERSION=$(cat VERSION)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
+      - name: Collect build metadata
+        run: |
+          set -euo pipefail
+          {
+            echo "BUILD_VERSION=${VERSION#v}"
+            echo "GIT_COMMIT=$(git rev-parse HEAD)"
+            echo "GIT_TREE_STATE=$([ -z "$(git status --porcelain)" ] && echo clean || echo dirty)"
+            echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)"
+          } >> "$GITHUB_ENV"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,7 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "ARCH=${platform#linux/}" >> $GITHUB_ENV
 
       - name: Checkout source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -132,6 +133,31 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_REGISTRY }}/${{ env.OPERATOR_IMAGE_REPOSITORY }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export operator binary
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          platforms: ${{ matrix.platform }}
+          target: artifacts
+          outputs: type=local,dest=${{ runner.temp }}/binary
+
+      - name: Package operator binary
+        run: |
+          set -euo pipefail
+          stage="${RUNNER_TEMP}/stage"
+          mkdir -p "${stage}" "${RUNNER_TEMP}/dist"
+          cp "${RUNNER_TEMP}/binary/spark-operator" "${stage}/"
+          cp LICENSE entrypoint.sh "${stage}/"
+          tar -czf "${RUNNER_TEMP}/dist/spark-operator_${VERSION}_linux_${ARCH}.tar.gz" \
+            -C "${stage}" spark-operator LICENSE entrypoint.sh
+
+      - name: Upload operator binary archive
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: binaries-operator-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Export digest
         run: |
@@ -402,33 +428,12 @@ jobs:
           VERSION=$(cat VERSION)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      - name: Download operator binary archives
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          go-version-file: go.mod
-          cache: false
-
-      # NOTE: this must run before "Package Helm charts". That step writes
-      # *.tgz into the repository root, which is not gitignored, so
-      # `git status --porcelain` becomes non-empty and the Makefile would
-      # stamp the binaries with GIT_TREE_STATE=dirty.
-      - name: Build operator binaries
-        run: |
-          set -euo pipefail
-          # The Makefile derives GIT_TREE_STATE from `git status --porcelain`,
-          # so fail loudly here rather than silently stamping binaries dirty.
-          test -z "$(git status --porcelain)"
-          mkdir -p "${RUNNER_TEMP}/dist"
-          for arch in amd64 arm64; do
-            stage="${RUNNER_TEMP}/stage/linux_${arch}"
-            mkdir -p "${stage}"
-            echo "Building linux/${arch}..."
-            GOOS=linux GOARCH="${arch}" \
-              make build-operator SPARK_OPERATOR="${stage}/spark-operator"
-            cp LICENSE entrypoint.sh "${stage}/"
-            tar -czf "${RUNNER_TEMP}/dist/spark-operator_${VERSION}_linux_${arch}.tar.gz" \
-              -C "${stage}" spark-operator LICENSE entrypoint.sh
-          done
+          path: ${{ runner.temp }}/dist
+          pattern: binaries-operator-*
+          merge-multiple: true
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,6 +142,11 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.BUILD_VERSION }}
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
+            GIT_TREE_STATE=${{ env.GIT_TREE_STATE }}
+            SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
           outputs: type=image,name=${{ env.IMAGE_REGISTRY }}/${{ env.OPERATOR_IMAGE_REPOSITORY }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export operator binary
@@ -149,7 +154,27 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           target: artifacts
+          build-args: |
+            VERSION=${{ env.BUILD_VERSION }}
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
+            GIT_TREE_STATE=${{ env.GIT_TREE_STATE }}
+            SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
           outputs: type=local,dest=${{ runner.temp }}/binary
+
+      - name: Verify exported binary matches image
+        run: |
+          set -euo pipefail
+          image="${IMAGE_REGISTRY}/${OPERATOR_IMAGE_REPOSITORY}@${DIGEST}"
+          cid=$(docker create --platform "${{ matrix.platform }}" "${image}")
+          docker cp "${cid}:/usr/bin/spark-operator" "${RUNNER_TEMP}/from-image"
+          docker rm "${cid}"
+          exported=$(sha256sum "${RUNNER_TEMP}/binary/spark-operator" | cut -d' ' -f1)
+          from_image=$(sha256sum "${RUNNER_TEMP}/from-image" | cut -d' ' -f1)
+          echo "exported:   ${exported}"
+          echo "from image: ${from_image}"
+          [ "${exported}" = "${from_image}" ]
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Package operator binary
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,12 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on make build-operator
 
+# Export-only stage. `docker build` targets the final stage by default, so this
+# is never built unless requested via --target=artifacts. CI uses it to extract
+# the exact binary that ships in the image.
+FROM scratch AS artifacts
+COPY --from=builder /workspace/bin/spark-operator /spark-operator
+
 FROM ${SPARK_IMAGE}
 
 ARG SPARK_UID=185

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,21 @@ ENV GOCACHE=/root/.cache/go-build
 
 ARG TARGETARCH
 
+# Build metadata. When unset, the Makefile derives these from the git tree
+# inside the build context, preserving the behaviour of a plain `docker build`.
+ARG VERSION=
+ARG GIT_COMMIT=
+ARG GIT_TREE_STATE=
+ARG SOURCE_DATE_EPOCH=
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on make build-operator
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on \
+    make build-operator \
+      ${VERSION:+VERSION=$VERSION} \
+      ${GIT_COMMIT:+GIT_COMMIT=$GIT_COMMIT} \
+      ${GIT_TREE_STATE:+GIT_TREE_STATE=$GIT_TREE_STATE} \
+      ${SOURCE_DATE_EPOCH:+SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH}
 
 # Export-only stage. `docker build` targets the final stage by default, so this
 # is never built unless requested via --target=artifacts. CI uses it to extract

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ SHELL = /usr/bin/env bash -o pipefail
 
 # Version information.
 VERSION := $(shell cat VERSION | sed "s/^v//")
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct 2>/dev/null || date -u +%s)
-BUILD_DATE := $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" +"%Y-%m-%dT%H:%M:%S%:z" 2>/dev/null \
-                   || date -u -r $(SOURCE_DATE_EPOCH) +"%Y-%m-%dT%H:%M:%S%:z")
+# BUILD_DATE defaults to the current time. Set SOURCE_DATE_EPOCH (as CI does)
+# to pin it to a fixed timestamp for reproducible builds.
+BUILD_DATE := $(shell if [ -n "$(SOURCE_DATE_EPOCH)" ]; then \
+                        date -u -d "@$(SOURCE_DATE_EPOCH)" +"%Y-%m-%dT%H:%M:%S%:z" 2>/dev/null \
+                        || date -u -r "$(SOURCE_DATE_EPOCH)" +"%Y-%m-%dT%H:%M:%S%:z"; \
+                      else \
+                        date -u +"%Y-%m-%dT%H:%M:%S%:z"; \
+                      fi)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_TAG := $(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)
 GIT_TREE_STATE := $(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ SHELL = /usr/bin/env bash -o pipefail
 
 # Version information.
 VERSION := $(shell cat VERSION | sed "s/^v//")
-BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%S%:z")
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct 2>/dev/null || date -u +%s)
+BUILD_DATE := $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" +"%Y-%m-%dT%H:%M:%S%:z" 2>/dev/null \
+                   || date -u -r $(SOURCE_DATE_EPOCH) +"%Y-%m-%dT%H:%M:%S%:z")
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_TAG := $(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)
 GIT_TREE_STATE := $(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)


### PR DESCRIPTION
Follow-up to #3078, as discussed there.

#3078 built the release binaries with a separate `make build-operator` on the
runner. Same commit and same make target as the images, but not the same
artifact — the image compiles inside `golang:1.25.11` (digest-pinned in the
`Dockerfile`) while the runner used `setup-go` with `go-version-file: go.mod`,
so the two could resolve to different Go patch releases, and `BUILD_DATE`
differed because it was wall-clock.

This extracts the binary from the image build instead of rebuilding it.

### Changes

- **`Dockerfile`**: adds a `scratch`-based `artifacts` stage that copies the
  binary out of the existing `builder` stage. It is deliberately not the final
  stage, so `docker build .`, `make docker-build` and `make docker-buildx` are
  unchanged and the stage is only built when requested via `--target=artifacts`.

- **`build_operator_images`**: runs a second buildx invocation with
  `target: artifacts`, mirroring the inputs of the image build so the `builder`
  stage is a cache hit. The exported binary is the object that shipped in the
  image, not an equivalent one. Archives are packaged per-arch in this job and
  uploaded as workflow artifacts.

- **`draft_release`**: downloads and publishes those archives rather than
  building. `Set up Go` and the ordering constraint around `helm package` are
  both gone, since nothing compiles in this job anymore. Checksum generation and
  verification are unchanged.

- **`Makefile`**: `BUILD_DATE` now derives from the commit timestamp via
  `SOURCE_DATE_EPOCH` rather than the wall clock, so metadata is identical
  regardless of which job produced the binary. This also fixes the existing
  divergence between the amd64 and arm64 images, which are built on separate
  runners and therefore carry different build dates today at the same commit.

### Alternative considered

Having the `Dockerfile` `COPY` a prebuilt binary would also give a single
compilation, but it breaks `docker build .` from a clean checkout and moves the
arch-matching contract outside the `Dockerfile` — a mismatch would then produce
an image that builds fine and fails at runtime. Exporting from the image build
keeps cross-compilation inside buildx via `TARGETARCH` and leaves the local
build path untouched.

### Testing notes

- Verified locally that the binary exported via `--target=artifacts` is
  byte-identical (sha256 `0db9dc25…`) to the one inside the image produced by a
  default `docker build .`, and that the image build reuses the cached `builder`
  layers rather than recompiling. Note this was an arm64-native build on macOS;
  the amd64 cross-compile path is only exercised in CI.
- `BUILD_DATE` confirmed to track the commit timestamp rather than the wall
  clock on both GNU and BSD `date`.
- As with #3078, the verification steps only execute during a real
  `draft_release` run, which cannot be triggered from a fork PR — a maintainer
  dry-run is the first genuine exercise of that path.

Note: BSD `date` does not support the `%:z` specifier, so local macOS builds
produce a slightly malformed timezone suffix in `buildDate`. This predates the
change (plain `date -u +"%:z"` behaves the same) and CI uses GNU `date`, but
flagging it so it is not mistaken for a regression here.

Part of #3073