### PR TITLE
refactor: centralize Spark container selection

### DIFF
--- a/internal/controller/sparkconnect/options.go
+++ b/internal/controller/sparkconnect/options.go
@@ -84,16 +84,14 @@ func imageOption(conn *v1alpha1.SparkConnect) ([]string, error) {
 
 	template := conn.Spec.Executor.Template
 	if template != nil && len(template.Spec.Containers) != 0 {
-		index := 0
-		for i, container := range template.Spec.Containers {
-			if container.Name == common.Spark3DefaultExecutorContainerName {
-				index = i
-				break
-			}
-		}
 
-		if template.Spec.Containers[index].Image != "" {
-			executorImage = template.Spec.Containers[index].Image
+		container := util.GetContainerByNameOrFirst(
+			template.Spec.Containers,
+			common.Spark3DefaultExecutorContainerName,
+		)
+
+		if container.Image != "" {
+			executorImage = container.Image
 		}
 	}
 

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -358,6 +358,7 @@ func (r *Reconciler) mutateServerPod(_ context.Context, conn *v1alpha1.SparkConn
 			})
 		}
 
+		// Build Spark connect server container.
 		container := util.GetContainerByNameOrFirst(
 			pod.Spec.Containers,
 			common.SparkDriverContainerName,

--- a/internal/controller/sparkconnect/reconciler.go
+++ b/internal/controller/sparkconnect/reconciler.go
@@ -358,17 +358,10 @@ func (r *Reconciler) mutateServerPod(_ context.Context, conn *v1alpha1.SparkConn
 			})
 		}
 
-		index := 0
-		for i, container := range pod.Spec.Containers {
-			if container.Name == common.SparkDriverContainerName {
-				index = i
-				break
-			}
-		}
-
-		// Build Spark connect server container.
-		container := &pod.Spec.Containers[index]
-
+		container := util.GetContainerByNameOrFirst(
+			pod.Spec.Containers,
+			common.SparkDriverContainerName,
+		)
 		// Setup image.
 		if container.Image == "" {
 			if conn.Spec.Image == nil || *conn.Spec.Image == "" {

--- a/internal/webhook/sparkconnect_validator.go
+++ b/internal/webhook/sparkconnect_validator.go
@@ -204,14 +204,11 @@ func podTemplateContainerImage(template *corev1.PodTemplateSpec, containerName s
 		return ""
 	}
 
-	index := 0
-	for i, container := range template.Spec.Containers {
-		if container.Name == containerName {
-			index = i
-			break
-		}
-	}
-	return template.Spec.Containers[index].Image
+	container := util.GetContainerByNameOrFirst(
+		template.Spec.Containers,
+		containerName,
+	)
+	return container.Image
 }
 
 // validateDynamicAllocation validates DynamicAllocation configuration.

--- a/pkg/util/container.go
+++ b/pkg/util/container.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import corev1 "k8s.io/api/core/v1"
+
+// GetContainerByNameOrFirst returns the container matching name.
+// If no container matches, it returns the first container.
+// It returns nil when containers is empty.
+func GetContainerByNameOrFirst(
+	containers []corev1.Container,
+	name string,
+) *corev1.Container {
+	if len(containers) == 0 {
+		return nil
+	}
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return &containers[0]
+}

--- a/pkg/util/container.go
+++ b/pkg/util/container.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubeflow authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/container_test.go
+++ b/pkg/util/container_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubeflow authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util_test
 
 import (
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +25,7 @@ import (
 
 var _ = Describe("GetContainerByNameOrFirst", func() {
 	It("returns nil when input container list is empty", func() {
-		Expect(GetContainerByNameOrFirst(nil, "spark")).To(BeNil())
+		Expect(util.GetContainerByNameOrFirst(nil, "spark")).To(BeNil())
 	})
 
 	It("returns the named container when it exists", func() {
@@ -33,7 +34,7 @@ var _ = Describe("GetContainerByNameOrFirst", func() {
 			{Name: "spark", Image: "apache/spark"},
 		}
 
-		container := GetContainerByNameOrFirst(containers, "spark")
+		container := util.GetContainerByNameOrFirst(containers, "spark")
 
 		Expect(container).NotTo(BeNil())
 		Expect(container.Name).To(Equal("spark"))
@@ -46,7 +47,7 @@ var _ = Describe("GetContainerByNameOrFirst", func() {
 			{Name: "second", Image: "second-image"},
 		}
 
-		container := GetContainerByNameOrFirst(containers, "spark")
+		container := util.GetContainerByNameOrFirst(containers, "spark")
 
 		Expect(container).NotTo(BeNil())
 		Expect(container.Name).To(Equal("first"))
@@ -59,7 +60,7 @@ var _ = Describe("GetContainerByNameOrFirst", func() {
 			{Name: "spark"},
 		}
 
-		container := GetContainerByNameOrFirst(containers, "spark")
+		container := util.GetContainerByNameOrFirst(containers, "spark")
 		Expect(container).NotTo(BeNil())
 
 		container.Image = "updated-image"

--- a/pkg/util/container_test.go
+++ b/pkg/util/container_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("GetContainerByNameOrFirst", func() {
+	It("returns nil when input container list is empty", func() {
+		Expect(GetContainerByNameOrFirst(nil, "spark")).To(BeNil())
+	})
+
+	It("returns the named container when it exists", func() {
+		containers := []corev1.Container{
+			{Name: "sidecar", Image: "busybox"},
+			{Name: "spark", Image: "apache/spark"},
+		}
+
+		container := GetContainerByNameOrFirst(containers, "spark")
+
+		Expect(container).NotTo(BeNil())
+		Expect(container.Name).To(Equal("spark"))
+		Expect(container.Image).To(Equal("apache/spark"))
+	})
+
+	It("returns the first container when the named container is absent", func() {
+		containers := []corev1.Container{
+			{Name: "first", Image: "first-image"},
+			{Name: "second", Image: "second-image"},
+		}
+
+		container := GetContainerByNameOrFirst(containers, "spark")
+
+		Expect(container).NotTo(BeNil())
+		Expect(container.Name).To(Equal("first"))
+		Expect(container.Image).To(Equal("first-image"))
+	})
+
+	It("returns a pointer to the original slice element", func() {
+		containers := []corev1.Container{
+			{Name: "first"},
+			{Name: "spark"},
+		}
+
+		container := GetContainerByNameOrFirst(containers, "spark")
+		Expect(container).NotTo(BeNil())
+
+		container.Image = "updated-image"
+
+		Expect(containers[1].Image).To(Equal("updated-image"))
+	})
+})


### PR DESCRIPTION
## Purpose of this PR

Centralize the Spark container-selection logic used by the Spark Connect controller and webhook.

Fixes #3105

**Proposed changes:**

- Add `GetContainerByNameOrFirst` to `pkg/util`.
- Replace duplicate container-selection logic in the Spark Connect reconciler, options builder, and validator.
- Preserve the existing behavior:
  - Return `nil` when the container list is empty.
  - Return the named container when found.
  - Fall back to the first container when the requested name is not found.
- Add unit tests for the shared utility.

## Change Category

- [x] Refactor (no intended behavioral change)
- [ ] Bugfix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation update

### Rationale

Container-selection rules were duplicated across multiple Spark Connect components. Moving this logic into a shared utility reduces duplication and ensures consistent fallback behavior.

## Testing

Added unit tests covering:

- Empty and nil container lists.
- Selection of a container by name.
- Fallback to the first container when the name is not found.
- Returning a pointer to the original slice element.

Executed the complete unit-test suite:

```console
make unit-test

All unit tests passed.
Relevant package results:
ok  github.com/kubeflow/spark-operator/v2/internal/controller/sparkconnect  coverage: 43.5%
ok  github.com/kubeflow/spark-operator/v2/internal/webhook                 coverage: 78.7%
ok  github.com/kubeflow/spark-operator/v2/pkg/util                         coverage: 45.7%
ok  github.com/kubeflow/spark-operator/v2/test/kustomize
```
Checklist
- I have conducted a self-review of my own code.
- Documentation is not required because this is an internal refactoring.
- I have added tests that verify the shared utility.
- Existing unit tests pass locally with my changes.
Additional Notes
The refactoring is intended to preserve the existing Spark container-selection behavior while providing a single reusable implementation.
