### PR TITLE
fix(webhook): apply configured leader election timings

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -162,6 +162,9 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | webhook.replicas | int | `1` | Number of replicas of webhook server. |
 | webhook.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | webhook.leaderElection.enable | bool | `true` | Specifies whether to enable leader election for webhook. |
+| webhook.leaderElection.leaseDuration | string | `"15s"` | Leader election lease duration. |
+| webhook.leaderElection.renewDeadline | string | `"10s"` | Leader election renew deadline. |
+| webhook.leaderElection.retryPeriod | string | `"2s"` | Leader election retry period. |
 | webhook.logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |
 | webhook.logEncoder | string | `"console"` | Configure the encoder of logging, can be one of `console` or `json`. |
 | webhook.port | int | `9443` | Specifies webhook port. |

--- a/charts/spark-operator-chart/templates/webhook/deployment.yaml
+++ b/charts/spark-operator-chart/templates/webhook/deployment.yaml
@@ -95,6 +95,9 @@ spec:
         - --leader-election=true
         - --leader-election-lock-name={{ include "spark-operator.webhook.leaderElectionName" . }}
         - --leader-election-lock-namespace={{ .Release.Namespace }}
+        - --leader-election-lease-duration={{ .Values.webhook.leaderElection.leaseDuration }}
+        - --leader-election-renew-deadline={{ .Values.webhook.leaderElection.renewDeadline }}
+        - --leader-election-retry-period={{ .Values.webhook.leaderElection.retryPeriod }}
         {{- else -}}
         - --leader-election=false
         {{- end }}

--- a/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
+++ b/charts/spark-operator-chart/tests/webhook/deployment_test.yaml
@@ -201,6 +201,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
           content: --leader-election-lock-namespace=spark-operator
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-lease-duration=15s
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-renew-deadline=10s
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-retry-period=2s
 
   - it: Should disable leader election if `webhook.leaderElection.enable` is set to `false`
     set:
@@ -211,6 +220,34 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
           content: --leader-election=false
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-lease-duration=15s
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-renew-deadline=10s
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-retry-period=2s
+
+  - it: Should add leader election parameters if `webhook.leaderElection.leaseDuration`, `webhook.leaderElection.renewDeadline` and `webhook.leaderElection.retryPeriod` are set.
+    set:
+      webhook:
+        leaderElection:
+          enable: true
+          leaseDuration: 120s
+          renewDeadline: 30s
+          retryPeriod: 15s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-lease-duration=120s
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-renew-deadline=30s
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="spark-operator-webhook")].args
+          content: --leader-election-retry-period=15s
 
   - it: Should add webhook port
     set:

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -366,6 +366,12 @@ webhook:
   leaderElection:
     # -- Specifies whether to enable leader election for webhook.
     enable: true
+    # -- Leader election lease duration.
+    leaseDuration: 15s
+    # -- Leader election renew deadline.
+    renewDeadline: 10s
+    # -- Leader election retry period.
+    retryPeriod: 2s
 
   # -- Configure the verbosity of logging, can be one of `debug`, `info`, `error`.
   logLevel: info

--- a/cmd/operator/webhook/start.go
+++ b/cmd/operator/webhook/start.go
@@ -159,8 +159,8 @@ func NewStartCommand() *cobra.Command {
 	command.Flags().StringVar(&leaderElectionLockName, "leader-election-lock-name", "spark-operator-lock", "Name of the ConfigMap for leader election.")
 	command.Flags().StringVar(&leaderElectionLockNamespace, "leader-election-lock-namespace", "spark-operator", "Namespace in which to create the ConfigMap for leader election.")
 	command.Flags().DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "Leader election lease duration.")
-	command.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 14*time.Second, "Leader election renew deadline.")
-	command.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 4*time.Second, "Leader election retry period.")
+	command.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second, "Leader election renew deadline.")
+	command.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second, "Leader election retry period.")
 
 	// Prometheus metrics
 	command.Flags().BoolVar(&enableMetrics, "enable-metrics", false, "Enable metrics.")
@@ -227,6 +227,9 @@ func start() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        leaderElectionLockName,
 		LeaderElectionNamespace: leaderElectionLockNamespace,
+		LeaseDuration:           &leaderElectionLeaseDuration,
+		RenewDeadline:           &leaderElectionRenewDeadline,
+		RetryPeriod:             &leaderElectionRetryPeriod,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -57,6 +57,9 @@ spec:
             - --leader-election=true
             - --leader-election-lock-name=spark-operator-webhook-lock
             - --leader-election-lock-namespace=$(WEBHOOK_NAMESPACE)
+            - --leader-election-lease-duration=15s
+            - --leader-election-renew-deadline=10s
+            - --leader-election-retry-period=2s
           env:
             - name: WEBHOOK_NAMESPACE
               valueFrom:

--- a/docs/website/user-guide/leader-election.md
+++ b/docs/website/user-guide/leader-election.md
@@ -8,5 +8,5 @@ The operator supports a high-availability (HA) mode, in which there can be more 
 | `leader-election-lock-namespace` | `spark-operator` | Kubernetes namespace of the lock resource used for leader election. |
 | `leader-election-lock-name` | `spark-operator-lock` | Name of the lock resource used for leader election. |
 | `leader-election-lease-duration` | 15 seconds | Leader election lease duration. |
-| `leader-election-renew-deadline` | 14 seconds | Leader election renew deadline. |
-| `leader-election-retry-period` | 4 seconds | Leader election retry period. |
+| `leader-election-renew-deadline` | 10 seconds | Leader election renew deadline. |
+| `leader-election-retry-period` | 2 seconds | Leader election retry period. |


### PR DESCRIPTION
## Summary

The webhook has registered the three leader-election timing flags since the controller-runtime rewrite without ever passing them to the manager, so it runs on controller-runtime's built-in timings whatever is set — and the chart exposes only `webhook.leaderElection.enable`, so a cluster whose API server occasionally answers slowly has no way to stop the webhook losing its lease.

Honoring the flags makes their defaults take effect for the first time, hence the move to the controller's 10s and 2s: an unconfigured deployment keeps the timings it runs with today. `drift-check` compares the chart's rendered args against the Kustomize manifest, so both sides gain the flags together.

Closes #3068

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.
