### PR TITLE
fix(sparkconnect): resolve images from selected template containers

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -84,7 +84,7 @@ func imageOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 
 	template := conn.Spec.Executor.Template
 	if template != nil && len(template.Spec.Containers) != 0 {
-		index := -1
+		index := 0
 		for i, container := range template.Spec.Containers {
 			if container.Name == common.Spark3DefaultExecutorContainerName {
 				index = i
@@ -92,7 +92,7 @@ func imageOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 			}
 		}
 
-		if index != -1 && template.Spec.Containers[index].Image != "" {
+		if template.Spec.Containers[index].Image != "" {
 			executorImage = template.Spec.Containers[index].Image
 		}
 	}

--- a/internal/controller/sparkconnect/options_test.go
+++ b/internal/controller/sparkconnect/options_test.go
@@ -18,12 +18,14 @@ package sparkconnect
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
@@ -58,6 +60,33 @@ var _ = Describe("Options functions", func() {
 				SatisfyAll(
 					ContainSubstring(common.SparkKubernetesExecutorContainerImage+"="+image),
 				),
+			))
+		})
+
+		It("uses the first template container when the default executor container is absent", func() {
+			image := "apache/spark:3.5.0"
+			conn := &v1alpha1.SparkConnect{
+				Spec: v1alpha1.SparkConnectSpec{
+					Executor: v1alpha1.ExecutorSpec{
+						SparkPodSpec: v1alpha1.SparkPodSpec{
+							Template: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "executor",
+										Image: image,
+									}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			args, err := imageOption(conn)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(ContainElements(
+				fmt.Sprintf("%s=%s", common.SparkKubernetesContainerImage, image),
+				fmt.Sprintf("%s=%s", common.SparkKubernetesExecutorContainerImage, image),
 			))
 		})
 	})

--- a/internal/webhook/sparkconnect_validator.go
+++ b/internal/webhook/sparkconnect_validator.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1alpha1"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
@@ -186,32 +188,30 @@ func (v *SparkConnectValidator) validateImage(sc *v1alpha1.SparkConnect) error {
 		return nil
 	}
 
-	// Otherwise, require that both server and executor pod templates provide container images.
-	serverImageFound := false
-	if sc.Spec.Server.Template != nil {
-		for _, container := range sc.Spec.Server.Template.Spec.Containers {
-			if container.Image != "" {
-				serverImageFound = true
-				break
-			}
-		}
-	}
-
-	executorImageFound := false
-	if sc.Spec.Executor.Template != nil {
-		for _, container := range sc.Spec.Executor.Template.Spec.Containers {
-			if container.Image != "" {
-				executorImageFound = true
-				break
-			}
-		}
-	}
+	// Otherwise, require that the server and executor containers selected from the pod templates provide images.
+	serverImageFound := podTemplateContainerImage(sc.Spec.Server.Template, common.SparkDriverContainerName) != ""
+	executorImageFound := podTemplateContainerImage(sc.Spec.Executor.Template, common.Spark3DefaultExecutorContainerName) != ""
 
 	if serverImageFound && executorImageFound {
 		return nil
 	}
 
-	return fmt.Errorf("image must be specified in spec.image or both server and executor pod templates must provide container images")
+	return fmt.Errorf("image must be specified in spec.image or in the selected server and executor template containers")
+}
+
+func podTemplateContainerImage(template *corev1.PodTemplateSpec, containerName string) string {
+	if template == nil || len(template.Spec.Containers) == 0 {
+		return ""
+	}
+
+	index := 0
+	for i, container := range template.Spec.Containers {
+		if container.Name == containerName {
+			index = i
+			break
+		}
+	}
+	return template.Spec.Containers[index].Image
 }
 
 // validateDynamicAllocation validates DynamicAllocation configuration.

--- a/internal/webhook/sparkconnect_validator_test.go
+++ b/internal/webhook/sparkconnect_validator_test.go
@@ -124,6 +124,45 @@ func TestSparkConnectValidatorValidateCreate_ImageOnlyInServerTemplate(t *testin
 	}
 }
 
+func TestSparkConnectValidatorValidateCreate_ImageOnlyInUnselectedContainer(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   []corev1.Container
+		executor []corev1.Container
+	}{
+		{
+			name: "server sidecar",
+			server: []corev1.Container{
+				{Name: "sidecar", Image: "busybox:1.36"},
+				{Name: common.SparkDriverContainerName},
+			},
+			executor: []corev1.Container{{Name: "executor", Image: "spark:3.5.0"}},
+		},
+		{
+			name:   "executor sidecar",
+			server: []corev1.Container{{Name: "server", Image: "spark:3.5.0"}},
+			executor: []corev1.Container{
+				{Name: "sidecar", Image: "busybox:1.36"},
+				{Name: common.Spark3DefaultExecutorContainerName},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validator := newTestSparkConnectValidator(t)
+			sc := newSparkConnect()
+			sc.Spec.Image = nil
+			sc.Spec.Server.Template = &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: test.server}}
+			sc.Spec.Executor.Template = &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: test.executor}}
+
+			if _, err := validator.ValidateCreate(context.Background(), sc); err == nil || !strings.Contains(err.Error(), "image must be specified") {
+				t.Fatalf("expected image validation error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestSparkConnectValidatorValidateCreate_DynamicAllocationMinGreaterThanMax(t *testing.T) {
 	validator := newTestSparkConnectValidator(t)
 


### PR DESCRIPTION
## Purpose of this PR

SparkConnect validation accepted an image from any pod template container. 
Reconciliation only used the selected Spark container, so some accepted resources failed forever with `image is not specified`

This restores Spark's first-container fallback for executor templates and validates the container runtime will actually select

Related: #2807, #2814

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Reproduction

Apply this with the default webhook enabled:

```yaml
apiVersion: sparkoperator.k8s.io/v1alpha1
kind: SparkConnect
metadata:
  name: image-repro
spec:
  sparkVersion: 4.0.4
  server:
    template:
      spec:
        containers:
        - name: spark-connect
          image: apache/spark:4.0.4
  executor:
    template:
      spec:
        containers:
        - name: executor
          image: apache/spark:4.0.4
```

Before this change the CR is accepted, then reconciliation fails with `image is not specified`. After it, the first executor container supplies the image as Spark documents.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] Documentation is not needed for this behavior fix.
- [x] I have added tests that prove my changes are effective.
- [x] Existing unit tests pass locally with my changes.

Tests: `make unit-test`, `make go-fmt`, `make go-vet`, `make go-lint`
