### PR TITLE
fix(webhook): validate ConfigMap references in SparkApplication specs

### DIFF
--- a/internal/webhook/configmap_validator.go
+++ b/internal/webhook/configmap_validator.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+)
+
+// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, and names
+// repeated within one list, which would mount two pod volumes under the same name. Neither
+// surfaces before the API server rejects the pod the mutating webhook has already built.
+func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) error {
+	var errs []error
+
+	if spec.SparkConfigMap != nil {
+		if err := validateConfigMapName(root.Child("sparkConfigMap"), *spec.SparkConfigMap); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if spec.HadoopConfigMap != nil {
+		if err := validateConfigMapName(root.Child("hadoopConfigMap"), *spec.HadoopConfigMap); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	errs = append(errs, validateConfigMapList(root.Child("driver", "configMaps"), spec.Driver.ConfigMaps)...)
+	errs = append(errs, validateConfigMapList(root.Child("executor", "configMaps"), spec.Executor.ConfigMaps)...)
+
+	return errors.Join(errs...)
+}
+
+func validateConfigMapList(path *field.Path, configMaps []v1beta2.NamePath) []error {
+	var errs []error
+	seen := make(map[string]bool, len(configMaps))
+	for i, configMap := range configMaps {
+		if err := validateConfigMapName(path.Index(i), configMap.Name); err != nil {
+			errs = append(errs, err)
+		}
+		if seen[configMap.Name] {
+			errs = append(errs, fmt.Errorf("%s has duplicate ConfigMap name %q", path.Index(i), configMap.Name))
+		}
+		seen[configMap.Name] = true
+	}
+	return errs
+}
+
+func validateConfigMapName(path *field.Path, name string) error {
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		return fmt.Errorf("%s has invalid ConfigMap name %q: %s", path, name, strings.Join(errs, ", "))
+	}
+	return nil
+}

--- a/internal/webhook/configmap_validator.go
+++ b/internal/webhook/configmap_validator.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubeflow authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -52,13 +52,16 @@ func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) er
 
 func validateConfigMapList(path *field.Path, configMaps []v1beta2.NamePath) []error {
 	var errs []error
+	// A repeated name only collides because the mutating webhook builds one volume per entry.
+	// Once it builds one volume per distinct ConfigMap, mount paths become the thing to keep
+	// unique instead; tracked at https://github.com/kubeflow/spark-operator/issues/3134
 	seen := make(map[string]bool, len(configMaps))
 	for i, configMap := range configMaps {
-		if err := validateConfigMapName(path.Index(i), configMap.Name); err != nil {
+		if err := validateConfigMapName(path.Index(i).Child("name"), configMap.Name); err != nil {
 			errs = append(errs, err)
 		}
 		if seen[configMap.Name] {
-			errs = append(errs, fmt.Errorf("%s has duplicate ConfigMap name %q", path.Index(i), configMap.Name))
+			errs = append(errs, fmt.Errorf("%s has duplicate ConfigMap name %q", path.Index(i).Child("name"), configMap.Name))
 		}
 		seen[configMap.Name] = true
 	}

--- a/internal/webhook/scheduledsparkapplication_validator.go
+++ b/internal/webhook/scheduledsparkapplication_validator.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -96,7 +97,10 @@ func (v *ScheduledSparkApplicationValidator) ValidateDelete(ctx context.Context,
 }
 
 func (v *ScheduledSparkApplicationValidator) validate(app *v1beta2.ScheduledSparkApplication) error {
-	return validateSparkConf(app.Spec.Template.SparkConf, app.Namespace)
+	if err := validateSparkConf(app.Spec.Template.SparkConf, app.Namespace); err != nil {
+		return err
+	}
+	return validateConfigMaps(&app.Spec.Template, field.NewPath("spec", "template"))
 }
 
 // validateName ensures the ScheduledSparkApplication metadata.name, when combined with suffixes,

--- a/internal/webhook/scheduledsparkapplication_validator_test.go
+++ b/internal/webhook/scheduledsparkapplication_validator_test.go
@@ -189,7 +189,7 @@ func TestScheduledSparkApplicationValidatorValidateCreate_ConfigMapNames(t *test
 	app.Spec.Template.Driver.ConfigMaps = configMapRefs("MY_CONFIG")
 
 	_, err := validator.ValidateCreate(context.Background(), app)
-	if err == nil || !strings.Contains(err.Error(), `spec.template.driver.configMaps[0] has invalid ConfigMap name "MY_CONFIG"`) {
+	if err == nil || !strings.Contains(err.Error(), `spec.template.driver.configMaps[0].name has invalid ConfigMap name "MY_CONFIG"`) {
 		t.Fatalf("expected an invalid ConfigMap name error, got %v", err)
 	}
 }

--- a/internal/webhook/scheduledsparkapplication_validator_test.go
+++ b/internal/webhook/scheduledsparkapplication_validator_test.go
@@ -181,3 +181,15 @@ func TestScheduledSparkApplicationValidatorValidateName(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduledSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
+	validator := NewScheduledSparkApplicationValidator()
+
+	app := newScheduledSparkApplication()
+	app.Spec.Template.Driver.ConfigMaps = configMapRefs("MY_CONFIG")
+
+	_, err := validator.ValidateCreate(context.Background(), app)
+	if err == nil || !strings.Contains(err.Error(), `spec.template.driver.configMaps[0] has invalid ConfigMap name "MY_CONFIG"`) {
+		t.Fatalf("expected an invalid ConfigMap name error, got %v", err)
+	}
+}

--- a/internal/webhook/sparkapplication_validator.go
+++ b/internal/webhook/sparkapplication_validator.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -153,6 +154,10 @@ func (v *SparkApplicationValidator) validateSpec(ctx context.Context, app *v1bet
 	}
 
 	if err := validateSparkConf(app.Spec.SparkConf, app.Namespace); err != nil {
+		return err
+	}
+
+	if err := validateConfigMaps(&app.Spec, field.NewPath("spec")); err != nil {
 		return err
 	}
 

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -460,4 +461,106 @@ func TestSparkApplicationValidatorSparkConf_BenignKeysPass(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	tests := []struct {
+		name       string
+		mutate     func(app *v1beta2.SparkApplication)
+		wantErrors []string
+	}{
+		{
+			name:   "valid driver ConfigMap name",
+			mutate: func(app *v1beta2.SparkApplication) { app.Spec.Driver.ConfigMaps = configMapRefs("spark.conf") },
+		},
+		{
+			// Volume names are DNS labels, but ConfigMap names are DNS subdomains,
+			// so the longest legal name must keep passing.
+			name: "driver ConfigMap name at the length limit",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = configMapRefs(strings.Repeat("a", 253))
+			},
+		},
+		{
+			name:       "driver ConfigMap name with uppercase and underscore",
+			mutate:     func(app *v1beta2.SparkApplication) { app.Spec.Driver.ConfigMaps = configMapRefs("MY_CONFIG") },
+			wantErrors: []string{`spec.driver.configMaps[0] has invalid ConfigMap name "MY_CONFIG"`},
+		},
+		{
+			name: "invalid name after a valid one",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf", "MY_CONFIG")
+			},
+			wantErrors: []string{`spec.driver.configMaps[1] has invalid ConfigMap name "MY_CONFIG"`},
+		},
+		{
+			name:       "empty executor ConfigMap name",
+			mutate:     func(app *v1beta2.SparkApplication) { app.Spec.Executor.ConfigMaps = configMapRefs("") },
+			wantErrors: []string{`spec.executor.configMaps[0] has invalid ConfigMap name ""`},
+		},
+		{
+			name:       "Spark ConfigMap name with a space",
+			mutate:     func(app *v1beta2.SparkApplication) { app.Spec.SparkConfigMap = ptr.To("spark conf") },
+			wantErrors: []string{`spec.sparkConfigMap has invalid ConfigMap name "spark conf"`},
+		},
+		{
+			name:       "Hadoop ConfigMap name that is too long",
+			mutate:     func(app *v1beta2.SparkApplication) { app.Spec.HadoopConfigMap = ptr.To(strings.Repeat("a", 254)) },
+			wantErrors: []string{fmt.Sprintf("spec.hadoopConfigMap has invalid ConfigMap name %q", strings.Repeat("a", 254))},
+		},
+		{
+			name: "duplicate driver ConfigMap names",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf", "spark-conf")
+			},
+			wantErrors: []string{`spec.driver.configMaps[1] has duplicate ConfigMap name "spark-conf"`},
+		},
+		{
+			name: "same ConfigMap in both driver and executor",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf")
+				app.Spec.Executor.ConfigMaps = configMapRefs("spark-conf")
+			},
+		},
+		{
+			name: "every invalid name is reported",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.SparkConfigMap = ptr.To("BAD_SPARK")
+				app.Spec.Driver.ConfigMaps = configMapRefs("BAD_DRIVER")
+				app.Spec.Executor.ConfigMaps = configMapRefs("BAD_EXECUTOR")
+			},
+			wantErrors: []string{
+				`spec.sparkConfigMap has invalid ConfigMap name "BAD_SPARK"`,
+				`spec.driver.configMaps[0] has invalid ConfigMap name "BAD_DRIVER"`,
+				`spec.executor.configMaps[0] has invalid ConfigMap name "BAD_EXECUTOR"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newSparkApplication()
+			tt.mutate(app)
+
+			_, err := validator.ValidateCreate(context.Background(), app)
+			if hasError := err != nil; hasError != (len(tt.wantErrors) > 0) {
+				t.Fatalf("ValidateCreate() error = %v, wantErrors %v", err, tt.wantErrors)
+			}
+			for _, want := range tt.wantErrors {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("expected error to report %s, got %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+func configMapRefs(names ...string) []v1beta2.NamePath {
+	refs := make([]v1beta2.NamePath, 0, len(names))
+	for i, name := range names {
+		refs = append(refs, v1beta2.NamePath{Name: name, Path: fmt.Sprintf("/etc/spark/conf%d", i)})
+	}
+	return refs
 }

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -486,19 +486,19 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 		{
 			name:       "driver ConfigMap name with uppercase and underscore",
 			mutate:     func(app *v1beta2.SparkApplication) { app.Spec.Driver.ConfigMaps = configMapRefs("MY_CONFIG") },
-			wantErrors: []string{`spec.driver.configMaps[0] has invalid ConfigMap name "MY_CONFIG"`},
+			wantErrors: []string{`spec.driver.configMaps[0].name has invalid ConfigMap name "MY_CONFIG"`},
 		},
 		{
 			name: "invalid name after a valid one",
 			mutate: func(app *v1beta2.SparkApplication) {
 				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf", "MY_CONFIG")
 			},
-			wantErrors: []string{`spec.driver.configMaps[1] has invalid ConfigMap name "MY_CONFIG"`},
+			wantErrors: []string{`spec.driver.configMaps[1].name has invalid ConfigMap name "MY_CONFIG"`},
 		},
 		{
 			name:       "empty executor ConfigMap name",
 			mutate:     func(app *v1beta2.SparkApplication) { app.Spec.Executor.ConfigMaps = configMapRefs("") },
-			wantErrors: []string{`spec.executor.configMaps[0] has invalid ConfigMap name ""`},
+			wantErrors: []string{`spec.executor.configMaps[0].name has invalid ConfigMap name ""`},
 		},
 		{
 			name:       "Spark ConfigMap name with a space",
@@ -515,7 +515,7 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 			mutate: func(app *v1beta2.SparkApplication) {
 				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf", "spark-conf")
 			},
-			wantErrors: []string{`spec.driver.configMaps[1] has duplicate ConfigMap name "spark-conf"`},
+			wantErrors: []string{`spec.driver.configMaps[1].name has duplicate ConfigMap name "spark-conf"`},
 		},
 		{
 			name: "same ConfigMap in both driver and executor",
@@ -533,8 +533,8 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 			},
 			wantErrors: []string{
 				`spec.sparkConfigMap has invalid ConfigMap name "BAD_SPARK"`,
-				`spec.driver.configMaps[0] has invalid ConfigMap name "BAD_DRIVER"`,
-				`spec.executor.configMaps[0] has invalid ConfigMap name "BAD_EXECUTOR"`,
+				`spec.driver.configMaps[0].name has invalid ConfigMap name "BAD_DRIVER"`,
+				`spec.executor.configMaps[0].name has invalid ConfigMap name "BAD_EXECUTOR"`,
 			},
 		},
 	}
@@ -555,6 +555,44 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSparkApplicationValidatorValidateUpdate_ConfigMapNames(t *testing.T) {
+	validator := newTestValidator(t, false)
+
+	t.Run("metadata-only update to an invalid application is allowed", func(t *testing.T) {
+		oldApp := newSparkApplication()
+		oldApp.Spec.Driver.ConfigMaps = configMapRefs("MY_CONFIG")
+		newApp := oldApp.DeepCopy()
+		newApp.Labels = map[string]string{"team": "data"}
+
+		if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err != nil {
+			t.Fatalf("expected an unchanged spec to skip validation, got %v", err)
+		}
+	})
+
+	t.Run("spec update to an invalid application is rejected", func(t *testing.T) {
+		oldApp := newSparkApplication()
+		oldApp.Spec.Driver.ConfigMaps = configMapRefs("MY_CONFIG")
+		newApp := oldApp.DeepCopy()
+		newApp.Spec.Arguments = []string{"--foo"}
+
+		_, err := validator.ValidateUpdate(context.Background(), oldApp, newApp)
+		if err == nil || !strings.Contains(err.Error(), `spec.driver.configMaps[0].name has invalid ConfigMap name "MY_CONFIG"`) {
+			t.Fatalf("expected an invalid ConfigMap name error, got %v", err)
+		}
+	})
+
+	t.Run("spec update to a valid application is allowed", func(t *testing.T) {
+		oldApp := newSparkApplication()
+		oldApp.Spec.Driver.ConfigMaps = configMapRefs("spark-conf")
+		newApp := oldApp.DeepCopy()
+		newApp.Spec.Arguments = []string{"--foo"}
+
+		if _, err := validator.ValidateUpdate(context.Background(), oldApp, newApp); err != nil {
+			t.Fatalf("expected a valid spec update to be allowed, got %v", err)
+		}
+	})
 }
 
 func configMapRefs(names ...string) []v1beta2.NamePath {


### PR DESCRIPTION
## Summary

An invalid or repeated ConfigMap reference in `spec.sparkConfigMap`, `spec.hadoopConfigMap` or `spec.{driver,executor}.configMaps` is accepted today and only fails once the mutating webhook has turned it into a pod volume the API server refuses — over a name the user never wrote, while the SparkApplication reports nothing. `ScheduledSparkApplication` embeds the same spec, so it gets the same check.

Sanitizing, as #3099 and #3102 do for dotted and over-long names, cannot help here: no ConfigMap can carry a name like `MY_CONFIG`, so a legal volume name would only trade the rejection for a pod waiting on a ConfigMap that will never exist.

## Behavior change

Applications already carrying an invalid or repeated reference — none of which could have started — are rejected the next time their spec changes; an unchanged spec still skips validation on update.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
