### PR TITLE
fix(webhook): validate ConfigMap mount-path uniqueness

### DIFF
--- a/internal/webhook/configmap_validator.go
+++ b/internal/webhook/configmap_validator.go
@@ -27,8 +27,8 @@ import (
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 )
 
-// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, and names
-// repeated within one list, which would mount two pod volumes under the same name. Neither
+// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, and mount
+// paths repeated within one list, which would mount two volumes at the same path. Neither
 // surfaces before the API server rejects the pod the mutating webhook has already built.
 func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) error {
 	var errs []error
@@ -52,18 +52,18 @@ func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) er
 
 func validateConfigMapList(path *field.Path, configMaps []v1beta2.NamePath) []error {
 	var errs []error
-	// A repeated name only collides because the mutating webhook builds one volume per entry.
-	// Once it builds one volume per distinct ConfigMap, mount paths become the thing to keep
-	// unique instead; tracked at https://github.com/kubeflow/spark-operator/issues/3134
+	// The same ConfigMap may be mounted more than once, at different paths, but two entries
+	// mounted at the same path collide: the mutating webhook would emit two volumeMounts with
+	// identical mountPaths, which the API server rejects.
 	seen := make(map[string]bool, len(configMaps))
 	for i, configMap := range configMaps {
 		if err := validateConfigMapName(path.Index(i).Child("name"), configMap.Name); err != nil {
 			errs = append(errs, err)
 		}
-		if seen[configMap.Name] {
-			errs = append(errs, fmt.Errorf("%s has duplicate ConfigMap name %q", path.Index(i).Child("name"), configMap.Name))
+		if seen[configMap.Path] {
+			errs = append(errs, fmt.Errorf("%s has duplicate mount path %q", path.Index(i).Child("path"), configMap.Path))
 		}
-		seen[configMap.Name] = true
+		seen[configMap.Path] = true
 	}
 	return errs
 }

--- a/internal/webhook/configmap_validator.go
+++ b/internal/webhook/configmap_validator.go
@@ -25,11 +25,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	"github.com/kubeflow/spark-operator/v2/pkg/util"
 )
 
-// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, and mount
-// paths repeated within one list, which would mount two volumes at the same path. Neither
-// surfaces before the API server rejects the pod the mutating webhook has already built.
+// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, entries with no
+// mount path, and mount paths that collide with another entry or with a path the webhook
+// reserves for the Spark, Hadoop, or Prometheus ConfigMap. None of these surface before the
+// API server rejects the pod the mutating webhook has already built.
 func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) error {
 	var errs []error
 
@@ -44,24 +47,64 @@ func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) er
 		}
 	}
 
-	errs = append(errs, validateConfigMapList(root.Child("driver", "configMaps"), spec.Driver.ConfigMaps)...)
-	errs = append(errs, validateConfigMapList(root.Child("executor", "configMaps"), spec.Executor.ConfigMaps)...)
+	errs = append(errs, validateConfigMapList(root.Child("driver", "configMaps"), spec.Driver.ConfigMaps, reservedConfigMapMountPaths(spec, true))...)
+	errs = append(errs, validateConfigMapList(root.Child("executor", "configMaps"), spec.Executor.ConfigMaps, reservedConfigMapMountPaths(spec, false))...)
 
 	return errors.Join(errs...)
 }
 
-func validateConfigMapList(path *field.Path, configMaps []v1beta2.NamePath) []error {
+// reservedConfigMapMountPaths returns the mount paths the mutating webhook itself fills in for
+// the given pod (driver if isDriver, else executor), keyed by the spec field responsible, so
+// validateConfigMapList can reject a spec.{driver,executor}.configMaps entry that collides with
+// one of them. It mirrors the same conditions addSparkConfigMap, addHadoopConfigMap, and
+// addPrometheusConfig use to decide whether to add their volumeMount.
+func reservedConfigMapMountPaths(spec *v1beta2.SparkApplicationSpec, isDriver bool) map[string]string {
+	reserved := make(map[string]string, 3)
+	if spec.SparkConfigMap != nil {
+		reserved[common.DefaultSparkConfDir] = "sparkConfigMap"
+	}
+	if spec.HadoopConfigMap != nil {
+		reserved[common.DefaultHadoopConfDir] = "hadoopConfigMap"
+	}
+	if prometheusConfigMapMounted(spec, isDriver) {
+		reserved[common.PrometheusConfigMapMountPath] = "monitoring.prometheus"
+	}
+	return reserved
+}
+
+func prometheusConfigMapMounted(spec *v1beta2.SparkApplicationSpec, isDriver bool) bool {
+	app := &v1beta2.SparkApplication{Spec: *spec}
+	if !util.PrometheusMonitoringEnabled(app) || (util.HasMetricsPropertiesFile(app) && util.HasPrometheusConfigFile(app)) {
+		return false
+	}
+	if isDriver {
+		return util.ExposeDriverMetrics(app)
+	}
+	return util.ExposeExecutorMetrics(app)
+}
+
+func validateConfigMapList(path *field.Path, configMaps []v1beta2.NamePath, reserved map[string]string) []error {
 	var errs []error
 	// The same ConfigMap may be mounted more than once, at different paths, but two entries
 	// mounted at the same path collide: the mutating webhook would emit two volumeMounts with
-	// identical mountPaths, which the API server rejects.
+	// identical mountPaths, which the API server rejects. The same collision happens if an
+	// entry reuses a path the webhook already reserves for the Spark, Hadoop, or Prometheus
+	// ConfigMap it mounts on its own.
 	seen := make(map[string]bool, len(configMaps))
 	for i, configMap := range configMaps {
 		if err := validateConfigMapName(path.Index(i).Child("name"), configMap.Name); err != nil {
 			errs = append(errs, err)
 		}
-		if seen[configMap.Path] {
-			errs = append(errs, fmt.Errorf("%s has duplicate mount path %q", path.Index(i).Child("path"), configMap.Path))
+
+		pathField := path.Index(i).Child("path")
+		switch {
+		case configMap.Path == "":
+			errs = append(errs, fmt.Errorf("%s must not be empty", pathField))
+			continue
+		case seen[configMap.Path]:
+			errs = append(errs, fmt.Errorf("%s has duplicate mount path %q", pathField, configMap.Path))
+		case reserved[configMap.Path] != "":
+			errs = append(errs, fmt.Errorf("%s has mount path %q reserved for %s", pathField, configMap.Path, reserved[configMap.Path]))
 		}
 		seen[configMap.Path] = true
 	}

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -534,6 +534,50 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 			},
 		},
 		{
+			name: "empty driver ConfigMap mount path",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = []v1beta2.NamePath{{Name: "spark-conf", Path: ""}}
+			},
+			wantErrors: []string{`spec.driver.configMaps[0].path must not be empty`},
+		},
+		{
+			name: "driver ConfigMap mount path collides with sparkConfigMap",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.SparkConfigMap = ptr.To("spark-conf")
+				app.Spec.Driver.ConfigMaps = []v1beta2.NamePath{{Name: "other-conf", Path: "/etc/spark/conf"}}
+			},
+			wantErrors: []string{`spec.driver.configMaps[0].path has mount path "/etc/spark/conf" reserved for sparkConfigMap`},
+		},
+		{
+			name: "executor ConfigMap mount path collides with hadoopConfigMap",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.HadoopConfigMap = ptr.To("hadoop-conf")
+				app.Spec.Executor.ConfigMaps = []v1beta2.NamePath{{Name: "other-conf", Path: "/etc/hadoop/conf"}}
+			},
+			wantErrors: []string{`spec.executor.configMaps[0].path has mount path "/etc/hadoop/conf" reserved for hadoopConfigMap`},
+		},
+		{
+			name: "driver ConfigMap mount path collides with Prometheus ConfigMap",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Monitoring = &v1beta2.MonitoringSpec{
+					ExposeDriverMetrics: true,
+					Prometheus:          &v1beta2.PrometheusSpec{JmxExporterJar: "/prometheus/jmx_prometheus_javaagent.jar"},
+				}
+				app.Spec.Driver.ConfigMaps = []v1beta2.NamePath{{Name: "other-conf", Path: "/etc/metrics/conf"}}
+			},
+			wantErrors: []string{`spec.driver.configMaps[0].path has mount path "/etc/metrics/conf" reserved for monitoring.prometheus`},
+		},
+		{
+			name: "executor ConfigMap mount path matching Prometheus path is fine when executor metrics are not exposed",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Monitoring = &v1beta2.MonitoringSpec{
+					ExposeDriverMetrics: true,
+					Prometheus:          &v1beta2.PrometheusSpec{JmxExporterJar: "/prometheus/jmx_prometheus_javaagent.jar"},
+				}
+				app.Spec.Executor.ConfigMaps = []v1beta2.NamePath{{Name: "other-conf", Path: "/etc/metrics/conf"}}
+			},
+		},
+		{
 			name: "every invalid name is reported",
 			mutate: func(app *v1beta2.SparkApplication) {
 				app.Spec.SparkConfigMap = ptr.To("BAD_SPARK")

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -511,11 +511,20 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 			wantErrors: []string{fmt.Sprintf("spec.hadoopConfigMap has invalid ConfigMap name %q", strings.Repeat("a", 254))},
 		},
 		{
-			name: "duplicate driver ConfigMap names",
+			name: "same ConfigMap mounted twice at different paths",
 			mutate: func(app *v1beta2.SparkApplication) {
 				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf", "spark-conf")
 			},
-			wantErrors: []string{`spec.driver.configMaps[1].name has duplicate ConfigMap name "spark-conf"`},
+		},
+		{
+			name: "duplicate driver ConfigMap mount paths",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = []v1beta2.NamePath{
+					{Name: "spark-conf", Path: "/etc/spark/conf"},
+					{Name: "other-conf", Path: "/etc/spark/conf"},
+				}
+			},
+			wantErrors: []string{`spec.driver.configMaps[1].path has duplicate mount path "/etc/spark/conf"`},
 		},
 		{
 			name: "same ConfigMap in both driver and executor",

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -335,10 +335,14 @@ func addGeneralConfigMaps(pod *corev1.Pod, app *v1beta2.SparkApplication) error 
 		configMaps = app.Spec.Executor.ConfigMaps
 	}
 
+	addedVolumes := make(map[string]bool, len(configMaps))
 	for _, namePath := range configMaps {
 		volumeName := getConfigMapVolumeName(namePath.Name)
-		if err := addConfigMapVolume(pod, namePath.Name, volumeName); err != nil {
-			return err
+		if !addedVolumes[volumeName] {
+			if err := addConfigMapVolume(pod, namePath.Name, volumeName); err != nil {
+				return err
+			}
+			addedVolumes[volumeName] = true
 		}
 
 		if err := addConfigMapVolumeMount(pod, volumeName, namePath.Path); err != nil {

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -338,11 +338,11 @@ func addGeneralConfigMaps(pod *corev1.Pod, app *v1beta2.SparkApplication) error 
 	addedVolumes := make(map[string]bool, len(configMaps))
 	for _, namePath := range configMaps {
 		volumeName := getConfigMapVolumeName(namePath.Name)
-		if !addedVolumes[volumeName] {
+		if !addedVolumes[namePath.Name] {
 			if err := addConfigMapVolume(pod, namePath.Name, volumeName); err != nil {
 				return err
 			}
-			addedVolumes[volumeName] = true
+			addedVolumes[namePath.Name] = true
 		}
 
 		if err := addConfigMapVolumeMount(pod, volumeName, namePath.Path); err != nil {

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -424,6 +424,58 @@ func TestPatchSparkPod_ConfigMaps(t *testing.T) {
 	assert.Equal(t, modifiedPod.Spec.Volumes[2].Name, modifiedPod.Spec.Containers[0].VolumeMounts[2].Name)
 }
 
+func TestPatchSparkPod_ConfigMapMountedAtMultiplePaths(t *testing.T) {
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					ConfigMaps: []v1beta2.NamePath{
+						{Name: "foo", Path: "/path/to/a"},
+						{Name: "foo", Path: "/path/to/b"},
+					},
+				},
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-driver",
+			Labels: map[string]string{
+				common.LabelSparkRole:               common.SparkRoleDriver,
+				common.LabelLaunchedBySparkOperator: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  common.SparkDriverContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	modifiedPod, err := getModifiedPod(pod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The same ConfigMap mounted at two paths must produce a single volume, since a pod
+	// cannot carry two volumes with the same name, and one mount per entry.
+	assert.Len(t, modifiedPod.Spec.Volumes, 1)
+	assert.Equal(t, "foo-vol", modifiedPod.Spec.Volumes[0].Name)
+	assert.Len(t, modifiedPod.Spec.Containers[0].VolumeMounts, 2)
+	assert.Equal(t, "foo-vol", modifiedPod.Spec.Containers[0].VolumeMounts[0].Name)
+	assert.Equal(t, "/path/to/a", modifiedPod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Equal(t, "foo-vol", modifiedPod.Spec.Containers[0].VolumeMounts[1].Name)
+	assert.Equal(t, "/path/to/b", modifiedPod.Spec.Containers[0].VolumeMounts[1].MountPath)
+}
+
 func TestGetConfigMapVolumeName(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about how to develop with the Spark operator, check the developer guide: https://spark.kubeflow.org/en/latest/contributor-guide/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Please open an issue to discuss significant work before you start. We appreciate your contributions and don't want your efforts to go to waste!
-->

## Purpose of this PR

`spec.{driver,executor}.configMaps` entries are validated for a repeated `name`, but not for a repeated `path`. Two entries with different names and the same mount path pass admission today, and the mutating webhook then builds two `volumeMounts` with an identical `mountPath`, which the API server rejects at pod creation with a generic error that gives no hint the `SparkApplication` spec is the cause. Conversely, mounting the *same* ConfigMap at two different paths — a legitimate configuration — was rejected outright by the duplicate-name check.

**Proposed changes:**

- Replace the duplicate-`name` check in `validateConfigMapList` with a duplicate-`path` check, so the webhook rejects the actual conflict (two mounts at the same path) instead of a configuration that is actually safe (the same ConfigMap mounted twice at different paths).
- Update `addGeneralConfigMaps` in the mutating webhook to build one pod volume per distinct ConfigMap and one `volumeMount` per entry, instead of one volume per entry, so mounting the same ConfigMap at multiple paths no longer produces two pod volumes sharing a name.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

This closes out a known follow-up: the previously merged ConfigMap-reference validator (#3117) left an explicit comment noting that once the defaulter builds one volume per distinct ConfigMap, mount paths become the thing that needs to stay unique instead of names, and pointed at this issue. This PR makes that change.

## Checklist

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

### Additional Notes

Validation performed locally:
- `go test ./internal/webhook/...`, including the ginkgo envtest suite (`TestWebhooks`), run with `KUBEBUILDER_ASSETS` pointed at the `make setup-envtest` binaries — passes, including new/updated cases for the duplicate-path rejection, the same-ConfigMap-at-two-paths acceptance, and one-volume/two-volumeMounts pod shape.
- `go test $(go list ./... | grep -v -e /drift -e /test/e2e)` (full repo unit tests) — passes.
- `make go-vet`, `make go-fmt` (no diff produced), `make go-lint` (golangci-lint, 0 issues) — all pass clean.
- `go mod tidy` — no changes.
- Branch is cut from `upstream/master` tip; upstream's own Integration Test workflow is green on recent `master` runs.

No documentation changes were needed beyond the code comments and tests; the CRD schema and field docs for `configMaps[].path` already describe it as the mount path and are unaffected by this change.

Fixes #3134