### PR TITLE
fix(webhook): enforce unique ConfigMap mount paths

### DIFF
--- a/internal/webhook/configmap_validator.go
+++ b/internal/webhook/configmap_validator.go
@@ -27,8 +27,8 @@ import (
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 )
 
-// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, and names
-// repeated within one list, which would mount two pod volumes under the same name. Neither
+// validateConfigMaps rejects ConfigMap references no ConfigMap could satisfy, and mount
+// paths repeated within one list, which would mount two volumes at the same place. Neither
 // surfaces before the API server rejects the pod the mutating webhook has already built.
 func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) error {
 	var errs []error
@@ -52,18 +52,17 @@ func validateConfigMaps(spec *v1beta2.SparkApplicationSpec, root *field.Path) er
 
 func validateConfigMapList(path *field.Path, configMaps []v1beta2.NamePath) []error {
 	var errs []error
-	// A repeated name only collides because the mutating webhook builds one volume per entry.
-	// Once it builds one volume per distinct ConfigMap, mount paths become the thing to keep
-	// unique instead; tracked at https://github.com/kubeflow/spark-operator/issues/3134
+	// One ConfigMap may be mounted at several paths, but a path holds a single volume, so
+	// the name is free to repeat and the path is not.
 	seen := make(map[string]bool, len(configMaps))
 	for i, configMap := range configMaps {
 		if err := validateConfigMapName(path.Index(i).Child("name"), configMap.Name); err != nil {
 			errs = append(errs, err)
 		}
-		if seen[configMap.Name] {
-			errs = append(errs, fmt.Errorf("%s has duplicate ConfigMap name %q", path.Index(i).Child("name"), configMap.Name))
+		if seen[configMap.Path] {
+			errs = append(errs, fmt.Errorf("%s has duplicate mount path %q", path.Index(i).Child("path"), configMap.Path))
 		}
-		seen[configMap.Name] = true
+		seen[configMap.Path] = true
 	}
 	return errs
 }

--- a/internal/webhook/sparkapplication_validator_test.go
+++ b/internal/webhook/sparkapplication_validator_test.go
@@ -511,14 +511,36 @@ func TestSparkApplicationValidatorValidateCreate_ConfigMapNames(t *testing.T) {
 			wantErrors: []string{fmt.Sprintf("spec.hadoopConfigMap has invalid ConfigMap name %q", strings.Repeat("a", 254))},
 		},
 		{
-			name: "duplicate driver ConfigMap names",
+			name: "one ConfigMap mounted at two paths",
 			mutate: func(app *v1beta2.SparkApplication) {
-				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf", "spark-conf")
+				app.Spec.Driver.ConfigMaps = []v1beta2.NamePath{
+					{Name: "spark-conf", Path: "/etc/spark/conf"},
+					{Name: "spark-conf", Path: "/etc/spark/conf-copy"},
+				}
 			},
-			wantErrors: []string{`spec.driver.configMaps[1].name has duplicate ConfigMap name "spark-conf"`},
 		},
 		{
-			name: "same ConfigMap in both driver and executor",
+			name: "same mount path for two driver ConfigMaps",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Driver.ConfigMaps = []v1beta2.NamePath{
+					{Name: "spark-conf", Path: "/etc/spark/conf"},
+					{Name: "extra-conf", Path: "/etc/spark/conf"},
+				}
+			},
+			wantErrors: []string{`spec.driver.configMaps[1].path has duplicate mount path "/etc/spark/conf"`},
+		},
+		{
+			name: "repeated executor ConfigMap entry",
+			mutate: func(app *v1beta2.SparkApplication) {
+				app.Spec.Executor.ConfigMaps = []v1beta2.NamePath{
+					{Name: "spark-conf", Path: "/etc/spark/conf"},
+					{Name: "spark-conf", Path: "/etc/spark/conf"},
+				}
+			},
+			wantErrors: []string{`spec.executor.configMaps[1].path has duplicate mount path "/etc/spark/conf"`},
+		},
+		{
+			name: "same ConfigMap and mount path in both driver and executor",
 			mutate: func(app *v1beta2.SparkApplication) {
 				app.Spec.Driver.ConfigMaps = configMapRefs("spark-conf")
 				app.Spec.Executor.ConfigMaps = configMapRefs("spark-conf")

--- a/internal/webhook/sparkpod_defaulter.go
+++ b/internal/webhook/sparkpod_defaulter.go
@@ -335,10 +335,16 @@ func addGeneralConfigMaps(pod *corev1.Pod, app *v1beta2.SparkApplication) error 
 		configMaps = app.Spec.Executor.ConfigMaps
 	}
 
+	// A ConfigMap listed under several mount paths needs a single volume: one volume per
+	// entry would repeat its name, which the API server rejects.
+	volumeAdded := make(map[string]bool, len(configMaps))
 	for _, namePath := range configMaps {
 		volumeName := getConfigMapVolumeName(namePath.Name)
-		if err := addConfigMapVolume(pod, namePath.Name, volumeName); err != nil {
-			return err
+		if !volumeAdded[volumeName] {
+			if err := addConfigMapVolume(pod, namePath.Name, volumeName); err != nil {
+				return err
+			}
+			volumeAdded[volumeName] = true
 		}
 
 		if err := addConfigMapVolumeMount(pod, volumeName, namePath.Path); err != nil {

--- a/internal/webhook/sparkpod_defaulter_test.go
+++ b/internal/webhook/sparkpod_defaulter_test.go
@@ -424,6 +424,56 @@ func TestPatchSparkPod_ConfigMaps(t *testing.T) {
 	assert.Equal(t, modifiedPod.Spec.Volumes[2].Name, modifiedPod.Spec.Containers[0].VolumeMounts[2].Name)
 }
 
+func TestPatchSparkPod_ConfigMapAtMultiplePaths(t *testing.T) {
+	app := &v1beta2.SparkApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-test",
+			UID:  "spark-test-1",
+		},
+		Spec: v1beta2.SparkApplicationSpec{
+			Driver: v1beta2.DriverSpec{
+				SparkPodSpec: v1beta2.SparkPodSpec{
+					ConfigMaps: []v1beta2.NamePath{
+						{Name: "foo", Path: "/path/to/foo"},
+						{Name: "foo", Path: "/path/to/foo-copy"},
+					},
+				},
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "spark-driver",
+			Labels: map[string]string{
+				common.LabelSparkRole:               common.SparkRoleDriver,
+				common.LabelLaunchedBySparkOperator: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  common.SparkDriverContainerName,
+					Image: "spark-driver:latest",
+				},
+			},
+		},
+	}
+
+	modifiedPod, err := getModifiedPod(pod, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, modifiedPod.Spec.Volumes, 1)
+	assert.Equal(t, "foo-vol", modifiedPod.Spec.Volumes[0].Name)
+	assert.Len(t, modifiedPod.Spec.Containers[0].VolumeMounts, 2)
+	assert.Equal(t, "foo-vol", modifiedPod.Spec.Containers[0].VolumeMounts[0].Name)
+	assert.Equal(t, "/path/to/foo", modifiedPod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Equal(t, "foo-vol", modifiedPod.Spec.Containers[0].VolumeMounts[1].Name)
+	assert.Equal(t, "/path/to/foo-copy", modifiedPod.Spec.Containers[0].VolumeMounts[1].MountPath)
+}
+
 func TestGetConfigMapVolumeName(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Each `configMaps` entry becomes its own pod volume, so a ConfigMap listed twice collides on the generated volume name and the API server rejects the pod. #3117 stopped that by rejecting the repeated name, but the name is the wrong key: one ConfigMap at two paths is legitimate, and it is two entries sharing a mount path that Kubernetes refuses.

- Build one volume per distinct ConfigMap and one volume mount per entry.
- Validate mount paths, rather than names, for uniqueness within each list.

Paths are compared within a list only; an entry landing on the mount point of `spec.sparkConfigMap`, `spec.hadoopConfigMap` or the Prometheus ConfigMap fails the same way, which I would rather fix separately.

closes: #3134

## Behavior change

A ConfigMap repeated under different mount paths is now accepted; two entries sharing a mount path are rejected at admission.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have conducted a self-review of my own code.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
