### PR TITLE
fix(controller): keep scheduled run names within DNS label limit

### DIFF
--- a/internal/controller/scheduledsparkapplication/controller.go
+++ b/internal/controller/scheduledsparkapplication/controller.go
@@ -275,7 +275,7 @@ func (r *Reconciler) createSparkApplication(
 	}
 	app := &v1beta2.SparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", scheduledApp.Name, formatTimestamp(t, r.options.TimestampPrecision)),
+			Name:      util.GetScheduledSparkApplicationRunName(scheduledApp, formatTimestamp(t, r.options.TimestampPrecision)),
 			Namespace: scheduledApp.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{{

--- a/internal/controller/scheduledsparkapplication/controller_test.go
+++ b/internal/controller/scheduledsparkapplication/controller_test.go
@@ -18,6 +18,7 @@ package scheduledsparkapplication
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,11 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/internal/webhook"
 )
 
 var _ = Describe("ScheduledSparkApplication Controller", func() {
@@ -132,5 +135,39 @@ var _ = Describe("formatTimestamp", func() {
 	It("should use nanos for empty precision", func() {
 		result := formatTimestamp(testTime, "")
 		Expect(result).To(Equal("1234567890123456789"))
+	})
+})
+
+var _ = Describe("createSparkApplication", func() {
+	It("should create a valid run name for a long accepted schedule name", func(ctx SpecContext) {
+		scheduledApp := &v1beta2.ScheduledSparkApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      strings.Repeat("a", 55),
+				Namespace: "default",
+				UID:       "test-scheduled-app-uid",
+			},
+			Spec: v1beta2.ScheduledSparkApplicationSpec{
+				Schedule: "@every 1h",
+				Template: v1beta2.SparkApplicationSpec{
+					Type:                v1beta2.SparkApplicationTypeScala,
+					MainApplicationFile: ptr.To("local:///dummy.jar"),
+				},
+			},
+		}
+
+		_, err := webhook.NewScheduledSparkApplicationValidator().ValidateCreate(ctx, scheduledApp)
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciler := NewReconciler(k8sClient.Scheme(), k8sClient, nil, clock.RealClock{}, Options{TimestampPrecision: "minutes"})
+		app, err := reconciler.createSparkApplication(scheduledApp, time.Unix(1_800_000_000, 0))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(context.Background(), app)).To(Succeed())
+		})
+
+		Expect(app.Name).To(HaveLen(63))
+		Expect(validation.IsDNS1035Label(app.Name)).To(BeEmpty())
+		_, err = webhook.NewSparkApplicationValidator(nil, false).ValidateCreate(ctx, app)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/util/sparkapplication.go
+++ b/pkg/util/sparkapplication.go
@@ -201,6 +201,12 @@ func generateName(name, suffix string) string {
 	return fmt.Sprintf("%s-%s-%s", name[:maxNameLength], hash[:8], suffix)
 }
 
+// GetScheduledSparkApplicationRunName returns the name for a SparkApplication
+// created by a ScheduledSparkApplication.
+func GetScheduledSparkApplicationRunName(app *v1beta2.ScheduledSparkApplication, timestamp string) string {
+	return generateName(app.Name, timestamp)
+}
+
 func GetDefaultUIServiceName(app *v1beta2.SparkApplication) string {
 	return generateName(app.Name, "ui-svc")
 }

--- a/pkg/util/sparkapplication_test.go
+++ b/pkg/util/sparkapplication_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util_test
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,12 +25,33 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/kubeflow/spark-operator/v2/pkg/common"
 	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
+
+var _ = Describe("GetScheduledSparkApplicationRunName", func() {
+	It("Should preserve names that fit", func() {
+		app := &v1beta2.ScheduledSparkApplication{ObjectMeta: metav1.ObjectMeta{Name: "scheduled-app"}}
+		Expect(util.GetScheduledSparkApplicationRunName(app, "1234567890")).To(Equal("scheduled-app-1234567890"))
+	})
+
+	It("Should generate valid unique names when truncation is needed", func() {
+		prefix := strings.Repeat("a", 50)
+		firstApp := &v1beta2.ScheduledSparkApplication{ObjectMeta: metav1.ObjectMeta{Name: prefix + "first"}}
+		secondApp := &v1beta2.ScheduledSparkApplication{ObjectMeta: metav1.ObjectMeta{Name: prefix + "secon"}}
+		first := util.GetScheduledSparkApplicationRunName(firstApp, "1234567890123456789")
+		second := util.GetScheduledSparkApplicationRunName(secondApp, "1234567890123456789")
+
+		Expect(first).To(HaveLen(63))
+		Expect(validation.IsDNS1035Label(first)).To(BeEmpty())
+		Expect(first).To(HaveSuffix("-1234567890123456789"))
+		Expect(first).NotTo(Equal(second))
+	})
+})
 
 var _ = Describe("GetDriverPodName", func() {
 	Context("SparkApplication without driver pod name field and driver pod name conf", func() {


### PR DESCRIPTION
## Purpose of this PR

A 55 character `ScheduledSparkApplication` name is accepted, but even the shortest `minutes` suffix creates a 64 character run name. 
The child webhook rejects it, so the schedule never starts. 
so this is still reachable after #2827

Related to #2602.

Proposed changes:

- Reuse the existing hash and truncation helper for scheduled run names
- Keep names unchanged when they already fit
- Test the real parent admission and child creation path, plus collision safety

## Reproduction

1. Create a schedule with `metadata.name` set to 55 lowercase letters
2. Set timestamp precision to `minutes`
3. Wait for a run. The parent exists, but child creation fails with `must be no more than 63 characters`

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Only names that already fail are changed. Working names stay byte for byte the same, so yeah this is pretty contained.

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] Documentation is not needed for this behavior fix.
- [x] I have added tests that prove my changes are effective.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

`go test ./...`, `go vet ./...`, and `make go-lint` pass locally.