### PR TITLE
fix: set MinVersion on REST submitter TLS config

### DIFF
--- a/internal/controller/sparkapplication/rest_submission.go
+++ b/internal/controller/sparkapplication/rest_submission.go
@@ -441,7 +441,7 @@ func buildTransport(tlsCfg *TLSConfig) (http.RoundTripper, error) {
 		return transport, nil
 	}
 
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	caCertFile := strings.TrimSpace(tlsCfg.CACertFile)
 	certFile := strings.TrimSpace(tlsCfg.CertFile)


### PR DESCRIPTION
## Summary

- Set `MinVersion: tls.VersionTLS12` on the REST submitter's `tls.Config` to match the minimum version used elsewhere in the operator

## Test plan

- [ ] Existing unit and e2e tests pass
- [ ] No behavior change for clusters already using TLS 1.2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)