### PR TITLE
docs: document webhook failure when a service mesh sidecar is injected

### DIFF
--- a/docs/website/getting-started/index.md
+++ b/docs/website/getting-started/index.md
@@ -332,3 +332,74 @@ helm install my-release spark-operator/spark-operator \
    --set webhook.enable=true \
    --set webhook.port=443
 ```
+
+### Mutating Admission Webhook in a service mesh
+
+If the webhook pod receives a service mesh sidecar (for example Istio with automatic
+injection enabled in the operator's namespace, which is the default in a Kubeflow
+installation), the Kubernetes API server cannot reach the webhook and the operator will be
+unable to create any driver or executor pods.
+
+The failure is easy to misdiagnose, because everything else looks healthy: the webhook pod
+is `Running`, its certificate is valid, and the CA bundle is patched into the
+`MutatingWebhookConfiguration` successfully at startup. The `SparkApplication` or
+`SparkConnect` resource is accepted but never progresses, and has no events.
+
+The operator logs a generic `EOF`:
+
+```
+ERROR Reconciler error {"error": "failed to create or update server pod: Internal error occurred:
+  failed calling webhook \"mutate--v1-pod.sparkoperator.k8s.io\": failed to call webhook:
+  Post \"https://spark-operator-webhook-svc.spark-operator.svc:9443/mutate--v1-pod?timeout=10s\": EOF"}
+```
+
+The webhook's own logs show the handshakes failing, with `127.0.0.6` as the source address:
+
+```
+http: TLS handshake error from 127.0.0.6:52335: EOF
+http: TLS handshake error from 127.0.0.6:60629: EOF
+```
+
+`127.0.0.6` is the sidecar's loopback address, not a real client. The connection is being
+intercepted by the pod's own sidecar, which attempts mTLS, while the API server is speaking
+plain webhook TLS. Neither side can complete the other's handshake.
+
+This is not specific to this operator. The Kubernetes API server does not participate in the
+mesh, so any mesh-injected admission webhook needs the webhook port exempted from mesh mTLS.
+
+The simplest fix is to exclude the webhook port from sidecar interception:
+
+```shell
+helm install my-release spark-operator/spark-operator \
+   --namespace spark-operator \
+   --create-namespace \
+   --set webhook.enable=true \
+   --set-string webhook.annotations."traffic\.sidecar\.istio\.io/excludeInboundPorts"=9443
+```
+
+For clusters running STRICT mTLS mesh-wide, a port-level `PeerAuthentication` is a narrower
+exemption. The sidecar continues to handle the traffic, so telemetry and any
+`AuthorizationPolicy` still apply on the webhook port; it simply accepts plain TLS in
+addition to mTLS:
+
+```yaml
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: spark-operator-webhook
+  namespace: spark-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: spark-operator
+      app.kubernetes.io/component: webhook
+  mtls:
+    mode: STRICT
+  portLevelMtls:
+    9443:
+      mode: PERMISSIVE
+```
+
+Removing the webhook from the mesh entirely
+(`sidecar.istio.io/inject: "false"`) also works, but is a broader exemption than either of
+the above.

--- a/docs/website/getting-started/index.md
+++ b/docs/website/getting-started/index.md
@@ -400,6 +400,10 @@ spec:
       mode: PERMISSIVE
 ```
 
+If more than one release of the operator is installed in the namespace, add
+`app.kubernetes.io/instance: <release-name>` to the selector so the policy applies only to
+the intended webhook.
+
 Removing the webhook from the mesh entirely
 (`sidecar.istio.io/inject: "false"`) also works, but is a broader exemption than either of
 the above.


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents the webhook becoming unreachable when its pod receives a service mesh sidecar, and how to work around it.

Adds a `Mutating Admission Webhook in a service mesh` subsection to the getting-started guide, alongside the existing `Mutating Admission Webhooks on a private GKE or EKS cluster` subsection — both describe the API server being unable to reach the webhook in particular cluster configurations.

The subsection covers:

- the symptom: no driver or executor pods created, a generic `EOF` in the operator log, and no events on the `SparkApplication` or `SparkConnect` resource
- why it is easy to misdiagnose: the webhook pod is `Running`, its certificate is valid, and the CA bundle is patched successfully at startup
- the `127.0.0.6` source address in the webhook logs, which is the sidecar loopback rather than a real client, and the only real clue
- why it happens: the API server does not participate in the mesh, so any mesh-injected admission webhook needs its port exempted
- two remedies: excluding the webhook port from sidecar interception via `webhook.annotations`, and a port-level `PeerAuthentication` for clusters running STRICT mTLS mesh-wide

Both examples were rendered locally against master to confirm they work — the `--set-string` annotation escaping produces the expected pod annotation, and the `PeerAuthentication` selector matches the labels the chart generates.

As discussed in the issue, this is not specific to Spark Operator, so documenting the symptom and the remedies seemed the right level of intervention rather than changing chart defaults.

**Which issue(s) this PR fixes**:

Fixes #3090

**Checklist**:

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.