### PR TITLE
feat(helm): support restricted pod security for CRD upgrade hook Job

### DIFF
--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -93,6 +93,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | hook.tolerations | list | `[]` | List of node taints to tolerate for the Helm hook Job. |
 | hook.labels | object | `{}` | Extra labels for the Helm hook Job pod. |
 | hook.annotations | object | `{}` | Extra annotations for the Helm hook Job pod. |
+| hook.podSecurityContext | object | `{}` | Security context for the Helm hook Job pod. |
+| hook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the Helm hook Job container. |
 | controller.replicas | int | `1` | Number of replicas of controller. |
 | controller.featureGates | list | `[{"enabled":false,"name":"PartialRestart"},{"enabled":false,"name":"LoadSparkDefaults"},{"enabled":false,"name":"RestSubmitter"},{"enabled":false,"name":"DefaultTimeToLive"}]` | Feature gates to enable or disable specific features. |
 | controller.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |

--- a/charts/spark-operator-chart/README.md
+++ b/charts/spark-operator-chart/README.md
@@ -94,7 +94,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | hook.labels | object | `{}` | Extra labels for the Helm hook Job pod. |
 | hook.annotations | object | `{}` | Extra annotations for the Helm hook Job pod. |
 | hook.podSecurityContext | object | `{}` | Security context for the Helm hook Job pod. |
-| hook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the Helm hook Job container. |
+| hook.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the Helm hook Job container. |
 | controller.replicas | int | `1` | Number of replicas of controller. |
 | controller.featureGates | list | `[{"enabled":false,"name":"PartialRestart"},{"enabled":false,"name":"LoadSparkDefaults"},{"enabled":false,"name":"RestSubmitter"},{"enabled":false,"name":"DefaultTimeToLive"}]` | Feature gates to enable or disable specific features. |
 | controller.revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |

--- a/charts/spark-operator-chart/templates/hook/job.yaml
+++ b/charts/spark-operator-chart/templates/hook/job.yaml
@@ -55,13 +55,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.hook.securityContext }}
         securityContext:
-          readOnlyRootFilesystem: true
-          privileged: false
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -79,5 +76,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "spark-operator.hook.serviceAccount.name" . }}
+      {{- with .Values.hook.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
 {{- end }}

--- a/charts/spark-operator-chart/tests/hook/job_test.yaml
+++ b/charts/spark-operator-chart/tests/hook/job_test.yaml
@@ -228,6 +228,7 @@ tests:
           privileged: false
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          runAsUser: 65534
           capabilities:
             drop:
               - ALL

--- a/charts/spark-operator-chart/tests/hook/job_test.yaml
+++ b/charts/spark-operator-chart/tests/hook/job_test.yaml
@@ -215,3 +215,69 @@ tests:
     - equal:
         path: spec.template.metadata.labels.key2
         value: value2
+
+- it: Should use the default container securityContext
+  set:
+    hook:
+      upgradeCrd: true
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].securityContext
+        value:
+          readOnlyRootFilesystem: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+
+- it: Should add container securityContext if `hook.securityContext` is set
+  set:
+    hook:
+      upgradeCrd: true
+      securityContext:
+        readOnlyRootFilesystem: true
+        runAsUser: 1000
+        runAsGroup: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        privileged: false
+        seccompProfile:
+          type: RuntimeDefault
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].securityContext
+        value:
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
+          runAsGroup: 2000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          privileged: false
+          seccompProfile:
+            type: RuntimeDefault
+
+- it: Should add pod securityContext if `hook.podSecurityContext` is set
+  set:
+    hook:
+      upgradeCrd: true
+      podSecurityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
+  asserts:
+    - equal:
+        path: spec.template.spec.securityContext
+        value:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -83,6 +83,21 @@ hook:
     # key1: value1
     # key2: value2
 
+  # -- Security context for the Helm hook Job pod.
+  podSecurityContext: {}
+
+  # -- Security context for the Helm hook Job container.
+  securityContext:
+    readOnlyRootFilesystem: true
+    privileged: false
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
 controller:
   # -- Number of replicas of controller.
   replicas: 1

--- a/charts/spark-operator-chart/values.yaml
+++ b/charts/spark-operator-chart/values.yaml
@@ -92,6 +92,7 @@ hook:
     privileged: false
     allowPrivilegeEscalation: false
     runAsNonRoot: true
+    runAsUser: 65534
     capabilities:
       drop:
       - ALL

--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -36,4 +36,6 @@ COPY charts/spark-operator-chart/crds /etc/spark-operator/crds
 
 COPY --from=builder /workspace/kubectl /usr/bin/kubectl
 
+USER 65534:65534
+
 ENTRYPOINT ["/usr/bin/kubectl"]


### PR DESCRIPTION
## Description

Fixes #3070.

This PR updates the CRD upgrade hook Job so it can run in Kubernetes namespaces enforcing the `restricted` Pod Security Standard.

## Changes

- Run the kubectl hook image as a non-root user by default.
- Add configurable `hook.podSecurityContext` and `hook.securityContext` values.
- Add restricted Pod Security compliant defaults, including:
  - `runAsNonRoot: true`
  - `seccompProfile.type: RuntimeDefault`
  - `readOnlyRootFilesystem: true`
  - `allowPrivilegeEscalation: false`
  - `privileged: false`
  - `capabilities.drop: [ALL]`
- Add Helm unit tests for default and custom security contexts.
- Regenerate the Helm chart README documentation.

## Testing

- `./bin/helm unittest charts/spark-operator-chart --strict --file "tests/**/*_test.yaml"`
  - 235/235 tests passed
- Verified the rendered Helm template with default and custom security context values.
- Ran `git diff --check` successfully.