### PR TITLE
fix(webhook): generate valid volume names for ConfigMaps

### DIFF
--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"reflect"
 	"slices"
@@ -334,13 +335,8 @@ func addGeneralConfigMaps(pod *corev1.Pod, app *v1beta2.SparkApplication) error 
 		configMaps = app.Spec.Executor.ConfigMaps
 	}
 
-	logger := log.FromContext(context.TODO())
 	for _, namePath := range configMaps {
-		volumeName := namePath.Name + "-vol"
-		if len(volumeName) > maxNameLength {
-			volumeName = volumeName[0:maxNameLength]
-			logger.Info("ConfigMap volume name is too long. Truncating", "result", volumeName)
-		}
+		volumeName := getConfigMapVolumeName(namePath.Name)
 		if err := addConfigMapVolume(pod, namePath.Name, volumeName); err != nil {
 			return err
 		}
@@ -350,6 +346,26 @@ func addGeneralConfigMaps(pod *corev1.Pod, app *v1beta2.SparkApplication) error 
 		}
 	}
 	return nil
+}
+
+func getConfigMapVolumeName(configMapName string) string {
+	const volumeSuffix = "-vol"
+	preferredName := configMapName + volumeSuffix
+	if len(preferredName) <= maxNameLength && !strings.Contains(preferredName, ".") {
+		return preferredName
+	}
+
+	// ConfigMap names are DNS subdomains and may contain dots, while volume names
+	// must be DNS labels. Add a hash so sanitizing or truncating stays unique.
+	sanitizedName := strings.ReplaceAll(configMapName, ".", "-")
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(configMapName)))[:8]
+	hashedSuffix := "-" + hash + volumeSuffix
+	maxPrefixLength := maxNameLength - len(hashedSuffix)
+	if len(sanitizedName) > maxPrefixLength {
+		sanitizedName = sanitizedName[:maxPrefixLength]
+	}
+	sanitizedName = strings.TrimRight(sanitizedName, "-")
+	return sanitizedName + hashedSuffix
 }
 
 func addPrometheusConfig(pod *corev1.Pod, app *v1beta2.SparkApplication) error {

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
@@ -378,6 +379,7 @@ func TestPatchSparkPod_ConfigMaps(t *testing.T) {
 					ConfigMaps: []v1beta2.NamePath{
 						{Name: "foo", Path: "/path/to/foo"},
 						{Name: "bar", Path: "/path/to/bar"},
+						{Name: "spark.application.conf", Path: "/path/to/dotted"},
 					},
 				},
 			},
@@ -407,14 +409,57 @@ func TestPatchSparkPod_ConfigMaps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Len(t, modifiedPod.Spec.Volumes, 2)
+	assert.Len(t, modifiedPod.Spec.Volumes, 3)
 	assert.Equal(t, "foo-vol", modifiedPod.Spec.Volumes[0].Name)
 	assert.NotNil(t, modifiedPod.Spec.Volumes[0].ConfigMap)
 	assert.Equal(t, "bar-vol", modifiedPod.Spec.Volumes[1].Name)
 	assert.NotNil(t, modifiedPod.Spec.Volumes[1].ConfigMap)
-	assert.Len(t, modifiedPod.Spec.Containers[0].VolumeMounts, 2)
+	assert.Equal(t, "spark-application-conf-faf58873-vol", modifiedPod.Spec.Volumes[2].Name)
+	assert.NotNil(t, modifiedPod.Spec.Volumes[2].ConfigMap)
+	assert.Len(t, modifiedPod.Spec.Containers[0].VolumeMounts, 3)
 	assert.Equal(t, "/path/to/foo", modifiedPod.Spec.Containers[0].VolumeMounts[0].MountPath)
 	assert.Equal(t, "/path/to/bar", modifiedPod.Spec.Containers[0].VolumeMounts[1].MountPath)
+	assert.Equal(t, "/path/to/dotted", modifiedPod.Spec.Containers[0].VolumeMounts[2].MountPath)
+	assert.Equal(t, modifiedPod.Spec.Volumes[2].Name, modifiedPod.Spec.Containers[0].VolumeMounts[2].Name)
+}
+
+func TestGetConfigMapVolumeName(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMapName string
+		expected      string
+	}{
+		{
+			name:          "ordinary name stays unchanged",
+			configMapName: "configmap1",
+			expected:      "configmap1-vol",
+		},
+		{
+			name:          "dotted name is sanitized",
+			configMapName: "spark.application.conf",
+			expected:      "spark-application-conf-faf58873-vol",
+		},
+		{
+			name:          "long name is truncated with a hash",
+			configMapName: "generated-config-name-generated-config-name-generated-config-name",
+			expected:      "generated-config-name-generated-config-name-genera-d0f2ef0c-vol",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getConfigMapVolumeName(tt.configMapName)
+			assert.Equal(t, tt.expected, actual)
+			assert.LessOrEqual(t, len(actual), maxNameLength)
+			assert.Empty(t, validation.IsDNS1123Label(actual))
+		})
+	}
+
+	assert.NotEqual(t, getConfigMapVolumeName("a.b"), getConfigMapVolumeName("a-b"))
+	assert.NotEqual(t,
+		getConfigMapVolumeName("generated-config-name-generated-config-name-generated-config-name-first"),
+		getConfigMapVolumeName("generated-config-name-generated-config-name-generated-config-name-second"),
+	)
 }
 
 func TestPatchSparkPod_SparkConfigMap(t *testing.T) {


### PR DESCRIPTION
## Purpose of this PR

ConfigMap names may contain dots, but Pod volume names cannot. With the webhook enabled, mounting `spark.application.conf` through `spec.driver.configMaps` creates `spark.application.conf-vol`, so Kubernetes rejects the Pod with `must not contain dots`

Repro: create that ConfigMap, add it to `spec.driver.configMaps`, then submit the SparkApplication

**Proposed changes:**

- Generate valid, unique volume names for dotted or long ConfigMap names
- Keep ordinary names unchanged and add regression tests

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

This makes the documented ConfigMap mount flow work with valid Kubernetes ConfigMap names

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly - N/A here
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

Documentation is unchanged because this only corrects generated volume names.

### Additional Notes

Vet, lint, unit tests, and the operator build pass locally.
